### PR TITLE
Chore/remove page mocks

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,7 @@
 FROM nginx:alpine
 
 COPY index.html /usr/share/nginx/html/index.html
+COPY forgot-password.html /usr/share/nginx/html/forgot-password.html
 COPY register.html /usr/share/nginx/html/register.html
 COPY map.html /usr/share/nginx/html/map.html
 COPY story-create.html /usr/share/nginx/html/story-create.html

--- a/frontend/forgot-password.html
+++ b/frontend/forgot-password.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Local History Map - Forgot Password</title>
+  <script src="https://cdn.tailwindcss.com?plugins=forms"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Serif:wght@700;800&display=swap" rel="stylesheet">
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            background: "#fef9f0",
+            surface: "#ffffff",
+            primary: "#775a19",
+            "primary-light": "#c5a059",
+            secondary: "#506169",
+            tertiary: "#35618f",
+            border: "#e7e2d9",
+            textmain: "#1d1c16",
+            textmuted: "#5f584c"
+          },
+          fontFamily: {
+            body: ["Inter", "sans-serif"],
+            headline: ["Noto Serif", "serif"]
+          },
+          boxShadow: {
+            soft: "0 20px 50px rgba(0,0,0,0.08)"
+          }
+        }
+      }
+    };
+  </script>
+  <style>
+    body {
+      background:
+              linear-gradient(rgba(254, 249, 240, 0.9), rgba(254, 249, 240, 0.9)),
+              url("https://images.unsplash.com/photo-1512453979798-5ea266f8880c?auto=format&fit=crop&w=1600&q=80");
+      background-size: cover;
+      background-position: center;
+      background-attachment: fixed;
+    }
+  </style>
+</head>
+<body class="font-body text-textmain min-h-screen">
+<div class="min-h-screen flex items-center justify-center px-6 py-10">
+  <div class="w-full max-w-5xl grid lg:grid-cols-[1.15fr_0.95fr] bg-white/70 backdrop-blur-md rounded-3xl overflow-hidden shadow-soft border border-white/50">
+
+    <section class="hidden lg:flex flex-col justify-between p-12 bg-[rgba(53,97,143,0.08)]">
+      <div>
+        <div class="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-white/80 text-primary text-sm font-semibold border border-border">
+          <span>Account Recovery</span>
+        </div>
+
+        <h1 class="mt-8 font-headline text-5xl leading-tight font-extrabold text-textmain">
+          Reset access without losing your place on the map.
+        </h1>
+
+        <p class="mt-6 text-lg leading-8 text-textmuted max-w-xl">
+          Enter the email address you use for Local History Map. If password reset is enabled for your account, we will send the next steps there.
+        </p>
+      </div>
+
+      <div class="grid gap-4 sm:grid-cols-2">
+        <div class="rounded-2xl border border-border bg-white/80 p-4">
+          <p class="text-sm font-semibold text-primary">Security-first flow</p>
+          <p class="mt-2 text-sm text-textmuted">We return a generic success message so account recovery does not leak whether an email exists.</p>
+        </div>
+        <div class="rounded-2xl border border-border bg-white/80 p-4">
+          <p class="text-sm font-semibold text-primary">Fast way back</p>
+          <p class="mt-2 text-sm text-textmuted">Use the same email you normally sign in with to continue as soon as reset support is available.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="flex items-center justify-center bg-white/75 p-8 sm:p-12">
+      <div class="w-full max-w-md">
+        <div class="lg:hidden mb-8 text-center">
+          <h1 class="font-headline text-3xl font-extrabold text-textmain">Forgot password</h1>
+          <p class="mt-2 text-sm text-textmuted">Recover access to your account.</p>
+        </div>
+
+        <div class="mb-8">
+          <a href="index.html" class="inline-flex items-center gap-2 text-sm font-semibold text-primary hover:underline">
+            <span aria-hidden="true">&larr;</span>
+            Back to sign in
+          </a>
+          <h2 class="mt-5 text-3xl font-bold text-textmain">Reset your password</h2>
+          <p class="mt-2 text-textmuted">Enter your email and we will send password reset instructions if your account can be recovered.</p>
+        </div>
+
+        <div id="forgot-error" class="hidden mb-4 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700"></div>
+        <div id="forgot-success" class="hidden mb-4 rounded-xl border border-green-200 bg-green-50 p-3 text-sm text-green-700"></div>
+
+        <form id="forgot-password-form" class="space-y-5">
+          <div>
+            <label for="recovery-email" class="block text-sm font-semibold mb-2 text-textmain">Email</label>
+            <input
+                    id="recovery-email"
+                    type="email"
+                    placeholder="you@example.com"
+                    class="w-full rounded-xl border border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary"
+                    required
+            />
+          </div>
+
+          <button
+                  id="forgot-submit"
+                  type="submit"
+                  class="w-full rounded-xl bg-primary px-4 py-3 text-white font-semibold hover:opacity-95 transition"
+          >
+            Send reset link
+          </button>
+        </form>
+
+      </div>
+    </section>
+  </div>
+</div>
+
+<script src="config.js"></script>
+<script>
+  function showForgotMessage(kind, message) {
+    var errorEl = document.getElementById("forgot-error");
+    var successEl = document.getElementById("forgot-success");
+
+    errorEl.classList.add("hidden");
+    successEl.classList.add("hidden");
+
+    if (kind === "success") {
+      successEl.textContent = message;
+      successEl.classList.remove("hidden");
+      return;
+    }
+
+    errorEl.textContent = message;
+    errorEl.classList.remove("hidden");
+  }
+
+  async function handleForgotPassword(event) {
+    event.preventDefault();
+
+    var email = document.getElementById("recovery-email").value.trim();
+    var submitButton = document.getElementById("forgot-submit");
+
+    submitButton.disabled = true;
+    submitButton.textContent = "Sending...";
+
+    try {
+      var response = await fetch(API_BASE + "/auth/forgot-password", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: email })
+      });
+
+      if (response.ok) {
+        showForgotMessage(
+          "success",
+          "If an account exists for this email, reset instructions have been sent."
+        );
+        return;
+      }
+
+      if (response.status === 404 || response.status === 405) {
+        showForgotMessage(
+          "error",
+          "Password reset is not available right now. Please try again later."
+        );
+        return;
+      }
+
+      var data = await response.json().catch(function () { return {}; });
+      showForgotMessage(
+        "error",
+        data.detail || "Unable to start password reset right now. Please try again later."
+      );
+    } catch (err) {
+      showForgotMessage(
+        "error",
+        "Unable to reach the server right now. Please try again later."
+      );
+    } finally {
+      submitButton.disabled = false;
+      submitButton.textContent = "Send reset link";
+    }
+  }
+
+  document.getElementById("forgot-password-form").addEventListener("submit", handleForgotPassword);
+</script>
+</body>
+</html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -158,12 +158,6 @@
           </button>
         </div>
 
