### PR TITLE
fix: include media_url in upload response mapping

### DIFF
--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -331,4 +331,4 @@ async def upload_media_for_story(
             detail="Failed to persist media metadata",
         )
 
-    return MediaUploadResponse(media=MediaFileResponse.model_validate(media))
+    return MediaUploadResponse(media=_map_media_file(media))


### PR DESCRIPTION
## Description
This PR fixes the story media upload response to return `media_url` using the shared media mapping logic. Without this change, upload responses failed validation after `media_url` was added to `MediaFileResponse`.

Relevant labels: `backend`, `bugfix`

## Related Issue(s)
- Closes #178

## Changes

| File | Change |
|------|--------|
| `backend/app/services/story_service.py` | Updated the media upload response to use the shared `_map_media_file(...)` mapper so uploaded media objects include `media_url`. |

## Checklist
- [x] All tests passed
- [x] I have self-reviewed my own code
- [ ] I have requested at least 1 reviewer