### PR TITLE
feat: add location and date range fields to Story model

### DIFF
--- a/backend/alembic/versions/20260403_0002_add_location_and_date_to_stories.py
+++ b/backend/alembic/versions/20260403_0002_add_location_and_date_to_stories.py
@@ -1,0 +1,40 @@
+"""Add location and date range fields to stories table.
+
+Revision ID: 20260403_0002
+Revises: 20260402_0001
+Create Date: 2026-04-03 00:00:00
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "20260403_0002"
+down_revision: Union[str, Sequence[str], None] = "20260402_0001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("stories", sa.Column("place_name", sa.String(length=255), nullable=True))
+    op.add_column("stories", sa.Column("latitude", sa.Float(), nullable=True))
+    op.add_column("stories", sa.Column("longitude", sa.Float(), nullable=True))
+    op.add_column("stories", sa.Column("date_start", sa.Integer(), nullable=True))
+    op.add_column("stories", sa.Column("date_end", sa.Integer(), nullable=True))
+    op.create_check_constraint(
+        "ck_stories_date_range_valid",
+        "stories",
+        "date_end IS NULL OR date_start IS NULL OR date_end >= date_start",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_stories_date_range_valid", "stories", type_="check")
+    op.drop_column("stories", "date_end")
+    op.drop_column("stories", "date_start")
+    op.drop_column("stories", "longitude")
+    op.drop_column("stories", "latitude")
+    op.drop_column("stories", "place_name")

--- a/backend/app/db/story.py
+++ b/backend/app/db/story.py
@@ -1,7 +1,7 @@
 import uuid
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Enum, ForeignKey, Index, String, Text, text
+from sqlalchemy import CheckConstraint, Enum, Float, ForeignKey, Index, Integer, String, Text, text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -20,6 +20,10 @@ class Story(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         Index("ix_stories_user_id", "user_id"),
         Index("ix_stories_status", "status"),
         Index("ix_stories_visibility", "visibility"),
+        CheckConstraint(
+            "date_end IS NULL OR date_start IS NULL OR date_end >= date_start",
+            name="ck_stories_date_range_valid",
+        ),
     )
 
     user_id: Mapped[uuid.UUID] = mapped_column(
@@ -42,6 +46,12 @@ class Story(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         default=StoryVisibility.PRIVATE,
         server_default=text("'private'"),
     )
+
+    place_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    latitude: Mapped[float | None] = mapped_column(Float, nullable=True)
+    longitude: Mapped[float | None] = mapped_column(Float, nullable=True)
+    date_start: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    date_end: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
     user: Mapped["User"] = relationship(back_populates="stories")
     media_files: Mapped[list["MediaFile"]] = relationship(


### PR DESCRIPTION
## Description

Extends the `Story` database model and table with location and historical date range fields required for the MVP demo and map functionality.

## Related Issue(s)
- Closes #120
- Closes #123

## Changes

| File | Change |
|------|--------|
| `backend/app/db/story.py` | Added `place_name`, `latitude`, `longitude`, `date_start`, `date_end` fields and a check constraint ensuring `date_end >= date_start` when both are provided. |
| `backend/alembic/versions/20260403_0002_add_location_and_date_to_stories.py` | New Alembic migration that applies (and can roll back) these column additions to the live database. |

## Design Decisions

- All new fields are **nullable at the database level** to ensure the migration runs safely against existing rows and to give the application layer full control over validation. Location (`place_name`, `latitude`, `longitude`) will be **enforced as required** by the story creation API endpoint. Date range (`date_start`, `date_end`) will be **optional**, consistent with the demo plan which acknowledges stories may have only approximate or unknown dates.
- `date_start` / `date_end` are stored as **integers (years)** — simple, sufficient for decade-level filtering, and extensible later.
- `latitude` / `longitude` are stored as **Float** — standard for geospatial coordinates; precise enough for map pin placement.
- A **check constraint** (`ck_stories_date_range_valid`) enforces that if both dates are provided, `date_end >= date_start`. This is enforced at the DB level, not just in application code.

## Checklist
- [x] All tests passed
- [x] I have self-reviewed my own code