### PR TITLE
Feature: Auth Register

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI
 from sqlalchemy import text
 
 from app.db.session import engine
+from app.routers.auth import router as auth_router
 from app.services.storage import check_connection
 
 
@@ -20,6 +21,7 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(lifespan=lifespan)
+app.include_router(auth_router)
 
 
 @app.get("/")

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import BaseModel, EmailStr, Field, field_validator
 
 from app.db.enums import UserRole
 
@@ -12,10 +12,29 @@ class UserRegisterRequest(BaseModel):
     password: str = Field(min_length=8)
     display_name: str | None = Field(default=None, max_length=100)
 
+    @field_validator("password")
+    @classmethod
+    def validate_password_strength(cls, v: str) -> str:
+        errors = []
+        if not any(c.isupper() for c in v):
+            errors.append("one uppercase letter")
+        if not any(c.islower() for c in v):
+            errors.append("one lowercase letter")
+        if not any(c.isdigit() for c in v):
+            errors.append("one digit")
+        if not any(c in "!@#$%^&*()-_=+[]{}|;:',.<>?/`~" for c in v):
+            errors.append("one special character")
+        if errors:
+            raise ValueError(
+                "Password must contain at least: " + ", ".join(errors)
+            )
+        return v
+
 
 class UserLoginRequest(BaseModel):
     email: EmailStr
     password: str
+
 
 
 class UserResponse(BaseModel):
@@ -32,3 +51,4 @@ class UserResponse(BaseModel):
 class TokenResponse(BaseModel):
     access_token: str
     token_type: str = "bearer"
+

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,0 +1,24 @@
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_db
+from app.models.user import UserRegisterRequest, UserResponse
+from app.services.auth_service import register_user
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+@router.post(
+    "/register",
+    response_model=UserResponse,
+    status_code=status.HTTP_201_CREATED,
+    responses={
+        409: {"description": "Email or username already taken"},
+        422: {"description": "Validation error (weak password, invalid email, etc.)"},
+    },
+)
+async def register(
+    payload: UserRegisterRequest,
+    db: AsyncSession = Depends(get_db),
+):
+    return await register_user(db, payload)

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -1,0 +1,48 @@
+from fastapi import HTTPException, status
+from passlib.context import CryptContext
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.user import User
+from app.models.user import UserRegisterRequest, UserResponse
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def hash_password(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+async def register_user(
+    db: AsyncSession, payload: UserRegisterRequest
+) -> UserResponse:
+    email = payload.email.strip().lower()
+    username = payload.username.strip()
+
+    # Check email uniqueness
+    result = await db.execute(select(User).where(User.email == email))
+    if result.scalar_one_or_none() is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Email already registered",
+        )
+
+    # Check username uniqueness
+    result = await db.execute(select(User).where(User.username == username))
+    if result.scalar_one_or_none() is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Username already taken",
+        )
+
+    user = User(
+        username=username,
+        email=email,
+        password_hash=hash_password(payload.password),
+        display_name=payload.display_name,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+
+    return UserResponse.model_validate(user)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,5 +13,9 @@ pydantic-settings
 pydantic[email]
 python-dotenv
 
+# Auth
+passlib[bcrypt]
+bcrypt==4.2.1
+
 # Object storage (S3-compatible — works with MinIO locally and Supabase Storage in prod)
 boto3


### PR DESCRIPTION
## Description
Implement user registration endpoint with password strength validation and email/username uniqueness checks. Users can register via **POST** `/auth/register` with **bcrypt-hashed** passwords. Returns `201` on success, `409` for duplicate email/username, and `422` for validation errors (weak password, invalid email, etc.).



## Related Issue(s)
- Closes #109
- Closes #111


## Changes
<!-- List changes file by file. Add/remove rows as needed. -->

| File | Change |
|------|--------|
| backend/app/models/user.py | Added field_validator on password field enforcing uppercase, lowercase, digit, and special character requirements |
| backend/app/services/auth_service.py | Added register_user() with email normalization (lowercase + trim), email/username uniqueness checks, and bcrypt password hashing |
| backend/app/routers/auth.py | Added POST /auth/register endpoint returning UserResponse with 409/422 error documentation |
| backend/app/main.py | Wired auth router into the FastAPI app |
| backend/requirements.txt | Added passlib[bcrypt] and pinned bcrypt==4.2.1 for compatibility |



## Checklist
- [x] All tests passed 
- [x] I have self-reviewed my own code
- [ ] I have requested at least 1 reviewer
