### PR TITLE
S3-compatible media storage (MinIO local / Supabase prod)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,19 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
+      minio:
+        image: bitnami/minio:latest
+        env:
+          MINIO_ROOT_USER: minioadmin
+          MINIO_ROOT_PASSWORD: minioadmin
+        ports:
+          - 9000:9000
+        options: >-
+          --health-cmd "curl -f http://localhost:9000/minio/health/live"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -44,6 +57,10 @@ jobs:
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/localhistory
           LOG_SQL: "false"
+          STORAGE_ENDPOINT: http://localhost:9000
+          STORAGE_ACCESS_KEY: minioadmin
+          STORAGE_SECRET_KEY: minioadmin
+          STORAGE_REGION: us-east-1
         run: uvicorn app.main:app --host 0.0.0.0 --port 8000 &
 
       - name: Wait for backend to be ready
@@ -59,6 +76,7 @@ jobs:
           echo "$RESPONSE"
           echo "$RESPONSE" | grep '"status":"ok"'
           echo "$RESPONSE" | grep '"db":"ok"'
+          echo "$RESPONSE" | grep '"storage":"ok"'
 
   # ── 1. UNIT TESTS ────────────────────────────────────────────────────────────
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,22 +26,22 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
-      minio:
-        image: bitnami/minio:latest
-        env:
-          MINIO_ROOT_USER: minioadmin
-          MINIO_ROOT_PASSWORD: minioadmin
-        ports:
-          - 9000:9000
-        options: >-
-          --health-cmd "curl -f http://localhost:9000/minio/health/live"
-          --health-interval 5s
-          --health-timeout 5s
-          --health-retries 5
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Start MinIO
+        run: |
+          docker run -d \
+            --name minio \
+            -p 9000:9000 \
+            -e MINIO_ROOT_USER=minioadmin \
+            -e MINIO_ROOT_PASSWORD=minioadmin \
+            minio/minio server /data
+          for i in $(seq 1 10); do
+            curl -sf http://localhost:9000/minio/health/live && break
+            sleep 2
+          done
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,25 @@
+# ── Database ──────────────────────────────────────────────────────────────────
 # Local Postgres (matches docker-compose db service)
 DATABASE_URL=postgresql://postgres:postgres@db:5432/localhistory
 
 # Useful during development — leave false in production
 LOG_SQL=false
+
+# ── Object Storage ────────────────────────────────────────────────────────────
+# Local: MinIO (docker-compose minio service uses "minio" as the hostname inside Docker)
+STORAGE_ENDPOINT=http://minio:9000
+STORAGE_ACCESS_KEY=minioadmin
+STORAGE_SECRET_KEY=minioadmin
+STORAGE_REGION=us-east-1
+STORAGE_PUBLIC_URL=http://localhost:9000
+
+# Supabase Storage (S3-compatible) — swap these when deploying to prod
+# STORAGE_ENDPOINT=https://<project-ref>.supabase.co/storage/v1/s3
+# STORAGE_ACCESS_KEY=<supabase-s3-access-key>
+# STORAGE_SECRET_KEY=<supabase-s3-secret-key>
+# STORAGE_REGION=us-east-1
+# STORAGE_PUBLIC_URL=https://<project-ref>.supabase.co/storage/v1/object/public
+
+STORAGE_BUCKET_IMAGES=images
+STORAGE_BUCKET_AUDIO=audio
+STORAGE_BUCKET_VIDEOS=videos

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -7,6 +7,22 @@ class Settings(BaseSettings):
     # Set to "true" in .env to write every SQL query to logs/sql.log
     LOG_SQL: bool = False
 
+    # ── Object Storage (S3-compatible) ────────────────────────────────────────
+    # Local: points at MinIO.  Production: points at Supabase Storage S3 endpoint.
+    STORAGE_ENDPOINT: str = "http://localhost:9000"
+    STORAGE_ACCESS_KEY: str = "minioadmin"
+    STORAGE_SECRET_KEY: str = "minioadmin"
+    STORAGE_REGION: str = "us-east-1"
+    # Public base URL used to build direct links for public buckets.
+    # For MinIO local it's the same as STORAGE_ENDPOINT.
+    # For Supabase set this to https://<project>.supabase.co/storage/v1/object/public
+    STORAGE_PUBLIC_URL: str = "http://localhost:9000"
+
+    # Bucket names (must match what you created in MinIO / Supabase Storage)
+    STORAGE_BUCKET_IMAGES: str = "images"
+    STORAGE_BUCKET_AUDIO: str = "audio"
+    STORAGE_BUCKET_VIDEOS: str = "videos"
+
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI
 from sqlalchemy import text
 
 from app.db.session import engine
