### PR TITLE
infra: add health check for db session

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,67 @@ on:
   pull_request:
 
 jobs:
+  # ── 0. HEALTH CHECK ──────────────────────────────────────────────────────────
+
+  backend-health:
+    name: Backend Health Check
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: localhistory
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        working-directory: backend
+        run: pip install -r requirements.txt
+
+      - name: Start backend
+        working-directory: backend
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/localhistory
+          LOG_SQL: "false"
+        run: uvicorn app.main:app --host 0.0.0.0 --port 8000 &
+
+      - name: Wait for backend to be ready
+        run: |
+          for i in $(seq 1 10); do
+            curl -sf http://localhost:8000/health && break
+            sleep 2
+          done
+
+      - name: Check /health returns ok
+        run: |
+          RESPONSE=$(curl -sf http://localhost:8000/health)
+          echo "$RESPONSE"
+          echo "$RESPONSE" | grep '"status":"ok"'
+          echo "$RESPONSE" | grep '"db":"ok"'
+
   # ── 1. UNIT TESTS ────────────────────────────────────────────────────────────
 
   backend-unit:
     name: Backend Unit Tests
     runs-on: ubuntu-latest
+    needs: [backend-health]
 
     steps:
       - name: Checkout code

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,7 @@
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
+from sqlalchemy import text
 
 from app.db.session import engine
 
@@ -24,5 +25,16 @@ def root():
 
 
 @app.get("/health")
-def health():
-    return {"status": "ok"}
+async def health():
+    # Check DB connectivity — returns degraded status instead of crashing
+    try:
+        async with engine.connect() as conn:
+            await conn.execute(text("SELECT 1"))
+        db_status = "ok"
+    except Exception as e:
+        db_status = f"unreachable: {e}"
+
+    return {
+        "status": "ok" if db_status == "ok" else "degraded",
+        "db": db_status,
+    }


### PR DESCRIPTION
## Description
Extends the `/health` endpoint to report database connectivity status and adds a CI job that verifies the backend starts and can reach Postgres before any other tests run.

## Related Issue(s)
- Related #118

## Changes

| File | Change |
|------|--------|
| `backend/app/main.py` | Updated `/health` to run `SELECT 1` against the DB and return `"db": "ok"` or `"db": "unreachable: ..."` with a `degraded` status instead of crashing |
| `.github/workflows/ci.yml` | Added `backend-health` job that spins up a Postgres service container, starts the backend, and asserts `/health` returns `status: ok` and `db: ok` before unit tests run |

## Checklist
- [x] All tests passed
- [x] I have self-reviewed my own code
- [ ] I have requested at least 1 reviewer
