### PR TITLE
test: add story and media file factories for backend tests

### DIFF
--- a/backend/tests/factories/media_file_factory.py
+++ b/backend/tests/factories/media_file_factory.py
@@ -1,0 +1,69 @@
+import uuid
+from io import BytesIO
+
+from starlette.datastructures import Headers, UploadFile
+
+from app.db.enums import MediaType
+from app.db.media_file import MediaFile
+
+# Minimal valid PNG (67-byte 1×1 pixel) — small enough to be fast,
+# valid enough to pass content-type checks in the upload flow.
+_MINIMAL_PNG = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01"
+    b"\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde\x00\x00"
+    b"\x00\x0cIDATx\x9cc\xf8\x0f\x00\x00\x01\x01\x00\x05\x18"
+    b"\xd8N\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+DEFAULT_FILENAME = "test_photo.png"
+DEFAULT_CONTENT_TYPE = "image/png"
+DEFAULT_BUCKET_NAME = "images"
+DEFAULT_STORAGE_KEY_PREFIX = "stories"
+
+
+def make_upload_file(
+    *,
+    filename: str = DEFAULT_FILENAME,
+    content: bytes = _MINIMAL_PNG,
+    content_type: str = DEFAULT_CONTENT_TYPE,
+) -> UploadFile:
+    """Return an in-memory UploadFile for use in service-level unit tests.
+
+    No real file or cloud storage is involved — the content lives entirely
+    in a BytesIO buffer, so tests stay fast and isolated.
+    """
+    return UploadFile(
+        file=BytesIO(content),
+        filename=filename,
+        headers=Headers({"content-type": content_type}),
+    )
+
+
+def make_media_file_entity(
+    *,
+    story_id: uuid.UUID,
+    bucket_name: str = DEFAULT_BUCKET_NAME,
+    storage_key: str | None = None,
+    original_filename: str = DEFAULT_FILENAME,
+    mime_type: str = DEFAULT_CONTENT_TYPE,
+    media_type: MediaType = MediaType.IMAGE,
+    file_size_bytes: int = len(_MINIMAL_PNG),
+    sort_order: int = 0,
+    alt_text: str | None = None,
+    caption: str | None = None,
+) -> MediaFile:
+    """Return a MediaFile ORM object for direct insertion into a test DB session."""
+    if storage_key is None:
+        storage_key = f"{DEFAULT_STORAGE_KEY_PREFIX}/{story_id}/media/{uuid.uuid4()}.png"
+    return MediaFile(
+        story_id=story_id,
+        bucket_name=bucket_name,
+        storage_key=storage_key,
+        original_filename=original_filename,
+        mime_type=mime_type,
+        media_type=media_type,
+        file_size_bytes=file_size_bytes,
+        sort_order=sort_order,
+        alt_text=alt_text,
+        caption=caption,
+    )