+from app.services.storage import check_connection
 
 
 @asynccontextmanager
@@ -11,6 +12,8 @@ async def lifespan(app: FastAPI):
     # Startup: verify the DB connection is reachable
     async with engine.connect():
         pass
+    # Startup: verify storage backend is reachable
+    check_connection()
     yield
     # Shutdown: release connection pool
     await engine.dispose()
@@ -26,7 +29,7 @@ def root():
 
 @app.get("/health")
 async def health():
-    # Check DB connectivity — returns degraded status instead of crashing
+    # Check DB connectivity
     try:
         async with engine.connect() as conn:
             await conn.execute(text("SELECT 1"))
@@ -34,7 +37,16 @@ async def health():
     except Exception as e:
         db_status = f"unreachable: {e}"
 
+    # Check storage connectivity
+    try:
+        check_connection()
+        storage_status = "ok"
+    except Exception as e:
+        storage_status = f"unreachable: {e}"
+
+    all_ok = db_status == "ok" and storage_status == "ok"
     return {
-        "status": "ok" if db_status == "ok" else "degraded",
+        "status": "ok" if all_ok else "degraded",
         "db": db_status,
+        "storage": storage_status,
     }

--- a/backend/app/services/storage.py
+++ b/backend/app/services/storage.py
@@ -1,0 +1,21 @@
+import boto3
+from botocore.config import Config
+
+from app.core.config import settings
+
+# Local: points at MinIO (docker-compose).
+# Production: points at Supabase Storage S3 endpoint.
+# Switch by changing STORAGE_* in .env — no code changes needed.
+storage_client = boto3.client(
+    "s3",
+    endpoint_url=settings.STORAGE_ENDPOINT,
+    aws_access_key_id=settings.STORAGE_ACCESS_KEY,
+    aws_secret_access_key=settings.STORAGE_SECRET_KEY,
+    region_name=settings.STORAGE_REGION,
+    config=Config(signature_version="s3v4"),
+)
+
+
+def check_connection() -> None:
+    """Verify the storage backend is reachable by listing buckets."""
+    storage_client.list_buckets()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,3 +11,6 @@ alembic
 # Config
 pydantic-settings
 python-dotenv
+
+# Object storage (S3-compatible — works with MinIO locally and Supabase Storage in prod)
+boto3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,19 @@ services:
     depends_on:
       - db
 
+  minio:
+    image: minio/minio
+    restart: unless-stopped
+    ports:
+      - "9000:9000"   # S3 API
+      - "9001:9001"   # Web UI (http://localhost:9001, login: minioadmin/minioadmin)
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    command: server /data --console-address ":9001"
+    volumes:
+      - minio_data:/data
+
   # frontend:
   #   build:
   #     context: ./frontend
@@ -29,3 +42,4 @@ services:
 
 volumes:
   postgres_data:
+  minio_data:


### PR DESCRIPTION
## Description
Adds S3-compatible object storage support. MinIO runs locally via docker-compose; switching to Supabase Storage in production only requires changing env vars — no code changes needed.

## Related Issue(s)
- Closes #

## Changes

| File | Change |
|------|--------|
| `docker-compose.yml` | Added MinIO service and `minio_data` volume |
| `backend/.env.example` | Added `STORAGE_*` env var template |
| `backend/requirements.txt` | Added `boto3` for S3-compatible storage |
| `backend/app/core/config.py` | Added `STORAGE_*` settings |
| `backend/app/services/__init__.py` | Added in order to make services a package |
| `backend/app/services/storage.py` | Added S3 client and `check_connection()` |
| `backend/app/main.py` | Modified to verify storage connectivity on startup and in `/health` |

## Checklist
- [x] All tests passed
- [x] I have self-reviewed my own code
- [ ] I have requested at least 1 reviewer
