### PR TITLE
fix: update story factory to match DATE column type from migration 0003

### DIFF
--- a/backend/tests/factories/story_factory.py
+++ b/backend/tests/factories/story_factory.py
@@ -1,6 +1,7 @@
 import uuid
+from datetime import date
 
-from app.db.enums import StoryStatus, StoryVisibility
+from app.db.enums import DatePrecision, StoryStatus, StoryVisibility
 from app.db.story import Story
 
 # Fixed default coordinates: Çeliktepe, Istanbul — used as the primary
@@ -11,8 +12,16 @@ DEFAULT_SUMMARY = "A childhood memory from the Çeliktepe neighbourhood of Istan
 DEFAULT_PLACE_NAME = "Çeliktepe, Istanbul"
 DEFAULT_LATITUDE = 41.0739
 DEFAULT_LONGITUDE = 28.9606
+
+# Payload defaults: integers, because StoryCreateRequest accepts year integers
+# and normalises them internally before writing to the DB.
 DEFAULT_DATE_START = 1960
 DEFAULT_DATE_END = 1980
+
+# Entity defaults: full date objects, because the Story ORM column is DATE.
+# Year-precision stories are stored as Jan 1 (start) and Dec 31 (end).
+DEFAULT_ENTITY_DATE_START = date(1960, 1, 1)
+DEFAULT_ENTITY_DATE_END = date(1980, 12, 31)
 
 
 def make_story_payload(
@@ -84,13 +93,20 @@ def make_story_entity(
     place_name: str | None = DEFAULT_PLACE_NAME,
     latitude: float | None = DEFAULT_LATITUDE,
     longitude: float | None = DEFAULT_LONGITUDE,
-    date_start: int | None = DEFAULT_DATE_START,
-    date_end: int | None = DEFAULT_DATE_END,
+    date_start: date | None = DEFAULT_ENTITY_DATE_START,
+    date_end: date | None = DEFAULT_ENTITY_DATE_END,
+    date_precision: DatePrecision | None = DatePrecision.YEAR,
     status: StoryStatus = StoryStatus.PUBLISHED,
     visibility: StoryVisibility = StoryVisibility.PUBLIC,
     suffix: int | str | None = None,
 ) -> Story:
-    """Return a Story ORM object for direct insertion into a test DB session."""
+    """Return a Story ORM object for direct insertion into a test DB session.
+
+    date_start and date_end must be Python date objects matching the DATE
+    column type. Use year-precision stories as: date(1960, 1, 1) / date(1980, 12, 31).
+    The payload factories (make_story_payload) accept integers — that is correct
+    because StoryCreateRequest normalises them before writing to the DB.
+    """
     if suffix is not None:
         title = f"{title} {suffix}"
         if place_name is not None:
@@ -105,6 +121,7 @@ def make_story_entity(
         longitude=longitude,
         date_start=date_start,
         date_end=date_end,
+        date_precision=date_precision,
         status=status,
         visibility=visibility,
     )

--- a/backend/tests/unit/test_story_factory.py
+++ b/backend/tests/unit/test_story_factory.py
@@ -1,12 +1,15 @@
 import uuid
+from datetime import date
 
 import pytest
 
-from app.db.enums import StoryStatus, StoryVisibility
+from app.db.enums import DatePrecision, StoryStatus, StoryVisibility
 from app.db.story import Story
 from tests.factories.story_factory import (
     DEFAULT_DATE_END,
     DEFAULT_DATE_START,
+    DEFAULT_ENTITY_DATE_END,
+    DEFAULT_ENTITY_DATE_START,
     DEFAULT_LATITUDE,
     DEFAULT_LONGITUDE,
     DEFAULT_PLACE_NAME,
@@ -100,8 +103,17 @@ class TestMakeStoryEntity:
         assert story.place_name == DEFAULT_PLACE_NAME
         assert story.latitude == DEFAULT_LATITUDE
         assert story.longitude == DEFAULT_LONGITUDE
-        assert story.date_start == DEFAULT_DATE_START
-        assert story.date_end == DEFAULT_DATE_END
+        assert story.date_start == DEFAULT_ENTITY_DATE_START
+        assert story.date_end == DEFAULT_ENTITY_DATE_END
+
+    def test_default_dates_are_date_objects(self):
+        story = make_story_entity(user_id=uuid.uuid4())
+        assert isinstance(story.date_start, date)
+        assert isinstance(story.date_end, date)
+
+    def test_default_date_precision_is_year(self):
+        story = make_story_entity(user_id=uuid.uuid4())
+        assert story.date_precision == DatePrecision.YEAR
 
     def test_default_status_is_published_and_public(self):
         story = make_story_entity(user_id=uuid.uuid4())
@@ -122,14 +134,26 @@ class TestMakeStoryEntity:
             title="Override Title",
             status=StoryStatus.DRAFT,
             visibility=StoryVisibility.PRIVATE,
-            date_start=1970,
-            date_end=1975,
+            date_start=date(1970, 1, 1),
+            date_end=date(1975, 12, 31),
+            date_precision=DatePrecision.YEAR,
         )
         assert story.title == "Override Title"
         assert story.status == StoryStatus.DRAFT
         assert story.visibility == StoryVisibility.PRIVATE
-        assert story.date_start == 1970
-        assert story.date_end == 1975
+        assert story.date_start == date(1970, 1, 1)
+        assert story.date_end == date(1975, 12, 31)
+        assert story.date_precision == DatePrecision.YEAR
+
+    def test_exact_date_precision_accepted(self):
+        story = make_story_entity(
+            user_id=uuid.uuid4(),
+            date_start=date(1965, 6, 12),
+            date_end=date(1965, 6, 12),
+            date_precision=DatePrecision.DATE,
+        )
+        assert story.date_start == date(1965, 6, 12)
+        assert story.date_precision == DatePrecision.DATE
 
     def test_optional_fields_can_be_none(self):
         story = make_story_entity(
@@ -140,6 +164,7 @@ class TestMakeStoryEntity:
             longitude=None,
             date_start=None,
             date_end=None,
+            date_precision=None,
         )
         assert story.summary is None
         assert story.place_name is None
@@ -147,3 +172,4 @@ class TestMakeStoryEntity:
         assert story.longitude is None
         assert story.date_start is None
         assert story.date_end is None
+        assert story.date_precision is None


### PR DESCRIPTION
## Description

Migration `20260407_0003` converted `stories.date_start` and `stories.date_end` from `INTEGER` to `DATE` columns and added a `date_precision` field. The `make_story_entity` factory was not updated to match, which would cause a type error at DB commit time in any integration test that inserts a story directly via the ORM.

## Related Issue(s)
- Related to #106 (original factory PR)

## Changes

| File | Change |
|------|--------|
| `tests/factories/story_factory.py` | `make_story_entity` now accepts `date \| None` for `date_start`/`date_end` (was `int \| None`). Added `date_precision: DatePrecision \| None` parameter (default `YEAR`). Added `DEFAULT_ENTITY_DATE_START` / `DEFAULT_ENTITY_DATE_END` constants as `date` objects alongside the existing integer payload constants. |
| `tests/unit/test_story_factory.py` | `TestMakeStoryEntity` updated to assert `date` objects. Added `test_default_dates_are_date_objects`, `test_default_date_precision_is_year`, and `test_exact_date_precision_accepted`. |

## Why payload functions are unchanged

`make_story_payload` and `make_story_update_payload` intentionally still use **integers** — they produce dicts sent to the API via HTTP, and `StoryCreateRequest` (which inherits from `StoryDateInput`) accepts integer years and normalises them to `date` objects internally via `normalize_date_range()`. Changing them to `date` objects would break that flow.

## Checklist
- [x] All tests passed
- [x] I have self-reviewed my own code
- [ ] I have requested at least 1 reviewer