--- a/backend/tests/factories/story_factory.py
+++ b/backend/tests/factories/story_factory.py
@@ -1,0 +1,110 @@
+import uuid
+
+from app.db.enums import StoryStatus, StoryVisibility
+from app.db.story import Story
+
+# Fixed default coordinates: Çeliktepe, Istanbul — used as the primary
+# demo location and kept constant so map-related tests are deterministic.
+DEFAULT_TITLE = "A Story from Çeliktepe"
+DEFAULT_CONTENT = "Children used to play in the narrow streets between the gecekondu houses."
+DEFAULT_SUMMARY = "A childhood memory from the Çeliktepe neighbourhood of Istanbul."
+DEFAULT_PLACE_NAME = "Çeliktepe, Istanbul"
+DEFAULT_LATITUDE = 41.0739
+DEFAULT_LONGITUDE = 28.9606
+DEFAULT_DATE_START = 1960
+DEFAULT_DATE_END = 1980
+
+
+def make_story_payload(
+    *,
+    title: str = DEFAULT_TITLE,
+    content: str = DEFAULT_CONTENT,
+    summary: str | None = DEFAULT_SUMMARY,
+    place_name: str = DEFAULT_PLACE_NAME,
+    latitude: float = DEFAULT_LATITUDE,
+    longitude: float = DEFAULT_LONGITUDE,
+    date_start: int | None = DEFAULT_DATE_START,
+    date_end: int | None = DEFAULT_DATE_END,
+    suffix: int | str | None = None,
+) -> dict:
+    """Return a dict that matches StoryCreateRequest, for use in API-level tests."""
+    if suffix is not None:
+        title = f"{title} {suffix}"
+        place_name = f"{place_name} {suffix}"
+    payload = {
+        "title": title,
+        "content": content,
+        "place_name": place_name,
+        "latitude": latitude,
+        "longitude": longitude,
+    }
+    if summary is not None:
+        payload["summary"] = summary
+    if date_start is not None:
+        payload["date_start"] = date_start
+    if date_end is not None:
+        payload["date_end"] = date_end
+    return payload
+
+
+def make_story_update_payload(
+    *,
+    title: str = "An Updated Story from Çeliktepe",
+    content: str = "The neighbourhood changed a lot after the 1980s.",
+    summary: str | None = "An updated memory from Çeliktepe.",
+    place_name: str = DEFAULT_PLACE_NAME,
+    latitude: float = DEFAULT_LATITUDE,
+    longitude: float = DEFAULT_LONGITUDE,
+    date_start: int | None = DEFAULT_DATE_START,
+    date_end: int | None = DEFAULT_DATE_END,
+) -> dict:
+    """Return a dict that matches StoryUpdateRequest, for use in update API tests."""
+    payload = {
+        "title": title,
+        "content": content,
+        "place_name": place_name,
+        "latitude": latitude,
+        "longitude": longitude,
+    }
+    if summary is not None:
+        payload["summary"] = summary
+    if date_start is not None:
+        payload["date_start"] = date_start
+    if date_end is not None:
+        payload["date_end"] = date_end
+    return payload
+
+
+def make_story_entity(
+    *,
+    user_id: uuid.UUID,
+    title: str = DEFAULT_TITLE,
+    content: str = DEFAULT_CONTENT,
+    summary: str | None = DEFAULT_SUMMARY,
+    place_name: str | None = DEFAULT_PLACE_NAME,
+    latitude: float | None = DEFAULT_LATITUDE,
+    longitude: float | None = DEFAULT_LONGITUDE,
+    date_start: int | None = DEFAULT_DATE_START,
+    date_end: int | None = DEFAULT_DATE_END,
+    status: StoryStatus = StoryStatus.PUBLISHED,
+    visibility: StoryVisibility = StoryVisibility.PUBLIC,
+    suffix: int | str | None = None,
+) -> Story:
+    """Return a Story ORM object for direct insertion into a test DB session."""
+    if suffix is not None:
+        title = f"{title} {suffix}"
+        if place_name is not None:
+            place_name = f"{place_name} {suffix}"
+    return Story(
+        user_id=user_id,
+        title=title,
+        content=content,
+        summary=summary,
+        place_name=place_name,
+        latitude=latitude,
+        longitude=longitude,
+        date_start=date_start,
+        date_end=date_end,
+        status=status,
+        visibility=visibility,
+    )