-        <div class="mt-6 flex flex-wrap justify-center gap-3">
-          <a href="map.html" class="text-sm font-medium text-primary hover:underline">Open Map</a>
-          <a href="story-create.html" class="text-sm font-medium text-primary hover:underline">Story Creation</a>
-          <a href="story-detail.html" class="text-sm font-medium text-primary hover:underline">Story Detail</a>
-        </div>
-
         <p class="mt-8 text-sm text-textmuted text-center">
           By continuing, you agree to our Terms and Privacy Policy.
         </p>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -107,7 +107,7 @@
           <div>
             <div class="flex items-center justify-between mb-2">
               <label for="password" class="block text-sm font-semibold text-textmain">Password</label>
-              <a href="#" class="text-sm font-medium text-tertiary hover:underline">Forgot password?</a>
+              <a href="forgot-password.html" class="text-sm font-medium text-tertiary hover:underline">Forgot password?</a>
             </div>
             <input
                     id="password"

--- a/frontend/map.html
+++ b/frontend/map.html
@@ -16,6 +16,131 @@
     <!-- Leaflet CSS -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
     <script>
+        let profileButton;
+        let profileButtonIcon;
+        let profileButtonInitials;
+        let profileMenu;
+        let profileMenuState;
+        let profileMenuActions;
+        let profileMenuUser;
+        let profileMenuName;
+        let profileMenuEmail;
+        let currentUser = null;
+
+        function getProfileLabel(user) {
+            if (!user) return "";
+            return (user.display_name || user.username || user.email || "").trim();
+        }
+
+        function getProfileInitials(user) {
+            var label = getProfileLabel(user);
+            if (!label) return "";
+
+            return label
+                .split(/\s+/)
+                .filter(Boolean)
+                .slice(0, 2)
+                .map(function (part) {
+                    return part.charAt(0).toUpperCase();
+                })
+                .join("");
+        }
+
+        function setProfileButton(user) {
+            var initials = getProfileInitials(user);
+
+            if (initials) {
+                profileButtonIcon.classList.add("hidden");
+                profileButtonInitials.textContent = initials;
+                profileButtonInitials.classList.remove("hidden");
+                profileButtonInitials.classList.add("inline-flex");
+                profileButton.setAttribute("aria-label", "Open account menu for " + getProfileLabel(user));
+                return;
+            }
+
+            profileButtonIcon.classList.remove("hidden");
+            profileButtonInitials.textContent = "";
+            profileButtonInitials.classList.add("hidden");
+            profileButtonInitials.classList.remove("inline-flex");
+            profileButton.setAttribute("aria-label", "Open account menu");
+        }
+
+        function closeProfileMenu() {
+            profileMenu.hidden = true;
+            profileButton.setAttribute("aria-expanded", "false");
+        }
+
+        function openProfileMenu() {
+            profileMenu.hidden = false;
+            profileButton.setAttribute("aria-expanded", "true");
+        }
+
+        function toggleProfileMenu() {
+            if (profileMenu.hidden) {
+                openProfileMenu();
+                return;
+            }
+
+            closeProfileMenu();
+        }
+
+        function renderProfileMenu() {
+            profileMenuActions.innerHTML = "";
+
+            if (!currentUser) {
+                profileMenuState.textContent = "Sign in to create stories and manage your account.";
+                profileMenuUser.classList.add("hidden");
+
+                var signInLink = document.createElement("a");
+                signInLink.href = "index.html";
+                signInLink.className = "flex w-full items-center justify-center rounded-xl bg-primary px-4 py-3 text-sm font-semibold text-white transition hover:opacity-95";
+                signInLink.textContent = "Sign In";
+                signInLink.setAttribute("role", "menuitem");
+                profileMenuActions.appendChild(signInLink);
+                setProfileButton(null);
+                return;
+            }
+
+            profileMenuState.textContent = "Signed in";
+            profileMenuUser.classList.remove("hidden");
+            profileMenuName.textContent = getProfileLabel(currentUser);
+            profileMenuEmail.textContent = currentUser.email || "";
+
+            var signOutButton = document.createElement("button");
+            signOutButton.type = "button";
+            signOutButton.className = "flex w-full items-center justify-between rounded-xl px-4 py-3 text-sm font-medium text-textmain transition hover:bg-background";
+            signOutButton.textContent = "Sign Out";
+            signOutButton.setAttribute("role", "menuitem");
+            signOutButton.addEventListener("click", function () {
+                logout();
+            });
+            profileMenuActions.appendChild(signOutButton);
+            setProfileButton(currentUser);
+        }
+
+        async function loadCurrentUser() {
+            currentUser = null;
+            renderProfileMenu();
+
+            if (!isLoggedIn()) {
+                return;
+            }
+
+            try {
+                var response = await authFetch(API_BASE + "/auth/me");
+                if (!response.ok) {
+                    localStorage.removeItem(AUTH_TOKEN_KEY);
+                    renderProfileMenu();
+                    return;
+                }
+
+                currentUser = await response.json();
+                renderProfileMenu();
+            } catch (err) {
+                profileMenuState.textContent = "Unable to load account details right now.";
+                setProfileButton(null);
+            }
+        }
         tailwind.config = {
             theme: {
                 extend: {
@@ -131,6 +256,10 @@
             background: #c5a059;
             border-radius: 4px;
         }
+
+        #profile-menu[hidden] {
+            display: none;
+        }
     </style>
 </head>
 
@@ -139,17 +268,8 @@
     <!-- Top Navigation Bar -->
     <header class="fixed top-0 left-0 right-0 z-[1000] bg-[#f8f3ea]/95 backdrop-blur-sm border-b border-border/30">
         <div class="flex justify-between items-center w-full px-8 py-4 max-w-screen-2xl mx-auto">
-            <div class="flex items-center gap-8">
+            <div class="flex items-center">
                 <h1 class="text-2xl font-bold font-headline text-textmain tracking-tight">Local History Map</h1>
-                <nav class="hidden md:flex items-center gap-6">
-                    <a class="text-primary font-bold border-b-2 border-primary pb-1" href="map.html">Map</a>
-                    <a class="text-textmain font-medium hover:text-tertiary transition-colors"
-                        href="story-detail.html">Archive</a>
-                    <a class="text-textmain font-medium hover:text-tertiary transition-colors"
-                        href="story-create.html">Create Story</a>
-                    <a class="text-textmain font-medium hover:text-tertiary transition-colors"
-                        href="index.html">Login</a>
-                </nav>
             </div>
             <div class="flex items-center gap-3 sm:gap-4">
                 <!-- Search -->
@@ -163,11 +283,30 @@
                         class="absolute top-full left-0 right-0 mt-1 bg-white border border-border rounded-xl shadow-soft overflow-hidden hidden z-50">
                     </div>
                 </div>
-                <button id="btn-profile" type="button"
-                    class="inline-flex h-11 w-11 items-center justify-center rounded-full border border-border bg-white text-textmain shadow-sm transition hover:bg-stone-50"
-                    aria-label="Open profile">
-                    <span class="material-symbols-outlined text-[20px] leading-none">account_circle</span>
-                </button>
+                <div class="relative">
+                    <button id="btn-profile" type="button"
+                        class="inline-flex h-11 min-w-11 items-center justify-center rounded-full border border-border bg-white px-2 text-textmain shadow-sm transition hover:bg-stone-50"
+                        aria-label="Open account menu"
+                        aria-haspopup="menu"
+                        aria-expanded="false">
+                        <span id="profile-button-icon" class="material-symbols-outlined text-[20px] leading-none">account_circle</span>
+                        <span id="profile-button-initials"
+                            class="hidden h-7 min-w-7 items-center justify-center rounded-full bg-primary text-xs font-bold uppercase text-white"></span>
+                    </button>
+                    <div id="profile-menu" hidden
+                        class="absolute right-0 top-[calc(100%+0.75rem)] w-72 rounded-2xl border border-border bg-white p-2 shadow-soft"
+                        role="menu"
+                        aria-labelledby="btn-profile">
+                        <div id="profile-menu-state" class="px-4 py-3 text-sm text-textmuted">
+                            Checking account status...
+                        </div>
+                        <div id="profile-menu-actions" class="space-y-1"></div>
+                        <div id="profile-menu-user" class="hidden border-t border-border/70 px-4 py-3">
+                            <p id="profile-menu-name" class="text-sm font-semibold text-textmain"></p>
+                            <p id="profile-menu-email" class="mt-1 text-xs text-textmuted break-all"></p>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     </header>
@@ -212,7 +351,7 @@
 
         <!-- Discovery Sidebar -->
         <aside id="sidebar"
-            class="relative z-[1000] m-4 mt-5 glass-panel rounded-2xl p-5 shadow-sm border border-border/20 md:absolute md:top-24 md:right-4 md:m-0 md:mt-0 md:w-72 md:max-h-[calc(100vh-200px)] md:overflow-y-auto">
+            class="relative z-[1000] m-4 mt-5 glass-panel rounded-2xl p-5 shadow-sm border border-border/20 md:absolute md:top-48 md:right-4 md:m-0 md:mt-0 md:w-72 md:max-h-[calc(100vh-296px)] md:overflow-y-auto">
             <div class="flex items-center justify-between mb-5">
                 <h2 class="font-headline font-bold text-lg">Recent Stories</h2>
                 <button id="btn-close-sidebar" class="hidden text-textmuted hover:text-textmain transition-colors md:inline-flex">
@@ -225,10 +364,21 @@
         </aside>
     </main>
 
+    <script src="config.js"></script>
+    <script src="auth.js"></script>
     <!-- Leaflet JS -->
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 
     <script>
+        profileButton = document.getElementById("btn-profile");
+        profileButtonIcon = document.getElementById("profile-button-icon");
+        profileButtonInitials = document.getElementById("profile-button-initials");
+        profileMenu = document.getElementById("profile-menu");
+        profileMenuState = document.getElementById("profile-menu-state");
+        profileMenuActions = document.getElementById("profile-menu-actions");
+        profileMenuUser = document.getElementById("profile-menu-user");
+        profileMenuName = document.getElementById("profile-menu-name");
+        profileMenuEmail = document.getElementById("profile-menu-email");
         // ─── Mock story data (will be replaced by API calls) ───
         const MOCK_STORIES = [
             {
@@ -541,12 +691,27 @@
             if (!document.getElementById("search-container").contains(e.target)) {
                 searchResults.classList.add("hidden");
             }
+
+            if (!profileMenu.hidden && !profileMenu.contains(e.target) && !profileButton.contains(e.target)) {
+                closeProfileMenu();
+            }
+        });
+
+        profileButton.addEventListener("click", function () {
+            toggleProfileMenu();
+        });
+
+        document.addEventListener("keydown", function (e) {
+            if (e.key === "Escape") {
+                closeProfileMenu();
+            }
         });
 
         // ─── Initialize ───
         // In production, this would be: fetch("/api/stories").then(r => r.json()).then(loadStories)
         loadStories(MOCK_STORIES);
         populateSidebar(MOCK_STORIES);
+        loadCurrentUser();
         syncMapSize();
         window.addEventListener("resize", syncMapSize);
     </script>

--- a/frontend/story-create.html
+++ b/frontend/story-create.html
@@ -62,19 +62,16 @@
 <main class="w-full px-4 py-10 lg:px-8 xl:px-10 2xl:px-14">
   <header class="mb-10 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
     <div>
-      <p class="text-sm font-semibold uppercase tracking-[0.2em] text-primary">Story Creation</p>
-      <h1 class="mt-3 font-headline text-4xl font-extrabold leading-tight text-textmain">Share a piece of local history</h1>
+      <a href="map.html" class="inline-flex items-center gap-2 text-sm font-semibold text-primary hover:underline">
+        <span aria-hidden="true">&larr;</span>
+        Back to map
+      </a>
+      <h1 class="mt-5 font-headline text-4xl font-extrabold leading-tight text-textmain">Share a piece of local history</h1>
       <p class="mt-4 max-w-4xl text-base leading-7 text-textmuted">
         Add a memory, attach media, choose a location, and place your story on the map for others to discover.
       </p>
     </div>
     <div class="flex flex-wrap gap-3">
-      <a href="index.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-surface px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">
-        Login Page
-      </a>
-      <a href="map.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-surface px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">
-        Map Page
-      </a>
       <a href="story-detail.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-surface px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">
         Preview Story Detail
       </a>
@@ -97,8 +94,7 @@
         <!-- Map Placement Section -->
         <section>
           <div>
-            <p class="text-sm font-semibold uppercase tracking-[0.18em] text-primary">Map Placement</p>
-            <h2 class="mt-2 font-headline text-3xl font-bold text-textmain">Choose where the story belongs</h2>
+            <h2 class="font-headline text-3xl font-bold text-textmain">Choose where the story belongs</h2>
             <p class="mt-3 max-w-3xl text-sm leading-7 text-textmuted">
               Search for an address or click directly on the map to pin the story's location.
             </p>
@@ -141,8 +137,8 @@
             <input id="location" type="text" placeholder="Kadikoy, Istanbul" class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary" />
           </div>
           <div>
-            <label for="date-start" class="mb-2 block text-sm font-semibold text-textmain">Date / Year</label>
-            <input id="date-start" type="number" min="1" max="2026" placeholder="e.g. 1987" class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary" />
+            <label for="date-single" class="mb-2 block text-sm font-semibold text-textmain">Date</label>
+            <input id="date-single" type="text" inputmode="numeric" placeholder="mm/dd/yyyy" class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary" />
           </div>
         </div>
 
@@ -150,11 +146,17 @@
         <div>
           <label class="flex items-center gap-3 cursor-pointer">
             <input id="date-range-toggle" type="checkbox" class="rounded border-border text-primary focus:ring-primary" />
-            <span class="text-sm text-textmuted">Specify a date range (e.g. 1965–1985)</span>
+            <span class="text-sm text-textmuted">Specify a date range</span>
           </label>
-          <div id="date-range-end" class="mt-3 hidden">
-            <label for="date-end" class="mb-2 block text-sm font-semibold text-textmain">End Year</label>
-            <input id="date-end" type="number" min="1" max="2026" placeholder="e.g. 1995" class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary" />
+          <div id="date-range-fields" class="mt-3 hidden grid gap-4 md:grid-cols-2">
+            <div>
+              <label for="date-start" class="mb-2 block text-sm font-semibold text-textmain">Start Date</label>
+              <input id="date-start" type="text" inputmode="numeric" placeholder="mm/dd/yyyy" class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary" />
+            </div>
+            <div>
+              <label for="date-end" class="mb-2 block text-sm font-semibold text-textmain">End Date</label>
+              <input id="date-end" type="text" inputmode="numeric" placeholder="mm/dd/yyyy" class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary" />
+            </div>
           </div>
         </div>
 
@@ -343,8 +345,14 @@
   }
 
   // ─── Date Range Toggle ───
