### PR TITLE
feat: add initial user story and media file schemas

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -8,6 +8,9 @@ from alembic import context
 
 from app.core.config import settings
 from app.db.base import Base  # noqa: F401 — import all models here so autogenerate sees them
+from app.db.media_file import MediaFile  # noqa: F401
+from app.db.story import Story  # noqa: F401
+from app.db.user import User  # noqa: F401
 
 config = context.config
 

--- a/backend/alembic/versions/20260402_0001_create_core_schema.py
+++ b/backend/alembic/versions/20260402_0001_create_core_schema.py
@@ -1,0 +1,185 @@
+"""Create initial user, story, and media file tables.
+
+Revision ID: 20260402_0001
+Revises:
+Create Date: 2026-04-02 00:01:00
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "20260402_0001"
+down_revision: Union[str, Sequence[str], None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+user_role_enum = sa.Enum(
+    "user",
+    "admin",
+    name="user_role",
+    native_enum=False,
+)
+story_status_enum = sa.Enum(
+    "draft",
+    "published",
+    "archived",
+    name="story_status",
+    native_enum=False,
+)
+story_visibility_enum = sa.Enum(
+    "private",
+    "public",
+    "unlisted",
+    name="story_visibility",
+    native_enum=False,
+)
+media_type_enum = sa.Enum(
+    "image",
+    "audio",
+    "video",
+    "document",
+    name="media_type",
+    native_enum=False,
+)
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "users",
+        sa.Column("username", sa.String(length=50), nullable=False),
+        sa.Column("email", sa.String(length=255), nullable=False),
+        sa.Column("password_hash", sa.String(length=255), nullable=False),
+        sa.Column("display_name", sa.String(length=100), nullable=True),
+        sa.Column("bio", sa.Text(), nullable=True),
+        sa.Column("role", user_role_enum, nullable=False, server_default=sa.text("'user'")),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("email", name="uq_users_email"),
+        sa.UniqueConstraint("username", name="uq_users_username"),
+    )
+
+    op.create_table(
+        "stories",
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+        sa.Column("title", sa.String(length=255), nullable=False),
+        sa.Column("summary", sa.Text(), nullable=True),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column(
+            "status",
+            story_status_enum,
+            nullable=False,
+            server_default=sa.text("'draft'"),
+        ),
+        sa.Column(
+            "visibility",
+            story_visibility_enum,
+            nullable=False,
+            server_default=sa.text("'private'"),
+        ),
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_stories_status", "stories", ["status"], unique=False)
+    op.create_index("ix_stories_user_id", "stories", ["user_id"], unique=False)
+    op.create_index("ix_stories_visibility", "stories", ["visibility"], unique=False)
+
+    op.create_table(
+        "media_files",
+        sa.Column(
+            "story_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+        sa.Column("bucket_name", sa.String(length=63), nullable=False),
+        sa.Column("storage_key", sa.String(length=512), nullable=False),
+        sa.Column("original_filename", sa.String(length=255), nullable=False),
+        sa.Column("mime_type", sa.String(length=255), nullable=False),
+        sa.Column("media_type", media_type_enum, nullable=False),
+        sa.Column("file_size_bytes", sa.BigInteger(), nullable=False),
+        sa.Column("sort_order", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("alt_text", sa.Text(), nullable=True),
+        sa.Column("caption", sa.Text(), nullable=True),
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.CheckConstraint(
+            "file_size_bytes >= 0",
+            name="ck_media_files_file_size_non_negative",
+        ),
+        sa.ForeignKeyConstraint(["story_id"], ["stories.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "bucket_name",
+            "storage_key",
+            name="uq_media_files_bucket_storage_key",
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table("media_files")
+    op.drop_index("ix_stories_visibility", table_name="stories")
+    op.drop_index("ix_stories_user_id", table_name="stories")
+    op.drop_index("ix_stories_status", table_name="stories")
+    op.drop_table("stories")
+    op.drop_table("users")

--- a/backend/app/db/README.md
+++ b/backend/app/db/README.md
@@ -1,0 +1,22 @@
+# Database Models
+
+SQLAlchemy table models live in this package.
+
+## Implemented schema
+
+- `users`: authentication and profile fields
+- `stories`: story content plus publication metadata
+- `media_files`: object-storage-backed media linked to stories
+
+## Design notes
+
+- All primary keys use UUIDs so rows can be created safely across environments.
+- `created_at` and `updated_at` are included on every table for auditability.
+- `users.username` and `users.email` are unique.
+- `users.password_hash` stores only a hash, never a raw password.
+- `users.role` and `users.is_active` are included now so auth and authorization can grow without reshaping the table immediately.
+- `stories` belongs to `users` through `user_id`.
+- `stories.status` and `stories.visibility` are explicit enums so draft/publication flow can evolve cleanly.
+- `media_files` belongs to `stories` through `story_id`.
+- `media_files` stores storage location as `bucket_name + storage_key`, which keeps the schema compatible with MinIO locally and S3-compatible storage in production.
+- `media_files.alt_text` and `media_files.caption` are optional initial metadata fields for accessibility and presentation.

--- a/backend/app/db/__init__.py
+++ b/backend/app/db/__init__.py
@@ -1,0 +1,6 @@
+from app.db.base import Base
+from app.db.media_file import MediaFile
+from app.db.story import Story
+from app.db.user import User
+
+__all__ = ["Base", "MediaFile", "Story", "User"]

--- a/backend/app/db/enums.py
+++ b/backend/app/db/enums.py
@@ -1,0 +1,25 @@
+from enum import Enum
+
+
+class UserRole(str, Enum):
+    USER = "user"
+    ADMIN = "admin"
+
+
+class StoryStatus(str, Enum):
+    DRAFT = "draft"
+    PUBLISHED = "published"
+    ARCHIVED = "archived"
+
+
+class StoryVisibility(str, Enum):
+    PRIVATE = "private"
+    PUBLIC = "public"
+    UNLISTED = "unlisted"
+
+
+class MediaType(str, Enum):
+    IMAGE = "image"
+    AUDIO = "audio"
+    VIDEO = "video"
+    DOCUMENT = "document"

--- a/backend/app/db/media_file.py
+++ b/backend/app/db/media_file.py
@@ -1,0 +1,63 @@
+import uuid
+from typing import TYPE_CHECKING
+
+from sqlalchemy import (
+    BigInteger,
+    CheckConstraint,
+    Enum,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    text,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+from app.db.enums import MediaType
+from app.db.mixins import TimestampMixin, UUIDPrimaryKeyMixin
+
+if TYPE_CHECKING:
+    from app.db.story import Story
+
+
+class MediaFile(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "media_files"
+    __table_args__ = (
+        UniqueConstraint(
+            "bucket_name",
+            "storage_key",
+            name="uq_media_files_bucket_storage_key",
+        ),
+        CheckConstraint(
+            "file_size_bytes >= 0",
+            name="ck_media_files_file_size_non_negative",
+        ),
+    )
+
+    story_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("stories.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    bucket_name: Mapped[str] = mapped_column(String(63), nullable=False)
+    storage_key: Mapped[str] = mapped_column(String(512), nullable=False)
+    original_filename: Mapped[str] = mapped_column(String(255), nullable=False)
+    mime_type: Mapped[str] = mapped_column(String(255), nullable=False)
+    media_type: Mapped[MediaType] = mapped_column(
+        Enum(MediaType, name="media_type", native_enum=False),
+        nullable=False,
+    )
+    file_size_bytes: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    sort_order: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=0,
+        server_default=text("0"),
+    )
+    alt_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    caption: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    story: Mapped["Story"] = relationship(back_populates="media_files")

--- a/backend/app/db/mixins.py
+++ b/backend/app/db/mixins.py
@@ -1,0 +1,28 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+
+class UUIDPrimaryKeyMixin:
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+
+
+class TimestampMixin:
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )

--- a/backend/app/db/story.py
+++ b/backend/app/db/story.py
@@ -1,0 +1,50 @@
+import uuid
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Enum, ForeignKey, Index, String, Text, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+from app.db.enums import StoryStatus, StoryVisibility
+from app.db.mixins import TimestampMixin, UUIDPrimaryKeyMixin
+
+if TYPE_CHECKING:
+    from app.db.media_file import MediaFile
+    from app.db.user import User
+
+
+class Story(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "stories"
+    __table_args__ = (
+        Index("ix_stories_user_id", "user_id"),
+        Index("ix_stories_status", "status"),
+        Index("ix_stories_visibility", "visibility"),
+    )
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    summary: Mapped[str | None] = mapped_column(Text, nullable=True)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[StoryStatus] = mapped_column(
+        Enum(StoryStatus, name="story_status", native_enum=False),
+        nullable=False,
+        default=StoryStatus.DRAFT,
+        server_default=text("'draft'"),
+    )
+    visibility: Mapped[StoryVisibility] = mapped_column(
+        Enum(StoryVisibility, name="story_visibility", native_enum=False),
+        nullable=False,
+        default=StoryVisibility.PRIVATE,
+        server_default=text("'private'"),
+    )
+
+    user: Mapped["User"] = relationship(back_populates="stories")
+    media_files: Mapped[list["MediaFile"]] = relationship(
+        back_populates="story",
+        cascade="all, delete-orphan",
+    )

--- a/backend/app/db/user.py
+++ b/backend/app/db/user.py
@@ -1,0 +1,42 @@
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Boolean, Enum, String, Text, UniqueConstraint, text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+from app.db.enums import UserRole
+from app.db.mixins import TimestampMixin, UUIDPrimaryKeyMixin
+
+if TYPE_CHECKING:
+    from app.db.story import Story
+
+
+class User(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "users"
+    __table_args__ = (
+        UniqueConstraint("username", name="uq_users_username"),
+        UniqueConstraint("email", name="uq_users_email"),
+    )
+
+    username: Mapped[str] = mapped_column(String(50), nullable=False)
+    email: Mapped[str] = mapped_column(String(255), nullable=False)
+    password_hash: Mapped[str] = mapped_column(String(255), nullable=False)
+    display_name: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    bio: Mapped[str | None] = mapped_column(Text, nullable=True)
+    role: Mapped[UserRole] = mapped_column(
+        Enum(UserRole, name="user_role", native_enum=False),
+        nullable=False,
+        default=UserRole.USER,
+        server_default=text("'user'"),
+    )
+    is_active: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=True,
+        server_default=text("true"),
+    )
+
+    stories: Mapped[list["Story"]] = relationship(
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )


### PR DESCRIPTION
## Description
Implements the initial backend database schema for users, stories, and media files. This PR adds the SQLAlchemy models, shared schema helpers, and the first Alembic migration needed to create the core relational structure for authentication, story management, and media storage.

Suggested labels: `feature`, `backend`

## Related Issue(s)
- Closes #96
- Closes #99
- Closes #104

## Changes

| File | Change |
|------|--------|
| `backend/app/db/user.py` | Added the `User` SQLAlchemy model with authentication/profile fields, unique constraints, role/status defaults, and relationship to stories. |
| `backend/app/db/story.py` | Added the `Story` SQLAlchemy model with content/publication metadata and foreign key relationship to users. |
| `backend/app/db/media_file.py` | Added the `MediaFile` SQLAlchemy model with storage metadata, file constraints, and foreign key relationship to stories. |
| `backend/app/db/mixins.py` | Added shared UUID primary key and timestamp mixins to keep model definitions consistent. |
| `backend/app/db/enums.py` | Added enum definitions for user roles, story status/visibility, and media types. |
| `backend/app/db/__init__.py` | Exported the DB models and base class from the package. |
| `backend/app/db/README.md` | Documented the schema decisions and initial table design. |
| `backend/alembic/env.py` | Imported the new models so Alembic can detect them during migrations/autogeneration. |
| `backend/alembic/versions/20260402_0001_create_core_schema.py` | Added the initial migration that creates the `users`, `stories`, and `media_files` tables with constraints and indexes. |

## Checklist
- [x] All tests passed
- [x] I have self-reviewed my own code
- [x] I have requested at least 1 reviewer