--- a/backend/tests/unit/test_media_file_factory.py
+++ b/backend/tests/unit/test_media_file_factory.py
@@ -1,0 +1,120 @@
+import uuid
+
+from starlette.datastructures import UploadFile
+
+from app.db.enums import MediaType
+from app.db.media_file import MediaFile
+from tests.factories.media_file_factory import (
+    DEFAULT_BUCKET_NAME,
+    DEFAULT_CONTENT_TYPE,
+    DEFAULT_FILENAME,
+    make_media_file_entity,
+    make_upload_file,
+)
+
+
+class TestMakeUploadFile:
+    def test_returns_upload_file_instance(self):
+        upload = make_upload_file()
+        assert isinstance(upload, UploadFile)
+
+    def test_defaults_are_a_valid_png(self):
+        upload = make_upload_file()
+        assert upload.filename == DEFAULT_FILENAME
+        assert upload.content_type == DEFAULT_CONTENT_TYPE
+
+    def test_content_is_readable_and_non_empty(self):
+        upload = make_upload_file()
+        content = upload.file.read()
+        assert len(content) > 0
+
+    def test_filename_override(self):
+        upload = make_upload_file(filename="archive.jpg", content_type="image/jpeg")
+        assert upload.filename == "archive.jpg"
+        assert upload.content_type == "image/jpeg"
+
+    def test_content_override(self):
+        custom_bytes = b"fake-audio-data"
+        upload = make_upload_file(
+            filename="clip.mp3",
+            content=custom_bytes,
+            content_type="audio/mpeg",
+        )
+        assert upload.file.read() == custom_bytes
+
+    def test_each_call_produces_independent_buffer(self):
+        u1 = make_upload_file()
+        u2 = make_upload_file()
+        # Reading one should not affect the other
+        u1.file.read()
+        assert len(u2.file.read()) > 0
+
+    def test_no_external_dependencies(self):
+        # Simply constructing the upload file must not raise — confirming
+        # no network or filesystem access occurs.
+        upload = make_upload_file()
+        assert upload is not None
+
+
+class TestMakeMediaFileEntity:
+    def test_returns_media_file_instance(self):
+        story_id = uuid.uuid4()
+        media = make_media_file_entity(story_id=story_id)
+        assert isinstance(media, MediaFile)
+
+    def test_story_id_is_set_correctly(self):
+        story_id = uuid.uuid4()
+        media = make_media_file_entity(story_id=story_id)
+        assert media.story_id == story_id
+
+    def test_defaults_match_factory_constants(self):
+        story_id = uuid.uuid4()
+        media = make_media_file_entity(story_id=story_id)
+        assert media.bucket_name == DEFAULT_BUCKET_NAME
+        assert media.original_filename == DEFAULT_FILENAME
+        assert media.mime_type == DEFAULT_CONTENT_TYPE
+        assert media.media_type == MediaType.IMAGE
+        assert media.file_size_bytes > 0
+        assert media.sort_order == 0
+
+    def test_storage_key_is_auto_generated_and_unique(self):
+        story_id = uuid.uuid4()
+        m1 = make_media_file_entity(story_id=story_id)
+        m2 = make_media_file_entity(story_id=story_id)
+        assert m1.storage_key != m2.storage_key
+
+    def test_storage_key_contains_story_id(self):
+        story_id = uuid.uuid4()
+        media = make_media_file_entity(story_id=story_id)
+        assert str(story_id) in media.storage_key
+
+    def test_custom_storage_key_is_respected(self):
+        story_id = uuid.uuid4()
+        custom_key = "stories/custom/path/file.png"
+        media = make_media_file_entity(story_id=story_id, storage_key=custom_key)
+        assert media.storage_key == custom_key
+
+    def test_field_overrides_are_applied(self):
+        story_id = uuid.uuid4()
+        media = make_media_file_entity(
+            story_id=story_id,
+            original_filename="voice_memo.mp3",
+            mime_type="audio/mpeg",
+            media_type=MediaType.AUDIO,
+            file_size_bytes=5000,
+            sort_order=2,
+            alt_text="A voice recording",
+            caption="Recorded in 1978",
+        )
+        assert media.original_filename == "voice_memo.mp3"
+        assert media.mime_type == "audio/mpeg"
+        assert media.media_type == MediaType.AUDIO
+        assert media.file_size_bytes == 5000
+        assert media.sort_order == 2
+        assert media.alt_text == "A voice recording"
+        assert media.caption == "Recorded in 1978"
+
+    def test_optional_fields_default_to_none(self):
+        media = make_media_file_entity(story_id=uuid.uuid4())
+        assert media.alt_text is None
+        assert media.caption is None