+  function isValidDateInput(value) {
+    return /^(0[1-9]|1[0-2])\/(0[1-9]|[12][0-9]|3[01])\/\d{4}$/.test(value);
+  }
+
   document.getElementById("date-range-toggle").addEventListener("change", function () {
-    document.getElementById("date-range-end").classList.toggle("hidden", !this.checked);
+    document.getElementById("date-range-fields").classList.toggle("hidden", !this.checked);
+    document.getElementById("date-single").closest("div").classList.toggle("hidden", this.checked);
+    updateChecklist();
   });
 
   // ─── File Upload Display ───
@@ -366,7 +374,13 @@
     var titleOk = document.getElementById("title").value.trim().length > 0;
     var storyOk = document.getElementById("story").value.trim().length > 0;
     var locationOk = document.getElementById("latitude").value !== "";
-    var dateOk = document.getElementById("date-start").value.trim().length > 0;
+    var dateSingle = document.getElementById("date-single").value.trim();
+    var dateStart = document.getElementById("date-start").value.trim();
+    var dateEnd = document.getElementById("date-end").value.trim();
+    var usingDateRange = document.getElementById("date-range-toggle").checked;
+    var dateOk = usingDateRange
+      ? isValidDateInput(dateStart) && isValidDateInput(dateEnd)
+      : isValidDateInput(dateSingle);
 
     setCheckState("check-title", titleOk);
     setCheckState("check-story", storyOk);
