### PR TITLE
fetch deployment logs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,11 +19,110 @@ jobs:
           fi
 
       - name: Trigger Render Deploy
+        id: trigger
         run: |
-          curl -X POST "https://api.render.com/v1/services/${{ steps.set-service.outputs.SERVICE_ID }}/deploys" \
+          RESPONSE=$(curl -s -X POST "https://api.render.com/v1/services/${{ steps.set-service.outputs.SERVICE_ID }}/deploys" \
             -H "Authorization: Bearer ${{ secrets.RENDER_API_KEY }}" \
             -H "Content-Type: application/json" \
-            -d '{}'
+            -d '{}')
+
+          echo "Response: $RESPONSE"
+
+          DEPLOY_ID=$(echo "$RESPONSE" | jq -r '.id')
+          DEPLOY_STATUS=$(echo "$RESPONSE" | jq -r '.status')
+
+          if [[ "$DEPLOY_ID" == "null" || -z "$DEPLOY_ID" ]]; then
+            echo "::error::Failed to trigger deploy. Response: $RESPONSE"
+            exit 1
+          fi
+
+          echo "DEPLOY_ID=$DEPLOY_ID" >> $GITHUB_OUTPUT
+          echo "Deploy triggered: $DEPLOY_ID (status: $DEPLOY_STATUS)"
+
+      - name: Poll Deploy Status
+        id: poll
+        run: |
+          SERVICE_ID="${{ steps.set-service.outputs.SERVICE_ID }}"
+          DEPLOY_ID="${{ steps.trigger.outputs.DEPLOY_ID }}"
+          API_KEY="${{ secrets.RENDER_API_KEY }}"
+          MAX_ATTEMPTS=60   # 10 minutes max (60 * 10s)
+          ATTEMPT=0
+
+          while [[ $ATTEMPT -lt $MAX_ATTEMPTS ]]; do
+            RESPONSE=$(curl -s "https://api.render.com/v1/services/${SERVICE_ID}/deploys/${DEPLOY_ID}" \
+              -H "Authorization: Bearer ${API_KEY}")
+
+            STATUS=$(echo "$RESPONSE" | jq -r '.status')
+            UPDATED_AT=$(echo "$RESPONSE" | jq -r '.updatedAt')
+            FINISHED_AT=$(echo "$RESPONSE" | jq -r '.finishedAt')
+            COMMIT_MSG=$(echo "$RESPONSE" | jq -r '.commit.message // empty')
+
+            echo "[$(date -u +%H:%M:%S)] Status: $STATUS (attempt $((ATTEMPT+1))/$MAX_ATTEMPTS)"
+
+            case "$STATUS" in
+              live)
+                echo "FINAL_STATUS=success" >> $GITHUB_OUTPUT
+                echo "DEPLOY_STATUS=$STATUS" >> $GITHUB_OUTPUT
+                echo "FINISHED_AT=$FINISHED_AT" >> $GITHUB_OUTPUT
+                echo "COMMIT_MSG=$COMMIT_MSG" >> $GITHUB_OUTPUT
+                echo "::notice::Deploy succeeded!"
+                exit 0
+                ;;
+              build_failed|update_failed|pre_deploy_failed|canceled|deactivated)
+                echo "FINAL_STATUS=failure" >> $GITHUB_OUTPUT
+                echo "DEPLOY_STATUS=$STATUS" >> $GITHUB_OUTPUT
+                echo "FINISHED_AT=$FINISHED_AT" >> $GITHUB_OUTPUT
+                echo "COMMIT_MSG=$COMMIT_MSG" >> $GITHUB_OUTPUT
+                echo "::error::Deploy failed with status: $STATUS"
+                exit 1
+                ;;
+              created|build_in_progress|update_in_progress|pre_deploy_in_progress)
+                # Still in progress, keep polling
+                ;;
+              *)
+                echo "::warning::Unknown status: $STATUS"
+                ;;
+            esac
+
+            ATTEMPT=$((ATTEMPT + 1))
+            sleep 10
+          done
+
+          echo "FINAL_STATUS=timeout" >> $GITHUB_OUTPUT
+          echo "DEPLOY_STATUS=timeout" >> $GITHUB_OUTPUT
+          echo "::error::Deploy timed out after $((MAX_ATTEMPTS * 10)) seconds"
+          exit 1
+
+      - name: Write Job Summary
+        if: always()
+        run: |
+          DEPLOY_ID="${{ steps.trigger.outputs.DEPLOY_ID }}"
+          STATUS="${{ steps.poll.outputs.DEPLOY_STATUS }}"
+          FINISHED="${{ steps.poll.outputs.FINISHED_AT }}"
+          COMMIT="${{ steps.poll.outputs.COMMIT_MSG }}"
+          SERVICE_ID="${{ steps.set-service.outputs.SERVICE_ID }}"
+          BRANCH="${{ github.ref_name }}"
+
+          if [[ "$STATUS" == "live" ]]; then
+            STATUS_ICON="✅"
+          elif [[ "$STATUS" == "timeout" ]]; then
+            STATUS_ICON="⏱️"
+          else
+            STATUS_ICON="❌"
+          fi
+
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## ${STATUS_ICON} Backend Deployment — \`${BRANCH}\`
+
+          | Field | Value |
+          |-------|-------|
+          | **Status** | \`${STATUS}\` |
+          | **Deploy ID** | \`${DEPLOY_ID}\` |
+          | **Branch** | \`${BRANCH}\` |
+          | **Finished At** | ${FINISHED:-N/A} |
+          | **Commit** | ${COMMIT:-N/A} |
+          | **Dashboard** | [View on Render](https://dashboard.render.com/web/${SERVICE_ID}/deploys/${DEPLOY_ID}) |
+          EOF
 
   deploy-frontend:
     name: Deploy Frontend to Render


### PR DESCRIPTION
## Description
Enhances the deploy workflow to fetch and display Render deployment status and logs directly in GitHub Actions, instead of just firing a deploy trigger with no feedback.


## Related Issue(s)
<!-- Link all related issues. Use "Closes #N" to auto-close on merge. -->
- Closes #152 


## Changes
<!-- List changes file by file. Add/remove rows as needed. -->

| File | Change |
|------|--------|
| `.github/worflows/deploy.yml` | Modified to capture deploy ID from Render API response, poll deploy status every 10s until terminal state, and write a job summary with status, deploy ID, branch, timestamps, and a direct Render dashboard link. |


## Checklist
- [x] All tests passed 
- [x] I have self-reviewed my own code
- [ ] I have requested at least 1 reviewer