--- a/backend/tests/unit/test_story_factory.py
+++ b/backend/tests/unit/test_story_factory.py
@@ -1,0 +1,149 @@
+import uuid
+
+import pytest
+
+from app.db.enums import StoryStatus, StoryVisibility
+from app.db.story import Story
+from tests.factories.story_factory import (
+    DEFAULT_DATE_END,
+    DEFAULT_DATE_START,
+    DEFAULT_LATITUDE,
+    DEFAULT_LONGITUDE,
+    DEFAULT_PLACE_NAME,
+    DEFAULT_TITLE,
+    make_story_entity,
+    make_story_payload,
+    make_story_update_payload,
+)
+
+
+class TestMakeStoryPayload:
+    def test_defaults_produce_valid_create_request_fields(self):
+        payload = make_story_payload()
+        assert payload["title"] == DEFAULT_TITLE
+        assert payload["place_name"] == DEFAULT_PLACE_NAME
+        assert payload["latitude"] == DEFAULT_LATITUDE
+        assert payload["longitude"] == DEFAULT_LONGITUDE
+        assert payload["date_start"] == DEFAULT_DATE_START
+        assert payload["date_end"] == DEFAULT_DATE_END
+        assert "content" in payload
+
+    def test_coordinates_are_within_valid_bounds(self):
+        payload = make_story_payload()
+        assert -90.0 <= payload["latitude"] <= 90.0
+        assert -180.0 <= payload["longitude"] <= 180.0
+
+    def test_date_range_is_valid(self):
+        payload = make_story_payload()
+        assert payload["date_start"] <= payload["date_end"]
+
+    def test_suffix_makes_title_and_place_name_unique(self):
+        p1 = make_story_payload(suffix=1)
+        p2 = make_story_payload(suffix=2)
+        assert p1["title"] != p2["title"]
+        assert p1["place_name"] != p2["place_name"]
+
+    def test_field_overrides_are_applied(self):
+        payload = make_story_payload(
+            title="Custom Title",
+            place_name="Beyoğlu, Istanbul",
+            latitude=41.0335,
+            longitude=28.9775,
+            date_start=1950,
+            date_end=1960,
+        )
+        assert payload["title"] == "Custom Title"
+        assert payload["place_name"] == "Beyoğlu, Istanbul"
+        assert payload["latitude"] == 41.0335
+        assert payload["longitude"] == 28.9775
+        assert payload["date_start"] == 1950
+        assert payload["date_end"] == 1960
+
+    def test_optional_summary_omitted_when_none(self):
+        payload = make_story_payload(summary=None)
+        assert "summary" not in payload
+
+    def test_optional_dates_omitted_when_none(self):
+        payload = make_story_payload(date_start=None, date_end=None)
+        assert "date_start" not in payload
+        assert "date_end" not in payload
+
+
+class TestMakeStoryUpdatePayload:
+    def test_defaults_produce_valid_update_fields(self):
+        payload = make_story_update_payload()
+        assert "title" in payload
+        assert "content" in payload
+        assert "place_name" in payload
+        assert "latitude" in payload
+        assert "longitude" in payload
+
+    def test_field_overrides_are_applied(self):
+        payload = make_story_update_payload(
+            title="Updated Title",
+            place_name="Karaköy, Istanbul",
+        )
+        assert payload["title"] == "Updated Title"
+        assert payload["place_name"] == "Karaköy, Istanbul"
+
+
+class TestMakeStoryEntity:
+    def test_returns_story_instance(self):
+        story = make_story_entity(user_id=uuid.uuid4())
+        assert isinstance(story, Story)
+
+    def test_defaults_match_factory_constants(self):
+        user_id = uuid.uuid4()
+        story = make_story_entity(user_id=user_id)
+        assert story.user_id == user_id
+        assert story.title == DEFAULT_TITLE
+        assert story.place_name == DEFAULT_PLACE_NAME
+        assert story.latitude == DEFAULT_LATITUDE
+        assert story.longitude == DEFAULT_LONGITUDE
+        assert story.date_start == DEFAULT_DATE_START
+        assert story.date_end == DEFAULT_DATE_END
+
+    def test_default_status_is_published_and_public(self):
+        story = make_story_entity(user_id=uuid.uuid4())
+        assert story.status == StoryStatus.PUBLISHED
+        assert story.visibility == StoryVisibility.PUBLIC
+
+    def test_suffix_makes_title_and_place_name_unique(self):
+        uid = uuid.uuid4()
+        s1 = make_story_entity(user_id=uid, suffix=1)
+        s2 = make_story_entity(user_id=uid, suffix=2)
+        assert s1.title != s2.title
+        assert s1.place_name != s2.place_name
+
+    def test_field_overrides_are_applied(self):
+        user_id = uuid.uuid4()
+        story = make_story_entity(
+            user_id=user_id,
+            title="Override Title",
+            status=StoryStatus.DRAFT,
+            visibility=StoryVisibility.PRIVATE,
+            date_start=1970,
+            date_end=1975,
+        )
+        assert story.title == "Override Title"
+        assert story.status == StoryStatus.DRAFT
+        assert story.visibility == StoryVisibility.PRIVATE
+        assert story.date_start == 1970
+        assert story.date_end == 1975
+
+    def test_optional_fields_can_be_none(self):
+        story = make_story_entity(
+            user_id=uuid.uuid4(),
+            summary=None,
+            place_name=None,
+            latitude=None,
+            longitude=None,
+            date_start=None,
+            date_end=None,
+        )
+        assert story.summary is None
+        assert story.place_name is None
+        assert story.latitude is None
+        assert story.longitude is None
+        assert story.date_start is None
+        assert story.date_end is None


