### PR TITLE
feat: add Pydantic request and response schemas for users and stories

### DIFF
--- a/backend/app/models/story.py
+++ b/backend/app/models/story.py
@@ -1,0 +1,77 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, Field, model_validator
+
+from app.db.enums import StoryStatus, StoryVisibility
+
+
+class StoryCreateRequest(BaseModel):
+    title: str = Field(min_length=1, max_length=255)
+    content: str = Field(min_length=1)
+    summary: str | None = None
+    latitude: float = Field(ge=-90.0, le=90.0)
+    longitude: float = Field(ge=-180.0, le=180.0)
+    place_name: str | None = Field(default=None, max_length=255)
+    date_start: int | None = Field(default=None, ge=1, le=9999)
+    date_end: int | None = Field(default=None, ge=1, le=9999)
+
+    @model_validator(mode="after")
+    def check_date_range(self) -> "StoryCreateRequest":
+        if self.date_start is not None and self.date_end is not None:
+            if self.date_end < self.date_start:
+                raise ValueError("date_end must be greater than or equal to date_start")
+        return self
+
+
+class StoryResponse(BaseModel):
+    id: uuid.UUID
+    title: str
+    summary: str | None
+    content: str
+    author: str
+    place_name: str | None
+    latitude: float | None
+    longitude: float | None
+    date_start: int | None
+    date_end: int | None
+    date_label: str | None
+    status: StoryStatus
+    visibility: StoryVisibility
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+    @classmethod
+    def from_orm_with_author(cls, story: object, author_username: str) -> "StoryResponse":
+        date_start = getattr(story, "date_start", None)
+        date_end = getattr(story, "date_end", None)
+
+        if date_start and date_end:
+            date_label = f"{date_start} - {date_end}"
+        elif date_start:
+            date_label = str(date_start)
+        else:
+            date_label = None
+
+        return cls(
+            id=story.id,
+            title=story.title,
+            summary=story.summary,
+            content=story.content,
+            author=author_username,
+            place_name=story.place_name,
+            latitude=story.latitude,
+            longitude=story.longitude,
+            date_start=date_start,
+            date_end=date_end,
+            date_label=date_label,
+            status=story.status,
+            visibility=story.visibility,
+            created_at=story.created_at,
+        )
+
+
+class StoryListResponse(BaseModel):
+    stories: list[StoryResponse]
+    total: int

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,0 +1,34 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, EmailStr, Field
+
+from app.db.enums import UserRole
+
+
+class UserRegisterRequest(BaseModel):
+    username: str = Field(min_length=3, max_length=50)
+    email: EmailStr
+    password: str = Field(min_length=8)
+    display_name: str | None = Field(default=None, max_length=100)
+
+
+class UserLoginRequest(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class UserResponse(BaseModel):
+    id: uuid.UUID
+    username: str
+    email: str
+    display_name: str | None
+    role: UserRole
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class TokenResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,6 +10,7 @@ alembic
 
 # Config
 pydantic-settings
+pydantic[email]
 python-dotenv
 
 # Object storage (S3-compatible — works with MinIO locally and Supabase Storage in prod)


### PR DESCRIPTION
## Description

Adds Pydantic v2 request/response schemas for the user authentication and story flows. These schemas are the contract between the API layer and both the frontend and future service implementations.

## Related Issue(s)
- Related to #151

## Changes

| File | Change |
|------|--------|
| `backend/app/models/user.py` | `UserRegisterRequest` (username, email, password, display_name), `UserLoginRequest` (email, password), `UserResponse` (full user profile), `TokenResponse` (JWT bearer token) |
| `backend/app/models/story.py` | `StoryCreateRequest` (with coordinate bounds validation and date range check), `StoryResponse` (includes computed `date_label` field for the frontend map view), `StoryListResponse` (paginated wrapper) |
| `backend/requirements.txt` | Added `pydantic[email]` for `EmailStr` validation support |

## Design Decisions

- **`latitude` and `longitude` are required** in `StoryCreateRequest` — enforces Requirement 1.2.2.1 (every story must map to a geospatial coordinate). Coordinate bounds validated at schema level (`-90 ≤ lat ≤ 90`, `-180 ≤ lon ≤ 180`).
- **`date_start` / `date_end` are optional** — matches the demo plan where stories may have approximate or unknown dates.
- **`date_label`** is a computed field on `StoryResponse` (e.g. `"1965 - 1985"`) — derived from `date_start`/`date_end` to match what the frontend `map.html` already expects.
- **`from_orm_with_author`** is a factory classmethod on `StoryResponse` — since `author` (the username string) lives on the related `User` object, not on `Story` directly, the router will call this method after joining the user.
- **`model_config = {"from_attributes": True}`** on response schemas — required by Pydantic v2 to build a schema instance directly from a SQLAlchemy ORM object.
- **`password` is never included in any response schema** — intentional; `UserResponse` only exposes safe fields.

## Checklist
- [ ] All tests passed
- [x] I have self-reviewed my own code
- [ ] I have requested at least 1 reviewer