@@ -388,7 +402,7 @@
   }
 
   // Listen for changes to update checklist
-  ["title", "story", "date-start"].forEach(function (id) {
+  ["title", "story", "date-single", "date-start", "date-end"].forEach(function (id) {
     document.getElementById(id).addEventListener("input", updateChecklist);
   });
 
@@ -405,7 +419,10 @@
     var content = document.getElementById("story").value.trim();
     var lat = document.getElementById("latitude").value;
     var lng = document.getElementById("longitude").value;
+    var dateSingle = document.getElementById("date-single").value.trim();
     var dateStart = document.getElementById("date-start").value.trim();
+    var usingDateRange = document.getElementById("date-range-toggle").checked;
+    var dateEnd = document.getElementById("date-end").value.trim();
 
     if (!title || !content) {
       errorEl.textContent = "Please fill in the title and story content.";
@@ -419,8 +436,32 @@
       return;
     }
 
-    if (!dateStart) {
-      errorEl.textContent = "Please provide a date or year for the story.";
+    if (!usingDateRange && !dateSingle) {
+      errorEl.textContent = "Please provide a date in mm/dd/yyyy format.";
+      errorEl.classList.remove("hidden");
+      return;
+    }
+
+    if (!usingDateRange && !isValidDateInput(dateSingle)) {
+      errorEl.textContent = "Date must use mm/dd/yyyy format.";
+      errorEl.classList.remove("hidden");
+      return;
+    }
+
+    if (usingDateRange && (!dateStart || !dateEnd)) {
+      errorEl.textContent = "Please provide both start and end dates.";
+      errorEl.classList.remove("hidden");
+      return;
+    }
+
+    if (usingDateRange && !isValidDateInput(dateStart)) {
+      errorEl.textContent = "Start date must use mm/dd/yyyy format.";
+      errorEl.classList.remove("hidden");
+      return;
+    }
+
+    if (usingDateRange && !isValidDateInput(dateEnd)) {
+      errorEl.textContent = "End date must use mm/dd/yyyy format.";
       errorEl.classList.remove("hidden");
       return;
     }
@@ -432,8 +473,8 @@
       latitude: parseFloat(lat),
       longitude: parseFloat(lng),
       location_name: document.getElementById("location").value.trim(),
-      date_start: parseInt(dateStart),
-      date_end: document.getElementById("date-range-toggle").checked ? parseInt(document.getElementById("date-end").value) : null
+      date_start: usingDateRange ? dateStart : dateSingle,
+      date_end: usingDateRange ? dateEnd : null
     };
 
     console.log("Story payload:", payload);


### PR DESCRIPTION
  ## Description
  This PR cleans up several frontend pages and removes mock-oriented or extra navigation elements that should not appear
  in the production flow.

  It updates the map page account menu behavior, adds a forgot password page and wires it from the login page,
  simplifies the login page footer links, and adjusts the story creation page header and date input flow.


  ## Changes

  | File | Change |
  |------|--------|
  | `frontend/map.html` | Updated the top bar by removing extra nav buttons and adding a profile/account dropdown that
  shows `Sign In` when signed out and `Sign Out` plus user info when signed in. |
  | `frontend/index.html` | Wired the forgot-password link to the new page and removed the extra footer links (`Open
  Map`, `Story Creation`, `Story Detail`). |
  | `frontend/forgot-password.html` | Added a dedicated forgot password page with production-facing copy and a reset-
  request form. |
  | `frontend/Dockerfile` | Added `forgot-password.html` to the frontend static file copy list. |
  | `frontend/story-create.html` | Replaced the top label with a `Back to map` link, removed extra top buttons, removed
  the `Map Placement` label, and changed date inputs so date range mode uses separate `Start Date` and `End Date` fields
  in `mm/dd/yyyy` format. |

  ## Checklist
  - [ ] All tests passed
  - [x] I have self-reviewed my own code
  - [ ] I have requested at least 1 reviewer