### PR DESCRIPTION
## Description

Adds two reusable test factory modules to `tests/factories/`, following the same conventions as the existing `user_factory.py`. These factories are a direct dependency for the open integration test issues (#119, #121, #145, #146).

## Related Issue(s)
- Closes #106
- Closes #107

## Changes

| File | What it provides |
|------|-----------------|
| `tests/factories/story_factory.py` | `make_story_payload()` — dict for `POST /stories` API tests; `make_story_update_payload()` — dict for `PUT /stories/{id}` tests; `make_story_entity()` — `Story` ORM object for direct DB insertion in integration tests |
| `tests/factories/media_file_factory.py` | `make_upload_file()` — in-memory `UploadFile` with a minimal valid PNG (no real files, no cloud storage); `make_media_file_entity()` — `MediaFile` ORM object for direct DB insertion |
| `tests/unit/test_story_factory.py` | Unit tests for all three story factory functions |
| `tests/unit/test_media_file_factory.py` | Unit tests for both media file factory functions |

## Design Decisions

- **Fixed coordinates** for `make_story_entity` default to Çeliktepe, Istanbul (`41.0739, 28.9606`) — the primary demo location from the MVP Demo Plan wiki. This keeps map-related tests deterministic and aligned with the demo scenario.
- **Default date range 1960–1980** — consistent with the demo plan's 1950s–1980s gecekondu migration theme.
- **Minimal valid PNG** in `make_upload_file` is a real 67-byte 1×1 PNG, not random bytes — it passes content-type validation in the upload service without requiring any file I/O.
- **Auto-generated `storage_key`** in `make_media_file_entity` uses `uuid4()` per call, so multiple media files in one test never collide on the `uq_media_files_bucket_storage_key` unique constraint.
- **`suffix` parameter** on both entity/payload functions matches the `user_factory.py` convention — allows generating multiple unique records in a single test without manual string construction.

## Checklist
- [ ] All tests passed
- [x] I have self-reviewed my own code
- [x] I have requested at least 1 reviewer