### PR TITLE
feat:Expose media URLs in story detail responses

### DIFF
--- a/backend/app/models/story.py
+++ b/backend/app/models/story.py
@@ -127,6 +127,7 @@ class MediaFileResponse(BaseModel):
     story_id: uuid.UUID
     bucket_name: str
     storage_key: str
+    media_url: str
     original_filename: str
     mime_type: str
     media_type: MediaType

--- a/backend/app/services/storage.py
+++ b/backend/app/services/storage.py
@@ -1,5 +1,6 @@
 import boto3
 from botocore.config import Config
+from urllib.parse import quote
 
 from app.core.config import settings
 from app.db.enums import MediaType
@@ -50,3 +51,10 @@ def upload_bytes(
 
 def delete_object(*, bucket_name: str, storage_key: str) -> None:
     storage_client.delete_object(Bucket=bucket_name, Key=storage_key)
+
+
+def build_public_object_url(*, bucket_name: str, storage_key: str) -> str:
+    base_url = settings.STORAGE_PUBLIC_URL.rstrip("/")
+    encoded_bucket = quote(bucket_name, safe="")
+    encoded_key = quote(storage_key.lstrip("/"), safe="/")
+    return f"{base_url}/{encoded_bucket}/{encoded_key}"

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -12,15 +12,20 @@ from app.db.story import Story
 from app.db.user import User
 from app.models.story import (
     MediaFileResponse,
-    StoryDetailResponse,
-    StoryCreateRequest,
-    StoryUpdateRequest,
     MediaUploadRequest,
     MediaUploadResponse,
+    StoryCreateRequest,
+    StoryDetailResponse,
     StoryListResponse,
     StoryResponse,
+    StoryUpdateRequest,
 )
-from app.services.storage import delete_object, get_bucket_for_media_type, upload_bytes
+from app.services.storage import (
+    build_public_object_url,
+    delete_object,
+    get_bucket_for_media_type,
+    upload_bytes,
+)
 
 MAX_MEDIA_UPLOAD_BYTES = 20 * 1024 * 1024  # 20 MB
 
@@ -45,9 +50,30 @@ def _map_story_rows(rows: list[tuple[Story, str]]) -> StoryListResponse:
     return StoryListResponse(stories=stories, total=len(stories))
 
 
+def _map_media_file(media: MediaFile) -> MediaFileResponse:
+    return MediaFileResponse(
+        id=media.id,
+        story_id=media.story_id,
+        bucket_name=media.bucket_name,
+        storage_key=media.storage_key,
+        media_url=build_public_object_url(
+            bucket_name=media.bucket_name,
+            storage_key=media.storage_key,
+        ),
+        original_filename=media.original_filename,
+        mime_type=media.mime_type,
+        media_type=media.media_type,
+        file_size_bytes=media.file_size_bytes,
+        sort_order=media.sort_order,
+        alt_text=media.alt_text,
+        caption=media.caption,
+        created_at=media.created_at,
+    )
+
+
 def _map_story_detail(story: Story, author_username: str) -> StoryDetailResponse:
     story_response = StoryResponse.from_orm_with_author(story, author_username)
-    media_files = [MediaFileResponse.model_validate(media) for media in story.media_files]
+    media_files = [_map_media_file(media) for media in story.media_files]
     return StoryDetailResponse(**story_response.model_dump(), media_files=media_files)
 
 
@@ -287,4 +313,4 @@ async def upload_media_for_story(
             detail="Failed to persist media metadata",
         )
 
-    return MediaUploadResponse(media=MediaFileResponse.model_validate(media))
+    return MediaUploadResponse(media=_map_media_file(media))

--- a/backend/tests/api/test_story_api.py
+++ b/backend/tests/api/test_story_api.py
@@ -145,6 +145,7 @@ class TestStoryMediaUploadAPI:
         assert "id" in media
         assert "storage_key" in media
         assert "bucket_name" in media
+        assert media["media_url"].endswith(f'/{media["bucket_name"]}/{media["storage_key"]}')
         assert "created_at" in media
 
     async def test_upload_media_invalid_mime_type(self, client, db_session, monkeypatch):
@@ -246,6 +247,7 @@ class TestStoryDetailAPI:
         assert media_item["mime_type"] == "image/png"
         assert media_item["media_type"] == "image"
         assert media_item["file_size_bytes"] == 777
+        assert media_item["media_url"].endswith("/images/stories/test/photo.png")
 
     async def test_get_story_detail_not_found(self, client):
         resp = await client.get(f"/stories/{uuid.uuid4()}")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -27,8 +27,10 @@ async def db_session():
     """Provide a per-test engine + session so everything shares one event loop."""
     engine = create_async_engine(_url, echo=False)
 
-    # Create tables
+    # Reset the schema first so stale tables from earlier runs don't survive
+    # and silently bypass new columns added to the ORM models.
     async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
         await conn.run_sync(Base.metadata.create_all)
 
     session_factory = async_sessionmaker(

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -247,6 +247,8 @@ class TestGetStoryDetailByIdService:
         assert len(result.media_files) == 2
         assert result.media_files[0].original_filename == "photo1.png"
         assert result.media_files[1].original_filename == "photo2.png"
+        assert result.media_files[0].media_url.endswith("/images/stories/key.png")
+        assert result.media_files[1].media_url.endswith("/images/stories/key.png")
         db.execute.assert_awaited_once()
 
     async def test_raises_404_when_story_not_found(self):


### PR DESCRIPTION
## Description
This PR exposes backend-generated `media_url` values in story media responses so the frontend can render story images/videos without constructing storage URLs client-side. Existing storage metadata fields are kept for backward compatibility.

## Related Issue(s)
- Closes #178

## Changes

| File | Change |
|------|--------|
| `backend/app/models/story.py` | Added `media_url` to `MediaFileResponse` so story/media API responses expose a directly usable URL. |
| `backend/app/services/storage.py` | Added a helper to build public media URLs from `STORAGE_PUBLIC_URL`, `bucket_name`, and `storage_key`. |
| `backend/app/services/story_service.py` | Updated media mapping so story detail and media upload responses include `media_url` while preserving existing metadata fields. |
| `backend/tests/api/test_story_api.py` | Added API assertions to verify `media_url` is returned in story detail and media upload responses. |
| `backend/tests/unit/test_story_service.py` | Added service-level assertions for generated `media_url` values. |
| `backend/tests/conftest.py` | Reset test tables before `create_all` to prevent stale schemas from causing API test failures. |

## Checklist
- [x] All tests passed
- [x] I have self-reviewed my own code
- [x] I have requested at least 1 reviewer
