### PR TITLE
Add search page with backend API integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,9 +100,9 @@ jobs:
 
       - name: Run backend unit tests
         working-directory: backend
-        run: echo "pytest tests/unit/ -v"  # placeholder
-        # Covers: email/password validation, coordinate parsing, JWT helpers,
-        #         model constraints, file size checks
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/localhistory
+        run: pytest tests/unit/ -v
 
   frontend-unit:
     name: Frontend Unit Tests
@@ -119,8 +119,6 @@ jobs:
 
       - name: Run frontend unit tests
         run: echo "test"  # placeholder
-        # Covers: form validation components, date formatting, coordinate display,
-        #         isolated component rendering
 
   # ── 2. INTEGRATION TESTS ─────────────────────────────────────────────────────
 
@@ -128,6 +126,21 @@ jobs:
     name: Backend Integration Tests
     runs-on: ubuntu-latest
     needs: [backend-unit]
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: localhistory
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
       - name: Checkout code
@@ -144,10 +157,13 @@ jobs:
 
       - name: Run integration tests
         working-directory: backend
-        run: echo "pytest tests/integration/ -v"  # placeholder
-        # Covers: registration flow (API → service → DB), login + token issuance,
-        #         story creation with user FK, geospatial data retrieval,
-        #         permission enforcement at API boundary
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/localhistory
+          STORAGE_ENDPOINT: http://localhost:9000
+          STORAGE_ACCESS_KEY: minioadmin
+          STORAGE_SECRET_KEY: minioadmin
+          STORAGE_REGION: us-east-1
+        run: pytest tests/integration/ -v
 
   # ── 3. API TESTS ─────────────────────────────────────────────────────────────
 
@@ -155,6 +171,21 @@ jobs:
     name: Backend API Tests
     runs-on: ubuntu-latest
     needs: [backend-integration]
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: localhistory
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
       - name: Checkout code
@@ -171,11 +202,13 @@ jobs:
 
       - name: Run API tests
         working-directory: backend
-        run: echo "pytest tests/api/ -v"  # placeholder
-        # Covers: POST /auth/register, POST /auth/login, POST /stories,
-        #         GET /stories, GET /stories/{id}, GET /stories/search, GET /health
-        # Each endpoint tested for: success, error cases, invalid input,
-        #         missing/expired/valid auth tokens, status codes, response schema
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/localhistory
+          STORAGE_ENDPOINT: http://localhost:9000
+          STORAGE_ACCESS_KEY: minioadmin
+          STORAGE_SECRET_KEY: minioadmin
+          STORAGE_REGION: us-east-1
+        run: pytest tests/api/ -v
 
   # ── 4. E2E TESTS ─────────────────────────────────────────────────────────────
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,11 +19,110 @@ jobs:
           fi
 
       - name: Trigger Render Deploy
+        id: trigger
         run: |
-          curl -X POST "https://api.render.com/v1/services/${{ steps.set-service.outputs.SERVICE_ID }}/deploys" \
+          RESPONSE=$(curl -s -X POST "https://api.render.com/v1/services/${{ steps.set-service.outputs.SERVICE_ID }}/deploys" \
             -H "Authorization: Bearer ${{ secrets.RENDER_API_KEY }}" \
             -H "Content-Type: application/json" \
-            -d '{}'
+            -d '{}')
+
+          echo "Response: $RESPONSE"
+
+          DEPLOY_ID=$(echo "$RESPONSE" | jq -r '.id')
+          DEPLOY_STATUS=$(echo "$RESPONSE" | jq -r '.status')
+
+          if [[ "$DEPLOY_ID" == "null" || -z "$DEPLOY_ID" ]]; then
+            echo "::error::Failed to trigger deploy. Response: $RESPONSE"
+            exit 1
+          fi
+
+          echo "DEPLOY_ID=$DEPLOY_ID" >> $GITHUB_OUTPUT
+          echo "Deploy triggered: $DEPLOY_ID (status: $DEPLOY_STATUS)"
+
+      - name: Poll Deploy Status
+        id: poll
+        run: |
+          SERVICE_ID="${{ steps.set-service.outputs.SERVICE_ID }}"
+          DEPLOY_ID="${{ steps.trigger.outputs.DEPLOY_ID }}"
+          API_KEY="${{ secrets.RENDER_API_KEY }}"
+          MAX_ATTEMPTS=60   # 10 minutes max (60 * 10s)
+          ATTEMPT=0
+
+          while [[ $ATTEMPT -lt $MAX_ATTEMPTS ]]; do
+            RESPONSE=$(curl -s "https://api.render.com/v1/services/${SERVICE_ID}/deploys/${DEPLOY_ID}" \
+              -H "Authorization: Bearer ${API_KEY}")
+
+            STATUS=$(echo "$RESPONSE" | jq -r '.status')
+            UPDATED_AT=$(echo "$RESPONSE" | jq -r '.updatedAt')
+            FINISHED_AT=$(echo "$RESPONSE" | jq -r '.finishedAt')
+            COMMIT_MSG=$(echo "$RESPONSE" | jq -r '.commit.message // empty')
+
+            echo "[$(date -u +%H:%M:%S)] Status: $STATUS (attempt $((ATTEMPT+1))/$MAX_ATTEMPTS)"
+
+            case "$STATUS" in
+              live)
+                echo "FINAL_STATUS=success" >> $GITHUB_OUTPUT
+                echo "DEPLOY_STATUS=$STATUS" >> $GITHUB_OUTPUT
+                echo "FINISHED_AT=$FINISHED_AT" >> $GITHUB_OUTPUT
+                echo "COMMIT_MSG=$COMMIT_MSG" >> $GITHUB_OUTPUT
+                echo "::notice::Deploy succeeded!"
+                exit 0
+                ;;
+              build_failed|update_failed|pre_deploy_failed|canceled|deactivated)
+                echo "FINAL_STATUS=failure" >> $GITHUB_OUTPUT
+                echo "DEPLOY_STATUS=$STATUS" >> $GITHUB_OUTPUT
+                echo "FINISHED_AT=$FINISHED_AT" >> $GITHUB_OUTPUT
+                echo "COMMIT_MSG=$COMMIT_MSG" >> $GITHUB_OUTPUT
+                echo "::error::Deploy failed with status: $STATUS"
+                exit 1
+                ;;
+              created|build_in_progress|update_in_progress|pre_deploy_in_progress)
+                # Still in progress, keep polling
+                ;;
+              *)
+                echo "::warning::Unknown status: $STATUS"
+                ;;
+            esac
+
+            ATTEMPT=$((ATTEMPT + 1))
+            sleep 10
+          done
+
+          echo "FINAL_STATUS=timeout" >> $GITHUB_OUTPUT
+          echo "DEPLOY_STATUS=timeout" >> $GITHUB_OUTPUT
+          echo "::error::Deploy timed out after $((MAX_ATTEMPTS * 10)) seconds"
+          exit 1
+
+      - name: Write Job Summary
+        if: always()
+        run: |
+          DEPLOY_ID="${{ steps.trigger.outputs.DEPLOY_ID }}"
+          STATUS="${{ steps.poll.outputs.DEPLOY_STATUS }}"
+          FINISHED="${{ steps.poll.outputs.FINISHED_AT }}"
+          COMMIT="${{ steps.poll.outputs.COMMIT_MSG }}"
+          SERVICE_ID="${{ steps.set-service.outputs.SERVICE_ID }}"
+          BRANCH="${{ github.ref_name }}"
+
+          if [[ "$STATUS" == "live" ]]; then
+            STATUS_ICON="✅"
+          elif [[ "$STATUS" == "timeout" ]]; then
+            STATUS_ICON="⏱️"
+          else
+            STATUS_ICON="❌"
+          fi
+
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## ${STATUS_ICON} Backend Deployment — \`${BRANCH}\`
+
+          | Field | Value |
+          |-------|-------|
+          | **Status** | \`${STATUS}\` |
+          | **Deploy ID** | \`${DEPLOY_ID}\` |
+          | **Branch** | \`${BRANCH}\` |
+          | **Finished At** | ${FINISHED:-N/A} |
+          | **Commit** | ${COMMIT:-N/A} |
+          | **Dashboard** | [View on Render](https://dashboard.render.com/web/${SERVICE_ID}/deploys/${DEPLOY_ID}) |
+          EOF
 
   deploy-frontend:
     name: Deploy Frontend to Render

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,7 +64,11 @@ jobs:
                 echo "FINAL_STATUS=success" >> $GITHUB_OUTPUT
                 echo "DEPLOY_STATUS=$STATUS" >> $GITHUB_OUTPUT
                 echo "FINISHED_AT=$FINISHED_AT" >> $GITHUB_OUTPUT
-                echo "COMMIT_MSG=$COMMIT_MSG" >> $GITHUB_OUTPUT
+                {
+                  echo "COMMIT_MSG<<ENDOFMSG"
+                  echo "$COMMIT_MSG"
+                  echo "ENDOFMSG"
+                } >> $GITHUB_OUTPUT
                 echo "::notice::Deploy succeeded!"
                 exit 0
                 ;;
@@ -72,7 +76,11 @@ jobs:
                 echo "FINAL_STATUS=failure" >> $GITHUB_OUTPUT
                 echo "DEPLOY_STATUS=$STATUS" >> $GITHUB_OUTPUT
                 echo "FINISHED_AT=$FINISHED_AT" >> $GITHUB_OUTPUT
-                echo "COMMIT_MSG=$COMMIT_MSG" >> $GITHUB_OUTPUT
+                {
+                  echo "COMMIT_MSG<<ENDOFMSG"
+                  echo "$COMMIT_MSG"
+                  echo "ENDOFMSG"
+                } >> $GITHUB_OUTPUT
                 echo "::error::Deploy failed with status: $STATUS"
                 exit 1
                 ;;
@@ -131,4 +139,123 @@ jobs:
     steps:
       - name: Set Render Service ID
         id: set-service
-        run: echo 'PLACEHOLDER'  # Frontend deployment will be implemented here
+        run: |
+          if [[ "${{ github.ref_name }}" == "main" ]]; then
+            echo "SERVICE_ID=${{ secrets.FRONTEND_SERVICE_ID }}" >> $GITHUB_OUTPUT
+          else
+            echo "SERVICE_ID=${{ secrets.FRONTEND_SERVICE_ID_DEV }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Trigger Render Deploy
+        id: trigger
+        run: |
+          RESPONSE=$(curl -s -X POST "https://api.render.com/v1/services/${{ steps.set-service.outputs.SERVICE_ID }}/deploys" \
+            -H "Authorization: Bearer ${{ secrets.RENDER_API_KEY }}" \
+            -H "Content-Type: application/json" \
+            -d '{}')
+
+          echo "Response: $RESPONSE"
+
+          DEPLOY_ID=$(echo "$RESPONSE" | jq -r '.id')
+          DEPLOY_STATUS=$(echo "$RESPONSE" | jq -r '.status')
+
+          if [[ "$DEPLOY_ID" == "null" || -z "$DEPLOY_ID" ]]; then
+            echo "::error::Failed to trigger deploy. Response: $RESPONSE"
+            exit 1
+          fi
+
+          echo "DEPLOY_ID=$DEPLOY_ID" >> $GITHUB_OUTPUT
+          echo "Deploy triggered: $DEPLOY_ID (status: $DEPLOY_STATUS)"
+
+      - name: Poll Deploy Status
+        id: poll
+        run: |
+          SERVICE_ID="${{ steps.set-service.outputs.SERVICE_ID }}"
+          DEPLOY_ID="${{ steps.trigger.outputs.DEPLOY_ID }}"
+          API_KEY="${{ secrets.RENDER_API_KEY }}"
+          MAX_ATTEMPTS=60   # 10 minutes max (60 * 10s)
+          ATTEMPT=0
+
+          while [[ $ATTEMPT -lt $MAX_ATTEMPTS ]]; do
+            RESPONSE=$(curl -s "https://api.render.com/v1/services/${SERVICE_ID}/deploys/${DEPLOY_ID}" \
+              -H "Authorization: Bearer ${API_KEY}")
+
+            STATUS=$(echo "$RESPONSE" | jq -r '.status')
+            UPDATED_AT=$(echo "$RESPONSE" | jq -r '.updatedAt')
+            FINISHED_AT=$(echo "$RESPONSE" | jq -r '.finishedAt')
+            COMMIT_MSG=$(echo "$RESPONSE" | jq -r '.commit.message // empty')
+
+            echo "[$(date -u +%H:%M:%S)] Status: $STATUS (attempt $((ATTEMPT+1))/$MAX_ATTEMPTS)"
+
+            case "$STATUS" in
+              live)
+                echo "FINAL_STATUS=success" >> $GITHUB_OUTPUT
+                echo "DEPLOY_STATUS=$STATUS" >> $GITHUB_OUTPUT
+                echo "FINISHED_AT=$FINISHED_AT" >> $GITHUB_OUTPUT
+                {
+                  echo "COMMIT_MSG<<ENDOFMSG"
+                  echo "$COMMIT_MSG"
+                  echo "ENDOFMSG"
+                } >> $GITHUB_OUTPUT
+                echo "::notice::Deploy succeeded!"
+                exit 0
+                ;;
+              build_failed|update_failed|pre_deploy_failed|canceled|deactivated)
+                echo "FINAL_STATUS=failure" >> $GITHUB_OUTPUT
+                echo "DEPLOY_STATUS=$STATUS" >> $GITHUB_OUTPUT
+                echo "FINISHED_AT=$FINISHED_AT" >> $GITHUB_OUTPUT
+                {
+                  echo "COMMIT_MSG<<ENDOFMSG"
+                  echo "$COMMIT_MSG"
+                  echo "ENDOFMSG"
+                } >> $GITHUB_OUTPUT
+                echo "::error::Deploy failed with status: $STATUS"
+                exit 1
+                ;;
+              created|build_in_progress|update_in_progress|pre_deploy_in_progress)
+                # Still in progress, keep polling
+                ;;
+              *)
+                echo "::warning::Unknown status: $STATUS"
+                ;;
+            esac
+
+            ATTEMPT=$((ATTEMPT + 1))
+            sleep 10
+          done
+
+          echo "FINAL_STATUS=timeout" >> $GITHUB_OUTPUT
+          echo "DEPLOY_STATUS=timeout" >> $GITHUB_OUTPUT
+          echo "::error::Deploy timed out after $((MAX_ATTEMPTS * 10)) seconds"
+          exit 1
+
+      - name: Write Job Summary
+        if: always()
+        run: |
+          DEPLOY_ID="${{ steps.trigger.outputs.DEPLOY_ID }}"
+          STATUS="${{ steps.poll.outputs.DEPLOY_STATUS }}"
+          FINISHED="${{ steps.poll.outputs.FINISHED_AT }}"
+          COMMIT="${{ steps.poll.outputs.COMMIT_MSG }}"
+          SERVICE_ID="${{ steps.set-service.outputs.SERVICE_ID }}"
+          BRANCH="${{ github.ref_name }}"
+
+          if [[ "$STATUS" == "live" ]]; then
+            STATUS_ICON="✅"
+          elif [[ "$STATUS" == "timeout" ]]; then
+            STATUS_ICON="⏱️"
+          else
+            STATUS_ICON="❌"
+          fi
+
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## ${STATUS_ICON} Frontend Deployment — \`${BRANCH}\`
+
+          | Field | Value |
+          |-------|-------|
+          | **Status** | \`${STATUS}\` |
+          | **Deploy ID** | \`${DEPLOY_ID}\` |
+          | **Branch** | \`${BRANCH}\` |
+          | **Finished At** | ${FINISHED:-N/A} |
+          | **Commit** | ${COMMIT:-N/A} |
+          | **Dashboard** | [View on Render](https://dashboard.render.com/web/${SERVICE_ID}/deploys/${DEPLOY_ID}) |
+          EOF

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -23,3 +23,8 @@ STORAGE_PUBLIC_URL=http://localhost:9000
 STORAGE_BUCKET_IMAGES=images
 STORAGE_BUCKET_AUDIO=audio
 STORAGE_BUCKET_VIDEOS=videos
+
+# ── JWT ───────────────────────────────────────────────────────────────────────
+JWT_SECRET_KEY=your-secret-key  # Change this in production!
+JWT_ALGORITHM=HS256
+JWT_EXPIRE_MINUTES=30

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -25,6 +25,10 @@ STORAGE_BUCKET_AUDIO=audio
 STORAGE_BUCKET_VIDEOS=videos
 
 # ── JWT ───────────────────────────────────────────────────────────────────────
+# ── CORS ──────────────────────────────────────────────────────────────────
+# Comma-separated list of allowed origins
+CORS_ORIGINS=http://localhost:3000
+
 JWT_SECRET_KEY=your-secret-key  # Change this in production!
 JWT_ALGORITHM=HS256
 JWT_EXPIRE_MINUTES=30

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,4 +7,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["sh", "-c", "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000"]

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -8,6 +8,9 @@ from alembic import context
 
 from app.core.config import settings
 from app.db.base import Base  # noqa: F401 — import all models here so autogenerate sees them
+from app.db.media_file import MediaFile  # noqa: F401
+from app.db.story import Story  # noqa: F401
+from app.db.user import User  # noqa: F401
 
 config = context.config
 

--- a/backend/alembic/versions/20260402_0001_create_core_schema.py
+++ b/backend/alembic/versions/20260402_0001_create_core_schema.py
@@ -1,0 +1,185 @@
+"""Create initial user, story, and media file tables.
+
+Revision ID: 20260402_0001
+Revises:
+Create Date: 2026-04-02 00:01:00
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "20260402_0001"
+down_revision: Union[str, Sequence[str], None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+user_role_enum = sa.Enum(
+    "user",
+    "admin",
+    name="user_role",
+    native_enum=False,
+)
+story_status_enum = sa.Enum(
+    "draft",
+    "published",
+    "archived",
+    name="story_status",
+    native_enum=False,
+)
+story_visibility_enum = sa.Enum(
+    "private",
+    "public",
+    "unlisted",
+    name="story_visibility",
+    native_enum=False,
+)
+media_type_enum = sa.Enum(
+    "image",
+    "audio",
+    "video",
+    "document",
+    name="media_type",
+    native_enum=False,
+)
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "users",
+        sa.Column("username", sa.String(length=50), nullable=False),
+        sa.Column("email", sa.String(length=255), nullable=False),
+        sa.Column("password_hash", sa.String(length=255), nullable=False),
+        sa.Column("display_name", sa.String(length=100), nullable=True),
+        sa.Column("bio", sa.Text(), nullable=True),
+        sa.Column("role", user_role_enum, nullable=False, server_default=sa.text("'user'")),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("email", name="uq_users_email"),
+        sa.UniqueConstraint("username", name="uq_users_username"),
+    )
+
+    op.create_table(
+        "stories",
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+        sa.Column("title", sa.String(length=255), nullable=False),
+        sa.Column("summary", sa.Text(), nullable=True),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column(
+            "status",
+            story_status_enum,
+            nullable=False,
+            server_default=sa.text("'draft'"),
+        ),
+        sa.Column(
+            "visibility",
+            story_visibility_enum,
+            nullable=False,
+            server_default=sa.text("'private'"),
+        ),
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_stories_status", "stories", ["status"], unique=False)
+    op.create_index("ix_stories_user_id", "stories", ["user_id"], unique=False)
+    op.create_index("ix_stories_visibility", "stories", ["visibility"], unique=False)
+
+    op.create_table(
+        "media_files",
+        sa.Column(
+            "story_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+        sa.Column("bucket_name", sa.String(length=63), nullable=False),
+        sa.Column("storage_key", sa.String(length=512), nullable=False),
+        sa.Column("original_filename", sa.String(length=255), nullable=False),
+        sa.Column("mime_type", sa.String(length=255), nullable=False),
+        sa.Column("media_type", media_type_enum, nullable=False),
+        sa.Column("file_size_bytes", sa.BigInteger(), nullable=False),
+        sa.Column("sort_order", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("alt_text", sa.Text(), nullable=True),
+        sa.Column("caption", sa.Text(), nullable=True),
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.CheckConstraint(
+            "file_size_bytes >= 0",
+            name="ck_media_files_file_size_non_negative",
+        ),
+        sa.ForeignKeyConstraint(["story_id"], ["stories.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "bucket_name",
+            "storage_key",
+            name="uq_media_files_bucket_storage_key",
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table("media_files")
+    op.drop_index("ix_stories_visibility", table_name="stories")
+    op.drop_index("ix_stories_user_id", table_name="stories")
+    op.drop_index("ix_stories_status", table_name="stories")
+    op.drop_table("stories")
+    op.drop_table("users")

--- a/backend/alembic/versions/20260403_0002_add_location_and_date_to_stories.py
+++ b/backend/alembic/versions/20260403_0002_add_location_and_date_to_stories.py
@@ -1,0 +1,40 @@
+"""Add location and date range fields to stories table.
+
+Revision ID: 20260403_0002
+Revises: 20260402_0001
+Create Date: 2026-04-03 00:00:00
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "20260403_0002"
+down_revision: Union[str, Sequence[str], None] = "20260402_0001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("stories", sa.Column("place_name", sa.String(length=255), nullable=True))
+    op.add_column("stories", sa.Column("latitude", sa.Float(), nullable=True))
+    op.add_column("stories", sa.Column("longitude", sa.Float(), nullable=True))
+    op.add_column("stories", sa.Column("date_start", sa.Integer(), nullable=True))
+    op.add_column("stories", sa.Column("date_end", sa.Integer(), nullable=True))
+    op.create_check_constraint(
+        "ck_stories_date_range_valid",
+        "stories",
+        "date_end IS NULL OR date_start IS NULL OR date_end >= date_start",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_stories_date_range_valid", "stories", type_="check")
+    op.drop_column("stories", "date_end")
+    op.drop_column("stories", "date_start")
+    op.drop_column("stories", "longitude")
+    op.drop_column("stories", "latitude")
+    op.drop_column("stories", "place_name")

--- a/backend/alembic/versions/20260407_0003_convert_story_dates_to_date_range.py
+++ b/backend/alembic/versions/20260407_0003_convert_story_dates_to_date_range.py
@@ -21,6 +21,8 @@ depends_on: Union[str, Sequence[str], None] = None
 def upgrade() -> None:
     date_precision_enum = sa.Enum("year", "date", name="date_precision", native_enum=False)
 
+    op.drop_constraint("ck_stories_date_range_valid", "stories", type_="check")
+
     op.alter_column(
         "stories",
         "date_start",
@@ -34,6 +36,12 @@ def upgrade() -> None:
         type_=sa.Date(),
         postgresql_using="CASE WHEN date_end IS NULL THEN NULL ELSE make_date(date_end, 12, 31) END",
         existing_nullable=True,
+    )
+
+    op.create_check_constraint(
+        "ck_stories_date_range_valid",
+        "stories",
+        "date_end IS NULL OR date_start IS NULL OR date_end >= date_start",
     )
 
     op.add_column(
@@ -53,6 +61,8 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.drop_column("stories", "date_precision")
 
+    op.drop_constraint("ck_stories_date_range_valid", "stories", type_="check")
+
     op.alter_column(
         "stories",
         "date_start",
@@ -66,4 +76,10 @@ def downgrade() -> None:
         type_=sa.Integer(),
         postgresql_using="CASE WHEN date_end IS NULL THEN NULL ELSE EXTRACT(YEAR FROM date_end)::integer END",
         existing_nullable=True,
+    )
+
+    op.create_check_constraint(
+        "ck_stories_date_range_valid",
+        "stories",
+        "date_end IS NULL OR date_start IS NULL OR date_end >= date_start",
     )

--- a/backend/alembic/versions/20260407_0003_convert_story_dates_to_date_range.py
+++ b/backend/alembic/versions/20260407_0003_convert_story_dates_to_date_range.py
@@ -1,0 +1,69 @@
+"""Convert story date fields to DATE range and add precision metadata.
+
+Revision ID: 20260407_0003
+Revises: 20260403_0002
+Create Date: 2026-04-07 00:00:00
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "20260407_0003"
+down_revision: Union[str, Sequence[str], None] = "20260403_0002"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    date_precision_enum = sa.Enum("year", "date", name="date_precision", native_enum=False)
+
+    op.alter_column(
+        "stories",
+        "date_start",
+        type_=sa.Date(),
+        postgresql_using="CASE WHEN date_start IS NULL THEN NULL ELSE make_date(date_start, 1, 1) END",
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "stories",
+        "date_end",
+        type_=sa.Date(),
+        postgresql_using="CASE WHEN date_end IS NULL THEN NULL ELSE make_date(date_end, 12, 31) END",
+        existing_nullable=True,
+    )
+
+    op.add_column(
+        "stories",
+        sa.Column("date_precision", date_precision_enum, nullable=True),
+    )
+
+    op.execute(
+        """
+        UPDATE stories
+        SET date_precision = 'year'
+        WHERE date_start IS NOT NULL OR date_end IS NOT NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("stories", "date_precision")
+
+    op.alter_column(
+        "stories",
+        "date_start",
+        type_=sa.Integer(),
+        postgresql_using="CASE WHEN date_start IS NULL THEN NULL ELSE EXTRACT(YEAR FROM date_start)::integer END",
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "stories",
+        "date_end",
+        type_=sa.Integer(),
+        postgresql_using="CASE WHEN date_end IS NULL THEN NULL ELSE EXTRACT(YEAR FROM date_end)::integer END",
+        existing_nullable=True,
+    )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -7,6 +7,10 @@ class Settings(BaseSettings):
     # Set to "true" in .env to write every SQL query to logs/sql.log
     LOG_SQL: bool = False
 
+    # ── CORS ──────────────────────────────────────────────────────────────────
+    # Comma-separated list of allowed origins
+    CORS_ORIGINS: str = "http://localhost:3000"
+
     # ── JWT ───────────────────────────────────────────────────────────────────
     JWT_SECRET_KEY: str = "your-secret-key"  # Change this in production!
     JWT_ALGORITHM: str = "HS256"

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -7,6 +7,11 @@ class Settings(BaseSettings):
     # Set to "true" in .env to write every SQL query to logs/sql.log
     LOG_SQL: bool = False
 
+    # ── JWT ───────────────────────────────────────────────────────────────────
+    JWT_SECRET_KEY: str = "your-secret-key"  # Change this in production!
+    JWT_ALGORITHM: str = "HS256"
+    JWT_EXPIRE_MINUTES: int = 30
+
     # ── Object Storage (S3-compatible) ────────────────────────────────────────
     # Local: points at MinIO.  Production: points at Supabase Storage S3 endpoint.
     STORAGE_ENDPOINT: str = "http://localhost:9000"

--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -1,0 +1,54 @@
+import uuid
+
+import jwt
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.db.session import get_db
+from app.db.user import User
+
+security = HTTPBearer()
+
+
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+    db: AsyncSession = Depends(get_db),
+) -> User:
+    token = credentials.credentials
+    try:
+        payload = jwt.decode(
+            token,
+            settings.JWT_SECRET_KEY,
+            algorithms=[settings.JWT_ALGORITHM],
+        )
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token has expired",
+        )
+    except jwt.InvalidTokenError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token",
+        )
+
+    user_id = payload.get("sub")
+    if user_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token payload",
+        )
+
+    result = await db.execute(select(User).where(User.id == uuid.UUID(user_id)))
+    user = result.scalar_one_or_none()
+
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="User not found",
+        )
+
+    return user

--- a/backend/app/db/README.md
+++ b/backend/app/db/README.md
@@ -1,0 +1,22 @@
+# Database Models
+
+SQLAlchemy table models live in this package.
+
+## Implemented schema
+
+- `users`: authentication and profile fields
+- `stories`: story content plus publication metadata
+- `media_files`: object-storage-backed media linked to stories
+
+## Design notes
+
+- All primary keys use UUIDs so rows can be created safely across environments.
+- `created_at` and `updated_at` are included on every table for auditability.
+- `users.username` and `users.email` are unique.
+- `users.password_hash` stores only a hash, never a raw password.
+- `users.role` and `users.is_active` are included now so auth and authorization can grow without reshaping the table immediately.
+- `stories` belongs to `users` through `user_id`.
+- `stories.status` and `stories.visibility` are explicit enums so draft/publication flow can evolve cleanly.
+- `media_files` belongs to `stories` through `story_id`.
+- `media_files` stores storage location as `bucket_name + storage_key`, which keeps the schema compatible with MinIO locally and S3-compatible storage in production.
+- `media_files.alt_text` and `media_files.caption` are optional initial metadata fields for accessibility and presentation.

--- a/backend/app/db/__init__.py
+++ b/backend/app/db/__init__.py
@@ -1,0 +1,6 @@
+from app.db.base import Base
+from app.db.media_file import MediaFile
+from app.db.story import Story
+from app.db.user import User
+
+__all__ = ["Base", "MediaFile", "Story", "User"]

--- a/backend/app/db/enums.py
+++ b/backend/app/db/enums.py
@@ -23,3 +23,8 @@ class MediaType(str, Enum):
     AUDIO = "audio"
     VIDEO = "video"
     DOCUMENT = "document"
+
+
+class DatePrecision(str, Enum):
+    YEAR = "year"
+    DATE = "date"

--- a/backend/app/db/enums.py
+++ b/backend/app/db/enums.py
@@ -1,0 +1,25 @@
+from enum import Enum
+
+
+class UserRole(str, Enum):
+    USER = "user"
+    ADMIN = "admin"
+
+
+class StoryStatus(str, Enum):
+    DRAFT = "draft"
+    PUBLISHED = "published"
+    ARCHIVED = "archived"
+
+
+class StoryVisibility(str, Enum):
+    PRIVATE = "private"
+    PUBLIC = "public"
+    UNLISTED = "unlisted"
+
+
+class MediaType(str, Enum):
+    IMAGE = "image"
+    AUDIO = "audio"
+    VIDEO = "video"
+    DOCUMENT = "document"

--- a/backend/app/db/media_file.py
+++ b/backend/app/db/media_file.py
@@ -1,0 +1,63 @@
+import uuid
+from typing import TYPE_CHECKING
+
+from sqlalchemy import (
+    BigInteger,
+    CheckConstraint,
+    Enum,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    text,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+from app.db.enums import MediaType
+from app.db.mixins import TimestampMixin, UUIDPrimaryKeyMixin
+
+if TYPE_CHECKING:
+    from app.db.story import Story
+
+
+class MediaFile(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "media_files"
+    __table_args__ = (
+        UniqueConstraint(
+            "bucket_name",
+            "storage_key",
+            name="uq_media_files_bucket_storage_key",
+        ),
+        CheckConstraint(
+            "file_size_bytes >= 0",
+            name="ck_media_files_file_size_non_negative",
+        ),
+    )
+
+    story_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("stories.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    bucket_name: Mapped[str] = mapped_column(String(63), nullable=False)
+    storage_key: Mapped[str] = mapped_column(String(512), nullable=False)
+    original_filename: Mapped[str] = mapped_column(String(255), nullable=False)
+    mime_type: Mapped[str] = mapped_column(String(255), nullable=False)
+    media_type: Mapped[MediaType] = mapped_column(
+        Enum(MediaType, name="media_type", native_enum=False),
+        nullable=False,
+    )
+    file_size_bytes: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    sort_order: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=0,
+        server_default=text("0"),
+    )
+    alt_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    caption: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    story: Mapped["Story"] = relationship(back_populates="media_files")

--- a/backend/app/db/mixins.py
+++ b/backend/app/db/mixins.py
@@ -1,0 +1,28 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+
+class UUIDPrimaryKeyMixin:
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+
+
+class TimestampMixin:
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )

--- a/backend/app/db/story.py
+++ b/backend/app/db/story.py
@@ -1,12 +1,13 @@
 import uuid
+from datetime import date
 from typing import TYPE_CHECKING
 
-from sqlalchemy import CheckConstraint, Enum, Float, ForeignKey, Index, Integer, String, Text, text
+from sqlalchemy import CheckConstraint, Date, Enum, Float, ForeignKey, Index, String, Text, text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db.base import Base
-from app.db.enums import StoryStatus, StoryVisibility
+from app.db.enums import DatePrecision, StoryStatus, StoryVisibility
 from app.db.mixins import TimestampMixin, UUIDPrimaryKeyMixin
 
 if TYPE_CHECKING:
@@ -50,8 +51,12 @@ class Story(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     place_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
     latitude: Mapped[float | None] = mapped_column(Float, nullable=True)
     longitude: Mapped[float | None] = mapped_column(Float, nullable=True)
-    date_start: Mapped[int | None] = mapped_column(Integer, nullable=True)
-    date_end: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    date_start: Mapped[date | None] = mapped_column(Date, nullable=True)
+    date_end: Mapped[date | None] = mapped_column(Date, nullable=True)
+    date_precision: Mapped[DatePrecision | None] = mapped_column(
+        Enum(DatePrecision, name="date_precision", native_enum=False),
+        nullable=True,
+    )
 
     user: Mapped["User"] = relationship(back_populates="stories")
     media_files: Mapped[list["MediaFile"]] = relationship(

--- a/backend/app/db/story.py
+++ b/backend/app/db/story.py
@@ -1,0 +1,50 @@
+import uuid
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Enum, ForeignKey, Index, String, Text, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+from app.db.enums import StoryStatus, StoryVisibility
+from app.db.mixins import TimestampMixin, UUIDPrimaryKeyMixin
+
+if TYPE_CHECKING:
+    from app.db.media_file import MediaFile
+    from app.db.user import User
+
+
+class Story(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "stories"
+    __table_args__ = (
+        Index("ix_stories_user_id", "user_id"),
+        Index("ix_stories_status", "status"),
+        Index("ix_stories_visibility", "visibility"),
+    )
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    summary: Mapped[str | None] = mapped_column(Text, nullable=True)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[StoryStatus] = mapped_column(
+        Enum(StoryStatus, name="story_status", native_enum=False),
+        nullable=False,
+        default=StoryStatus.DRAFT,
+        server_default=text("'draft'"),
+    )
+    visibility: Mapped[StoryVisibility] = mapped_column(
+        Enum(StoryVisibility, name="story_visibility", native_enum=False),
+        nullable=False,
+        default=StoryVisibility.PRIVATE,
+        server_default=text("'private'"),
+    )
+
+    user: Mapped["User"] = relationship(back_populates="stories")
+    media_files: Mapped[list["MediaFile"]] = relationship(
+        back_populates="story",
+        cascade="all, delete-orphan",
+    )

--- a/backend/app/db/story.py
+++ b/backend/app/db/story.py
@@ -1,7 +1,7 @@
 import uuid
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Enum, ForeignKey, Index, String, Text, text
+from sqlalchemy import CheckConstraint, Enum, Float, ForeignKey, Index, Integer, String, Text, text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -20,6 +20,10 @@ class Story(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         Index("ix_stories_user_id", "user_id"),
         Index("ix_stories_status", "status"),
         Index("ix_stories_visibility", "visibility"),
+        CheckConstraint(
+            "date_end IS NULL OR date_start IS NULL OR date_end >= date_start",
+            name="ck_stories_date_range_valid",
+        ),
     )
 
     user_id: Mapped[uuid.UUID] = mapped_column(
@@ -42,6 +46,12 @@ class Story(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         default=StoryVisibility.PRIVATE,
         server_default=text("'private'"),
     )
+
+    place_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    latitude: Mapped[float | None] = mapped_column(Float, nullable=True)
+    longitude: Mapped[float | None] = mapped_column(Float, nullable=True)
+    date_start: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    date_end: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
     user: Mapped["User"] = relationship(back_populates="stories")
     media_files: Mapped[list["MediaFile"]] = relationship(

--- a/backend/app/db/user.py
+++ b/backend/app/db/user.py
@@ -1,0 +1,42 @@
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Boolean, Enum, String, Text, UniqueConstraint, text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+from app.db.enums import UserRole
+from app.db.mixins import TimestampMixin, UUIDPrimaryKeyMixin
+
+if TYPE_CHECKING:
+    from app.db.story import Story
+
+
+class User(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "users"
+    __table_args__ = (
+        UniqueConstraint("username", name="uq_users_username"),
+        UniqueConstraint("email", name="uq_users_email"),
+    )
+
+    username: Mapped[str] = mapped_column(String(50), nullable=False)
+    email: Mapped[str] = mapped_column(String(255), nullable=False)
+    password_hash: Mapped[str] = mapped_column(String(255), nullable=False)
+    display_name: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    bio: Mapped[str | None] = mapped_column(Text, nullable=True)
+    role: Mapped[UserRole] = mapped_column(
+        Enum(UserRole, name="user_role", native_enum=False),
+        nullable=False,
+        default=UserRole.USER,
+        server_default=text("'user'"),
+    )
+    is_active: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=True,
+        server_default=text("true"),
+    )
+
+    stories: Mapped[list["Story"]] = relationship(
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI
 from sqlalchemy import text
 
 from app.db.session import engine
+from app.routers.auth import router as auth_router
 from app.services.storage import check_connection
 
 
@@ -20,6 +21,7 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(lifespan=lifespan)
+app.include_router(auth_router)
 
 
 @app.get("/")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,7 @@ from sqlalchemy import text
 
 from app.db.session import engine
 from app.routers.auth import router as auth_router
+from app.routers.story import router as story_router
 from app.services.storage import check_connection
 
 
@@ -22,6 +23,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(lifespan=lifespan)
 app.include_router(auth_router)
+app.include_router(story_router)
 
 
 @app.get("/")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,8 +1,10 @@
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy import text
 
+from app.core.config import settings
 from app.db.session import engine
 from app.routers.auth import router as auth_router
 from app.services.storage import check_connection
@@ -21,6 +23,13 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(lifespan=lifespan)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[o.strip() for o in settings.CORS_ORIGINS.split(",")],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 app.include_router(auth_router)
 
 

--- a/backend/app/models/story.py
+++ b/backend/app/models/story.py
@@ -24,6 +24,24 @@ class StoryCreateRequest(BaseModel):
         return self
 
 
+class StoryUpdateRequest(BaseModel):
+    title: str = Field(min_length=1, max_length=255)
+    content: str = Field(min_length=1)
+    summary: str | None = None
+    latitude: float = Field(ge=-90.0, le=90.0)
+    longitude: float = Field(ge=-180.0, le=180.0)
+    place_name: str | None = Field(default=None, max_length=255)
+    date_start: int | None = Field(default=None, ge=1, le=9999)
+    date_end: int | None = Field(default=None, ge=1, le=9999)
+
+    @model_validator(mode="after")
+    def check_date_range(self) -> "StoryUpdateRequest":
+        if self.date_start is not None and self.date_end is not None:
+            if self.date_end < self.date_start:
+                raise ValueError("date_end must be greater than or equal to date_start")
+        return self
+
+
 class StoryResponse(BaseModel):
     id: uuid.UUID
     title: str

--- a/backend/app/models/story.py
+++ b/backend/app/models/story.py
@@ -1,65 +1,96 @@
 import uuid
-from datetime import datetime
+from datetime import date, datetime
+from typing import Self
 
 from pydantic import BaseModel, Field, model_validator
 
-from app.db.enums import MediaType, StoryStatus, StoryVisibility
+from app.db.enums import DatePrecision, MediaType, StoryStatus, StoryVisibility
 
 
-class StoryCreateRequest(BaseModel):
+class StoryDateInput(BaseModel):
+    date_start: int | date | None = Field(
+        default=None,
+        description="Start value. Either year (e.g. 1453) or ISO date (YYYY-MM-DD).",
+    )
+    date_end: int | date | None = Field(
+        default=None,
+        description="End value. Must match date_start type when provided.",
+    )
+    date_precision: DatePrecision | None = Field(
+        default=None,
+        description="Optional precision hint: 'year' or 'date'. Inferred from input type when omitted.",
+    )
+
+    @model_validator(mode="after")
+    def check_date_input(self) -> Self:
+        if self.date_start is None and self.date_end is None:
+            if self.date_precision is not None:
+                raise ValueError("date_precision requires date_start/date_end")
+            return self
+
+        if self.date_start is None and self.date_end is not None:
+            raise ValueError("date_start is required when date_end is provided")
+
+        if isinstance(self.date_start, int):
+            if not 1 <= self.date_start <= 9999:
+                raise ValueError("year input must be in range 1..9999")
+
+            if self.date_end is not None and not isinstance(self.date_end, int):
+                raise ValueError("date_start and date_end must use the same type")
+
+            if isinstance(self.date_end, int):
+                if not 1 <= self.date_end <= 9999:
+                    raise ValueError("year input must be in range 1..9999")
+                if self.date_end < self.date_start:
+                    raise ValueError("date_end must be greater than or equal to date_start")
+
+            if self.date_precision not in (None, DatePrecision.YEAR):
+                raise ValueError("date_precision must be 'year' for year inputs")
+            return self
+
+        if self.date_end is not None and not isinstance(self.date_end, date):
+            raise ValueError("date_start and date_end must use the same type")
+
+        if isinstance(self.date_end, date) and self.date_end < self.date_start:
+            raise ValueError("date_end must be greater than or equal to date_start")
+
+        if self.date_precision not in (None, DatePrecision.DATE):
+            raise ValueError("date_precision must be 'date' for date inputs")
+
+        return self
+
+    def normalize_date_range(self) -> tuple[date | None, date | None, DatePrecision | None]:
+        if self.date_start is None:
+            return None, None, None
+
+        if isinstance(self.date_start, int):
+            end_year = self.date_end if isinstance(self.date_end, int) else self.date_start
+            return (
+                date(self.date_start, 1, 1),
+                date(end_year, 12, 31),
+                DatePrecision.YEAR,
+            )
+
+        end_date = self.date_end if isinstance(self.date_end, date) else self.date_start
+        return self.date_start, end_date, DatePrecision.DATE
+
+
+class StoryCreateRequest(StoryDateInput):
     title: str = Field(min_length=1, max_length=255)
     content: str = Field(min_length=1)
     summary: str | None = None
     latitude: float = Field(ge=-90.0, le=90.0)
     longitude: float = Field(ge=-180.0, le=180.0)
     place_name: str | None = Field(default=None, max_length=255)
-    date_start: int | None = Field(
-        default=None,
-        ge=1,
-        le=9999,
-        description="Optional historical start year (1..9999)",
-    )
-    date_end: int | None = Field(
-        default=None,
-        ge=1,
-        le=9999,
-        description="Optional historical end year (1..9999); must be >= date_start when both are provided",
-    )
-
-    @model_validator(mode="after")
-    def check_date_range(self) -> "StoryCreateRequest":
-        if self.date_start is not None and self.date_end is not None:
-            if self.date_end < self.date_start:
-                raise ValueError("date_end must be greater than or equal to date_start")
-        return self
 
 
-class StoryUpdateRequest(BaseModel):
+class StoryUpdateRequest(StoryDateInput):
     title: str = Field(min_length=1, max_length=255)
     content: str = Field(min_length=1)
     summary: str | None = None
     latitude: float = Field(ge=-90.0, le=90.0)
     longitude: float = Field(ge=-180.0, le=180.0)
     place_name: str | None = Field(default=None, max_length=255)
-    date_start: int | None = Field(
-        default=None,
-        ge=1,
-        le=9999,
-        description="Optional historical start year (1..9999)",
-    )
-    date_end: int | None = Field(
-        default=None,
-        ge=1,
-        le=9999,
-        description="Optional historical end year (1..9999); must be >= date_start when both are provided",
-    )
-
-    @model_validator(mode="after")
-    def check_date_range(self) -> "StoryUpdateRequest":
-        if self.date_start is not None and self.date_end is not None:
-            if self.date_end < self.date_start:
-                raise ValueError("date_end must be greater than or equal to date_start")
-        return self
 
 
 class StoryBoundsFilter(BaseModel):
@@ -96,8 +127,9 @@ class StoryResponse(BaseModel):
     place_name: str | None
     latitude: float | None
     longitude: float | None
-    date_start: int | None
-    date_end: int | None
+    date_start: date | None
+    date_end: date | None
+    date_precision: DatePrecision | None
     date_label: str | None
     status: StoryStatus
     visibility: StoryVisibility
@@ -109,11 +141,24 @@ class StoryResponse(BaseModel):
     def from_orm_with_author(cls, story: object, author_username: str) -> "StoryResponse":
         date_start = getattr(story, "date_start", None)
         date_end = getattr(story, "date_end", None)
+        date_precision = getattr(story, "date_precision", None)
 
-        if date_start and date_end:
-            date_label = f"{date_start} - {date_end}"
+        if date_start and date_end and date_precision == DatePrecision.YEAR:
+            if date_start.year == date_end.year:
+                date_label = str(date_start.year)
+            else:
+                date_label = f"{date_start.year} - {date_end.year}"
+        elif date_start and date_end:
+            if date_start == date_end:
+                date_label = date_start.isoformat()
+            else:
+                date_label = f"{date_start.isoformat()} - {date_end.isoformat()}"
         elif date_start:
-            date_label = str(date_start)
+            date_label = (
+                str(date_start.year)
+                if date_precision == DatePrecision.YEAR
+                else date_start.isoformat()
+            )
         else:
             date_label = None
 
@@ -128,6 +173,7 @@ class StoryResponse(BaseModel):
             longitude=story.longitude,
             date_start=date_start,
             date_end=date_end,
+            date_precision=date_precision,
             date_label=date_label,
             status=story.status,
             visibility=story.visibility,

--- a/backend/app/models/story.py
+++ b/backend/app/models/story.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field, model_validator
 
-from app.db.enums import StoryStatus, StoryVisibility
+from app.db.enums import MediaType, StoryStatus, StoryVisibility
 
 
 class StoryCreateRequest(BaseModel):
@@ -75,3 +75,31 @@ class StoryResponse(BaseModel):
 class StoryListResponse(BaseModel):
     stories: list[StoryResponse]
     total: int
+
+
+class MediaUploadRequest(BaseModel):
+    media_type: MediaType
+    alt_text: str | None = Field(default=None, max_length=500)
+    caption: str | None = Field(default=None, max_length=500)
+    sort_order: int = Field(default=0, ge=0)
+
+
+class MediaFileResponse(BaseModel):
+    id: uuid.UUID
+    story_id: uuid.UUID
+    bucket_name: str
+    storage_key: str
+    original_filename: str
+    mime_type: str
+    media_type: MediaType
+    file_size_bytes: int
+    sort_order: int
+    alt_text: str | None
+    caption: str | None
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class MediaUploadResponse(BaseModel):
+    media: MediaFileResponse

--- a/backend/app/models/story.py
+++ b/backend/app/models/story.py
@@ -62,6 +62,31 @@ class StoryUpdateRequest(BaseModel):
         return self
 
 
+class StoryBoundsFilter(BaseModel):
+    min_lat: float | None = Field(default=None, ge=-90.0, le=90.0)
+    max_lat: float | None = Field(default=None, ge=-90.0, le=90.0)
+    min_lng: float | None = Field(default=None, ge=-180.0, le=180.0)
+    max_lng: float | None = Field(default=None, ge=-180.0, le=180.0)
+
+    @model_validator(mode="after")
+    def check_bounds(self) -> "StoryBoundsFilter":
+        values = [self.min_lat, self.max_lat, self.min_lng, self.max_lng]
+        provided_count = sum(v is not None for v in values)
+
+        if provided_count not in (0, 4):
+            raise ValueError(
+                "min_lat, max_lat, min_lng, max_lng must be provided together"
+            )
+
+        if provided_count == 4:
+            if self.min_lat > self.max_lat:
+                raise ValueError("min_lat must be less than or equal to max_lat")
+            if self.min_lng > self.max_lng:
+                raise ValueError("min_lng must be less than or equal to max_lng")
+
+        return self
+
+
 class StoryResponse(BaseModel):
     id: uuid.UUID
     title: str

--- a/backend/app/models/story.py
+++ b/backend/app/models/story.py
@@ -1,0 +1,77 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, Field, model_validator
+
+from app.db.enums import StoryStatus, StoryVisibility
+
+
+class StoryCreateRequest(BaseModel):
+    title: str = Field(min_length=1, max_length=255)
+    content: str = Field(min_length=1)
+    summary: str | None = None
+    latitude: float = Field(ge=-90.0, le=90.0)
+    longitude: float = Field(ge=-180.0, le=180.0)
+    place_name: str | None = Field(default=None, max_length=255)
+    date_start: int | None = Field(default=None, ge=1, le=9999)
+    date_end: int | None = Field(default=None, ge=1, le=9999)
+
+    @model_validator(mode="after")
+    def check_date_range(self) -> "StoryCreateRequest":
+        if self.date_start is not None and self.date_end is not None:
+            if self.date_end < self.date_start:
+                raise ValueError("date_end must be greater than or equal to date_start")
+        return self
+
+
+class StoryResponse(BaseModel):
+    id: uuid.UUID
+    title: str
+    summary: str | None
+    content: str
+    author: str
+    place_name: str | None
+    latitude: float | None
+    longitude: float | None
+    date_start: int | None
+    date_end: int | None
+    date_label: str | None
+    status: StoryStatus
+    visibility: StoryVisibility
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+    @classmethod
+    def from_orm_with_author(cls, story: object, author_username: str) -> "StoryResponse":
+        date_start = getattr(story, "date_start", None)
+        date_end = getattr(story, "date_end", None)
+
+        if date_start and date_end:
+            date_label = f"{date_start} - {date_end}"
+        elif date_start:
+            date_label = str(date_start)
+        else:
+            date_label = None
+
+        return cls(
+            id=story.id,
+            title=story.title,
+            summary=story.summary,
+            content=story.content,
+            author=author_username,
+            place_name=story.place_name,
+            latitude=story.latitude,
+            longitude=story.longitude,
+            date_start=date_start,
+            date_end=date_end,
+            date_label=date_label,
+            status=story.status,
+            visibility=story.visibility,
+            created_at=story.created_at,
+        )
+
+
+class StoryListResponse(BaseModel):
+    stories: list[StoryResponse]
+    total: int

--- a/backend/app/models/story.py
+++ b/backend/app/models/story.py
@@ -127,6 +127,7 @@ class MediaFileResponse(BaseModel):
     story_id: uuid.UUID
     bucket_name: str
     storage_key: str
+    media_url: str
     original_filename: str
     mime_type: str
     media_type: MediaType

--- a/backend/app/models/story.py
+++ b/backend/app/models/story.py
@@ -152,6 +152,7 @@ class MediaFileResponse(BaseModel):
     story_id: uuid.UUID
     bucket_name: str
     storage_key: str
+    media_url: str
     original_filename: str
     mime_type: str
     media_type: MediaType

--- a/backend/app/models/story.py
+++ b/backend/app/models/story.py
@@ -152,7 +152,6 @@ class MediaFileResponse(BaseModel):
     story_id: uuid.UUID
     bucket_name: str
     storage_key: str
-    media_url: str
     original_filename: str
     mime_type: str
     media_type: MediaType

--- a/backend/app/models/story.py
+++ b/backend/app/models/story.py
@@ -13,8 +13,18 @@ class StoryCreateRequest(BaseModel):
     latitude: float = Field(ge=-90.0, le=90.0)
     longitude: float = Field(ge=-180.0, le=180.0)
     place_name: str | None = Field(default=None, max_length=255)
-    date_start: int | None = Field(default=None, ge=1, le=9999)
-    date_end: int | None = Field(default=None, ge=1, le=9999)
+    date_start: int | None = Field(
+        default=None,
+        ge=1,
+        le=9999,
+        description="Optional historical start year (1..9999)",
+    )
+    date_end: int | None = Field(
+        default=None,
+        ge=1,
+        le=9999,
+        description="Optional historical end year (1..9999); must be >= date_start when both are provided",
+    )
 
     @model_validator(mode="after")
     def check_date_range(self) -> "StoryCreateRequest":
@@ -31,8 +41,18 @@ class StoryUpdateRequest(BaseModel):
     latitude: float = Field(ge=-90.0, le=90.0)
     longitude: float = Field(ge=-180.0, le=180.0)
     place_name: str | None = Field(default=None, max_length=255)
-    date_start: int | None = Field(default=None, ge=1, le=9999)
-    date_end: int | None = Field(default=None, ge=1, le=9999)
+    date_start: int | None = Field(
+        default=None,
+        ge=1,
+        le=9999,
+        description="Optional historical start year (1..9999)",
+    )
+    date_end: int | None = Field(
+        default=None,
+        ge=1,
+        le=9999,
+        description="Optional historical end year (1..9999); must be >= date_start when both are provided",
+    )
 
     @model_validator(mode="after")
     def check_date_range(self) -> "StoryUpdateRequest":

--- a/backend/app/models/story.py
+++ b/backend/app/models/story.py
@@ -118,6 +118,19 @@ class StoryBoundsFilter(BaseModel):
         return self
 
 
+class StoryDateRangeFilter(BaseModel):
+    query_start: int | date | None = Field(default=None)
+    query_end: int | date | None = Field(default=None)
+    query_precision: DatePrecision | None = Field(default=None)
+
+    def normalize_query_range(self) -> tuple[date | None, date | None, DatePrecision | None]:
+        return StoryDateInput(
+            date_start=self.query_start,
+            date_end=self.query_end,
+            date_precision=self.query_precision,
+        ).normalize_date_range()
+
+
 class StoryResponse(BaseModel):
     id: uuid.UUID
     title: str

--- a/backend/app/models/story.py
+++ b/backend/app/models/story.py
@@ -103,3 +103,7 @@ class MediaFileResponse(BaseModel):
 
 class MediaUploadResponse(BaseModel):
     media: MediaFileResponse
+
+
+class StoryDetailResponse(StoryResponse):
+    media_files: list[MediaFileResponse] = Field(default_factory=list)

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import BaseModel, EmailStr, Field, field_validator
 
 from app.db.enums import UserRole
 
@@ -12,10 +12,29 @@ class UserRegisterRequest(BaseModel):
     password: str = Field(min_length=8)
     display_name: str | None = Field(default=None, max_length=100)
 
+    @field_validator("password")
+    @classmethod
+    def validate_password_strength(cls, v: str) -> str:
+        errors = []
+        if not any(c.isupper() for c in v):
+            errors.append("one uppercase letter")
+        if not any(c.islower() for c in v):
+            errors.append("one lowercase letter")
+        if not any(c.isdigit() for c in v):
+            errors.append("one digit")
+        if not any(c in "!@#$%^&*()-_=+[]{}|;:',.<>?/`~" for c in v):
+            errors.append("one special character")
+        if errors:
+            raise ValueError(
+                "Password must contain at least: " + ", ".join(errors)
+            )
+        return v
+
 
 class UserLoginRequest(BaseModel):
     email: EmailStr
     password: str
+
 
 
 class UserResponse(BaseModel):
@@ -32,3 +51,4 @@ class UserResponse(BaseModel):
 class TokenResponse(BaseModel):
     access_token: str
     token_type: str = "bearer"
+

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,0 +1,34 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, EmailStr, Field
+
+from app.db.enums import UserRole
+
+
+class UserRegisterRequest(BaseModel):
+    username: str = Field(min_length=3, max_length=50)
+    email: EmailStr
+    password: str = Field(min_length=8)
+    display_name: str | None = Field(default=None, max_length=100)
+
+
+class UserLoginRequest(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class UserResponse(BaseModel):
+    id: uuid.UUID
+    username: str
+    email: str
+    display_name: str | None
+    role: UserRole
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class TokenResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,9 +1,11 @@
 from fastapi import APIRouter, Depends, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.deps import get_current_user
 from app.db.session import get_db
-from app.models.user import UserRegisterRequest, UserResponse
-from app.services.auth_service import register_user
+from app.db.user import User
+from app.models.user import TokenResponse, UserLoginRequest, UserRegisterRequest, UserResponse
+from app.services.auth_service import login_user, register_user
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
@@ -22,3 +24,28 @@ async def register(
     db: AsyncSession = Depends(get_db),
 ):
     return await register_user(db, payload)
+
+
+@router.post(
+    "/login",
+    response_model=TokenResponse,
+    responses={
+        401: {"description": "Invalid email or password"},
+    },
+)
+async def login(
+    payload: UserLoginRequest,
+    db: AsyncSession = Depends(get_db),
+):
+    return await login_user(db, payload)
+
+
+@router.get(
+    "/me",
+    response_model=UserResponse,
+    responses={
+        401: {"description": "Missing, invalid, or expired token"},
+    },
+)
+async def me(current_user: User = Depends(get_current_user)):
+    return UserResponse.model_validate(current_user)

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,0 +1,24 @@
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_db
+from app.models.user import UserRegisterRequest, UserResponse
+from app.services.auth_service import register_user
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+@router.post(
+    "/register",
+    response_model=UserResponse,
+    status_code=status.HTTP_201_CREATED,
+    responses={
+        409: {"description": "Email or username already taken"},
+        422: {"description": "Validation error (weak password, invalid email, etc.)"},
+    },
+)
+async def register(
+    payload: UserRegisterRequest,
+    db: AsyncSession = Depends(get_db),
+):
+    return await register_user(db, payload)

--- a/backend/app/routers/story.py
+++ b/backend/app/routers/story.py
@@ -1,13 +1,18 @@
 import uuid
 
-from fastapi import APIRouter, Depends, File, Form, Query, UploadFile, status
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.deps import get_current_user
 from app.db.enums import MediaType
 from app.db.session import get_db
 from app.db.user import User
-from app.models.story import MediaUploadRequest, MediaUploadResponse, StoryListResponse
+from app.models.story import (
+    MediaUploadRequest,
+    MediaUploadResponse,
+    StoryDetailResponse,
+    StoryListResponse,
+)
 from app.services.story_service import (
     list_available_stories,
     search_available_stories_by_place,
@@ -28,6 +33,22 @@ async def search_stories(
     db: AsyncSession = Depends(get_db),
 ):
     return await search_available_stories_by_place(db, place_name)
+
+
+@router.get(
+    "/{story_id}",
+    response_model=StoryDetailResponse,
+    responses={404: {"description": "Story not found"}},
+)
+async def get_story_by_id(
+    story_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+):
+    # Contract step only: retrieval logic will be implemented in service step.
+    raise HTTPException(
+        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        detail="Story detail retrieval is not implemented yet",
+    )
 
 
 @router.post(

--- a/backend/app/routers/story.py
+++ b/backend/app/routers/story.py
@@ -1,0 +1,13 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_db
+from app.models.story import StoryListResponse
+from app.services.story_service import list_available_stories
+
+router = APIRouter(prefix="/stories", tags=["stories"])
+
+
+@router.get("", response_model=StoryListResponse)
+async def list_stories(db: AsyncSession = Depends(get_db)):
+    return await list_available_stories(db)

--- a/backend/app/routers/story.py
+++ b/backend/app/routers/story.py
@@ -1,6 +1,8 @@
 import uuid
 
 from fastapi import APIRouter, Depends, File, Form, Query, UploadFile, status
+from fastapi import HTTPException
+from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.deps import get_current_user
@@ -71,12 +73,16 @@ async def list_stories(
     max_lng: float | None = Query(default=None),
     db: AsyncSession = Depends(get_db),
 ):
-    bounds = StoryBoundsFilter(
-        min_lat=min_lat,
-        max_lat=max_lat,
-        min_lng=min_lng,
-        max_lng=max_lng,
-    )
+    try:
+        bounds = StoryBoundsFilter(
+            min_lat=min_lat,
+            max_lat=max_lat,
+            min_lng=min_lng,
+            max_lng=max_lng,
+        )
+    except ValidationError as exc:
+        raise HTTPException(status_code=422, detail=exc.errors())
+
     return await list_available_stories(
         db,
         min_lat=bounds.min_lat,

--- a/backend/app/routers/story.py
+++ b/backend/app/routers/story.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.session import get_db
@@ -10,4 +10,13 @@ router = APIRouter(prefix="/stories", tags=["stories"])
 
 @router.get("", response_model=StoryListResponse)
 async def list_stories(db: AsyncSession = Depends(get_db)):
+    return await list_available_stories(db)
+
+
+@router.get("/search", response_model=StoryListResponse)
+async def search_stories(
+    place_name: str = Query(min_length=1, max_length=255),
+    db: AsyncSession = Depends(get_db),
+):
+    # Endpoint contract step: search logic will be wired in the service step.
     return await list_available_stories(db)

--- a/backend/app/routers/story.py
+++ b/backend/app/routers/story.py
@@ -13,6 +13,7 @@ from app.models.story import (
     MediaUploadRequest,
     MediaUploadResponse,
     StoryBoundsFilter,
+    StoryDateRangeFilter,
     StoryCreateRequest,
     StoryDetailResponse,
     StoryListResponse,
@@ -71,6 +72,9 @@ async def list_stories(
     max_lat: float | None = Query(default=None),
     min_lng: float | None = Query(default=None),
     max_lng: float | None = Query(default=None),
+    query_start: int | str | None = Query(default=None),
+    query_end: int | str | None = Query(default=None),
+    query_precision: str | None = Query(default=None),
     db: AsyncSession = Depends(get_db),
 ):
     try:
@@ -80,6 +84,12 @@ async def list_stories(
             min_lng=min_lng,
             max_lng=max_lng,
         )
+        date_filter = StoryDateRangeFilter(
+            query_start=query_start,
+            query_end=query_end,
+            query_precision=query_precision,
+        )
+        normalized_query_start, normalized_query_end, _ = date_filter.normalize_query_range()
     except ValidationError as exc:
         raise HTTPException(
             status_code=422,
@@ -92,15 +102,38 @@ async def list_stories(
         max_lat=bounds.max_lat,
         min_lng=bounds.min_lng,
         max_lng=bounds.max_lng,
+        query_start=normalized_query_start,
+        query_end=normalized_query_end,
     )
 
 
 @router.get("/search", response_model=StoryListResponse)
 async def search_stories(
     place_name: str = Query(min_length=1, max_length=255),
+    query_start: int | str | None = Query(default=None),
+    query_end: int | str | None = Query(default=None),
+    query_precision: str | None = Query(default=None),
     db: AsyncSession = Depends(get_db),
 ):
-    return await search_available_stories_by_place(db, place_name)
+    try:
+        date_filter = StoryDateRangeFilter(
+            query_start=query_start,
+            query_end=query_end,
+            query_precision=query_precision,
+        )
+        normalized_query_start, normalized_query_end, _ = date_filter.normalize_query_range()
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail=exc.errors(include_context=False, include_url=False),
+        )
+
+    return await search_available_stories_by_place(
+        db,
+        place_name,
+        query_start=normalized_query_start,
+        query_end=normalized_query_end,
+    )
 
 
 @router.get(

--- a/backend/app/routers/story.py
+++ b/backend/app/routers/story.py
@@ -3,7 +3,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.session import get_db
 from app.models.story import StoryListResponse
-from app.services.story_service import list_available_stories
+from app.services.story_service import (
+    list_available_stories,
+    search_available_stories_by_place,
+)
 
 router = APIRouter(prefix="/stories", tags=["stories"])
 
@@ -18,5 +21,4 @@ async def search_stories(
     place_name: str = Query(min_length=1, max_length=255),
     db: AsyncSession = Depends(get_db),
 ):
-    # Endpoint contract step: search logic will be wired in the service step.
-    return await list_available_stories(db)
+    return await search_available_stories_by_place(db, place_name)

--- a/backend/app/routers/story.py
+++ b/backend/app/routers/story.py
@@ -1,6 +1,6 @@
 import uuid
 
-from fastapi import APIRouter, Depends, File, Form, Query, UploadFile, status
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.deps import get_current_user
@@ -10,6 +10,7 @@ from app.db.user import User
 from app.models.story import (
     MediaUploadRequest,
     MediaUploadResponse,
+    StoryCreateRequest,
     StoryDetailResponse,
     StoryListResponse,
 )
@@ -21,6 +22,27 @@ from app.services.story_service import (
 )
 
 router = APIRouter(prefix="/stories", tags=["stories"])
+
+
+@router.post(
+    "",
+    response_model=StoryDetailResponse,
+    status_code=status.HTTP_201_CREATED,
+    responses={
+        401: {"description": "Missing or invalid authentication token"},
+        422: {"description": "Validation error for story/location input"},
+    },
+)
+async def create_story(
+    payload: StoryCreateRequest,
+    _current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    # Contract step only: creation logic will be implemented in service step.
+    raise HTTPException(
+        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        detail="Story creation is not implemented yet",
+    )
 
 
 @router.get("", response_model=StoryListResponse)

--- a/backend/app/routers/story.py
+++ b/backend/app/routers/story.py
@@ -10,6 +10,7 @@ from app.db.user import User
 from app.models.story import (
     MediaUploadRequest,
     MediaUploadResponse,
+    StoryBoundsFilter,
     StoryCreateRequest,
     StoryDetailResponse,
     StoryListResponse,
@@ -63,8 +64,26 @@ async def update_story(
 
 
 @router.get("", response_model=StoryListResponse)
-async def list_stories(db: AsyncSession = Depends(get_db)):
-    return await list_available_stories(db)
+async def list_stories(
+    min_lat: float | None = Query(default=None),
+    max_lat: float | None = Query(default=None),
+    min_lng: float | None = Query(default=None),
+    max_lng: float | None = Query(default=None),
+    db: AsyncSession = Depends(get_db),
+):
+    bounds = StoryBoundsFilter(
+        min_lat=min_lat,
+        max_lat=max_lat,
+        min_lng=min_lng,
+        max_lng=max_lng,
+    )
+    return await list_available_stories(
+        db,
+        min_lat=bounds.min_lat,
+        max_lat=bounds.max_lat,
+        min_lng=bounds.min_lng,
+        max_lng=bounds.max_lng,
+    )
 
 
 @router.get("/search", response_model=StoryListResponse)

--- a/backend/app/routers/story.py
+++ b/backend/app/routers/story.py
@@ -1,6 +1,6 @@
 import uuid
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile, status
+from fastapi import APIRouter, Depends, File, Form, Query, UploadFile, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.deps import get_current_user
@@ -15,6 +15,7 @@ from app.models.story import (
     StoryListResponse,
 )
 from app.services.story_service import (
+    create_story_with_location,
     get_story_detail_by_id,
     list_available_stories,
     search_available_stories_by_place,
@@ -35,14 +36,10 @@ router = APIRouter(prefix="/stories", tags=["stories"])
 )
 async def create_story(
     payload: StoryCreateRequest,
-    _current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    # Contract step only: creation logic will be implemented in service step.
-    raise HTTPException(
-        status_code=status.HTTP_501_NOT_IMPLEMENTED,
-        detail="Story creation is not implemented yet",
-    )
+    return await create_story_with_location(db, current_user, payload)
 
 
 @router.get("", response_model=StoryListResponse)

--- a/backend/app/routers/story.py
+++ b/backend/app/routers/story.py
@@ -1,11 +1,17 @@
-from fastapi import APIRouter, Depends, Query
+import uuid
+
+from fastapi import APIRouter, Depends, File, Form, Query, UploadFile, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.deps import get_current_user
+from app.db.enums import MediaType
 from app.db.session import get_db
-from app.models.story import StoryListResponse
+from app.db.user import User
+from app.models.story import MediaUploadRequest, MediaUploadResponse, StoryListResponse
 from app.services.story_service import (
     list_available_stories,
     search_available_stories_by_place,
+    upload_media_for_story,
 )
 
 router = APIRouter(prefix="/stories", tags=["stories"])
@@ -22,3 +28,27 @@ async def search_stories(
     db: AsyncSession = Depends(get_db),
 ):
     return await search_available_stories_by_place(db, place_name)
+
+
+@router.post(
+    "/{story_id}/media",
+    response_model=MediaUploadResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def upload_story_media(
+    story_id: uuid.UUID,
+    file: UploadFile = File(...),
+    media_type: MediaType = Form(...),
+    alt_text: str | None = Form(default=None),
+    caption: str | None = Form(default=None),
+    sort_order: int = Form(default=0),
+    _current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    payload = MediaUploadRequest(
+        media_type=media_type,
+        alt_text=alt_text,
+        caption=caption,
+        sort_order=sort_order,
+    )
+    return await upload_media_for_story(db, story_id, file, payload)

--- a/backend/app/routers/story.py
+++ b/backend/app/routers/story.py
@@ -13,12 +13,14 @@ from app.models.story import (
     StoryCreateRequest,
     StoryDetailResponse,
     StoryListResponse,
+    StoryUpdateRequest,
 )
 from app.services.story_service import (
     create_story_with_location,
     get_story_detail_by_id,
     list_available_stories,
     search_available_stories_by_place,
+    update_story_with_location_and_dates,
     upload_media_for_story,
 )
 
@@ -40,6 +42,24 @@ async def create_story(
     db: AsyncSession = Depends(get_db),
 ):
     return await create_story_with_location(db, current_user, payload)
+
+
+@router.put(
+    "/{story_id}",
+    response_model=StoryDetailResponse,
+    responses={
+        401: {"description": "Missing or invalid authentication token"},
+        404: {"description": "Story not found"},
+        422: {"description": "Validation error for story/location input"},
+    },
+)
+async def update_story(
+    story_id: uuid.UUID,
+    payload: StoryUpdateRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await update_story_with_location_and_dates(db, story_id, current_user, payload)
 
 
 @router.get("", response_model=StoryListResponse)

--- a/backend/app/routers/story.py
+++ b/backend/app/routers/story.py
@@ -1,6 +1,6 @@
 import uuid
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile, status
+from fastapi import APIRouter, Depends, File, Form, Query, UploadFile, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.deps import get_current_user
@@ -14,6 +14,7 @@ from app.models.story import (
     StoryListResponse,
 )
 from app.services.story_service import (
+    get_story_detail_by_id,
     list_available_stories,
     search_available_stories_by_place,
     upload_media_for_story,
@@ -44,11 +45,7 @@ async def get_story_by_id(
     story_id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
 ):
-    # Contract step only: retrieval logic will be implemented in service step.
-    raise HTTPException(
-        status_code=status.HTTP_501_NOT_IMPLEMENTED,
-        detail="Story detail retrieval is not implemented yet",
-    )
+    return await get_story_detail_by_id(db, story_id)
 
 
 @router.post(

--- a/backend/app/routers/story.py
+++ b/backend/app/routers/story.py
@@ -81,7 +81,10 @@ async def list_stories(
             max_lng=max_lng,
         )
     except ValidationError as exc:
-        raise HTTPException(status_code=422, detail=exc.errors())
+        raise HTTPException(
+            status_code=422,
+            detail=exc.errors(include_context=False, include_url=False),
+        )
 
     return await list_available_stories(
         db,

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -1,0 +1,48 @@
+from fastapi import HTTPException, status
+from passlib.context import CryptContext
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.user import User
+from app.models.user import UserRegisterRequest, UserResponse
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def hash_password(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+async def register_user(
+    db: AsyncSession, payload: UserRegisterRequest
+) -> UserResponse:
+    email = payload.email.strip().lower()
+    username = payload.username.strip()
+
+    # Check email uniqueness
+    result = await db.execute(select(User).where(User.email == email))
+    if result.scalar_one_or_none() is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Email already registered",
+        )
+
+    # Check username uniqueness
+    result = await db.execute(select(User).where(User.username == username))
+    if result.scalar_one_or_none() is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Username already taken",
+        )
+
+    user = User(
+        username=username,
+        email=email,
+        password_hash=hash_password(payload.password),
+        display_name=payload.display_name,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+
+    return UserResponse.model_validate(user)

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -1,16 +1,35 @@
+from datetime import datetime, timedelta, timezone
+
+import jwt
 from fastapi import HTTPException, status
 from passlib.context import CryptContext
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.db.user import User
-from app.models.user import UserRegisterRequest, UserResponse
+from app.models.user import TokenResponse, UserLoginRequest, UserRegisterRequest, UserResponse
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 
 def hash_password(password: str) -> str:
     return pwd_context.hash(password)
+
+
+def verify_password(plain: str, hashed: str) -> bool:
+    return pwd_context.verify(plain, hashed)
+
+
+def create_access_token(user: User) -> str:
+    expire = datetime.now(timezone.utc) + timedelta(minutes=settings.JWT_EXPIRE_MINUTES)
+    payload = {
+        "sub": str(user.id),
+        "email": user.email,
+        "role": user.role.value,
+        "exp": expire,
+    }
+    return jwt.encode(payload, settings.JWT_SECRET_KEY, algorithm=settings.JWT_ALGORITHM)
 
 
 async def register_user(
@@ -46,3 +65,21 @@ async def register_user(
     await db.refresh(user)
 
     return UserResponse.model_validate(user)
+
+
+async def login_user(
+    db: AsyncSession, payload: UserLoginRequest
+) -> TokenResponse:
+    email = payload.email.strip().lower()
+
+    result = await db.execute(select(User).where(User.email == email))
+    user = result.scalar_one_or_none()
+
+    if user is None or not verify_password(payload.password, user.password_hash):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid email or password",
+        )
+
+    token = create_access_token(user)
+    return TokenResponse(access_token=token)

--- a/backend/app/services/storage.py
+++ b/backend/app/services/storage.py
@@ -1,5 +1,6 @@
 import boto3
 from botocore.config import Config
+from urllib.parse import quote
 
 from app.core.config import settings
 from app.db.enums import MediaType
@@ -50,3 +51,10 @@ def upload_bytes(
 
 def delete_object(*, bucket_name: str, storage_key: str) -> None:
     storage_client.delete_object(Bucket=bucket_name, Key=storage_key)
+
+
+def build_public_object_url(*, bucket_name: str, storage_key: str) -> str:
+    base_url = settings.STORAGE_PUBLIC_URL.rstrip("/")
+    encoded_bucket = quote(bucket_name, safe="")
+    encoded_key = quote(storage_key.lstrip("/"), safe="/")
+    return f"{base_url}/{encoded_bucket}/{encoded_key}"

--- a/backend/app/services/storage.py
+++ b/backend/app/services/storage.py
@@ -2,6 +2,7 @@ import boto3
 from botocore.config import Config
 
 from app.core.config import settings
+from app.db.enums import MediaType
 
 # Local: points at MinIO (docker-compose).
 # Production: points at Supabase Storage S3 endpoint.
@@ -19,3 +20,33 @@ storage_client = boto3.client(
 def check_connection() -> None:
     """Verify the storage backend is reachable by listing buckets."""
     storage_client.list_buckets()
+
+
+def get_bucket_for_media_type(media_type: MediaType) -> str:
+    if media_type == MediaType.IMAGE:
+        return settings.STORAGE_BUCKET_IMAGES
+    if media_type == MediaType.AUDIO:
+        return settings.STORAGE_BUCKET_AUDIO
+    if media_type == MediaType.VIDEO:
+        return settings.STORAGE_BUCKET_VIDEOS
+    # MVP fallback: documents share the images bucket until a dedicated bucket is added.
+    return settings.STORAGE_BUCKET_IMAGES
+
+
+def upload_bytes(
+    *,
+    bucket_name: str,
+    storage_key: str,
+    content: bytes,
+    content_type: str,
+) -> None:
+    storage_client.put_object(
+        Bucket=bucket_name,
+        Key=storage_key,
+        Body=content,
+        ContentType=content_type,
+    )
+
+
+def delete_object(*, bucket_name: str, storage_key: str) -> None:
+    storage_client.delete_object(Bucket=bucket_name, Key=storage_key)

--- a/backend/app/services/storage.py
+++ b/backend/app/services/storage.py
@@ -1,6 +1,5 @@
 import boto3
 from botocore.config import Config
-from urllib.parse import quote
 
 from app.core.config import settings
 from app.db.enums import MediaType
@@ -51,10 +50,3 @@ def upload_bytes(
 
 def delete_object(*, bucket_name: str, storage_key: str) -> None:
     storage_client.delete_object(Bucket=bucket_name, Key=storage_key)
-
-
-def build_public_object_url(*, bucket_name: str, storage_key: str) -> str:
-    base_url = settings.STORAGE_PUBLIC_URL.rstrip("/")
-    encoded_bucket = quote(bucket_name, safe="")
-    encoded_key = quote(storage_key.lstrip("/"), safe="/")
-    return f"{base_url}/{encoded_bucket}/{encoded_key}"

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from fastapi import HTTPException, UploadFile, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.db.enums import StoryStatus, StoryVisibility
 from app.db.media_file import MediaFile
@@ -11,6 +12,7 @@ from app.db.story import Story
 from app.db.user import User
 from app.models.story import (
     MediaFileResponse,
+    StoryDetailResponse,
     MediaUploadRequest,
     MediaUploadResponse,
     StoryListResponse,
@@ -39,6 +41,12 @@ def _map_story_rows(rows: list[tuple[Story, str]]) -> StoryListResponse:
         for story, author_username in rows
     ]
     return StoryListResponse(stories=stories, total=len(stories))
+
+
+def _map_story_detail(story: Story, author_username: str) -> StoryDetailResponse:
+    story_response = StoryResponse.from_orm_with_author(story, author_username)
+    media_files = [MediaFileResponse.model_validate(media) for media in story.media_files]
+    return StoryDetailResponse(**story_response.model_dump(), media_files=media_files)
 
 
 def _validate_media_upload(file: UploadFile, payload: MediaUploadRequest) -> None:
@@ -106,6 +114,30 @@ async def search_available_stories_by_place(
     rows = result.all()
 
     return _map_story_rows(rows)
+
+
+async def get_story_detail_by_id(
+    db: AsyncSession,
+    story_id: uuid.UUID,
+) -> StoryDetailResponse:
+    stmt = (
+        select(Story, User.username)
+        .join(User, Story.user_id == User.id)
+        .where(Story.id == story_id)
+        .options(selectinload(Story.media_files))
+    )
+
+    result = await db.execute(stmt)
+    row = result.one_or_none()
+
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Story not found",
+        )
+
+    story, author_username = row
+    return _map_story_detail(story, author_username)
 
 
 async def upload_media_for_story(

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -1,0 +1,52 @@
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.enums import StoryStatus, StoryVisibility
+from app.db.story import Story
+from app.db.user import User
+from app.models.story import StoryListResponse, StoryResponse
+
+
+def _build_date_label(date_start: int | None, date_end: int | None) -> str | None:
+    if date_start is not None and date_end is not None:
+        return f"{date_start} - {date_end}"
+    if date_start is not None:
+        return str(date_start)
+    return None
+
+
+async def list_available_stories(db: AsyncSession) -> StoryListResponse:
+    stmt = (
+        select(Story, User.username)
+        .join(User, Story.user_id == User.id)
+        .where(
+            Story.status == StoryStatus.PUBLISHED,
+            Story.visibility == StoryVisibility.PUBLIC,
+        )
+        .order_by(Story.created_at.desc())
+    )
+
+    result = await db.execute(stmt)
+    rows = result.all()
+
+    stories = [
+        StoryResponse(
+            id=story.id,
+            title=story.title,
+            summary=story.summary,
+            content=story.content,
+            author=author_username,
+            place_name=story.place_name,
+            latitude=story.latitude,
+            longitude=story.longitude,
+            date_start=story.date_start,
+            date_end=story.date_end,
+            date_label=_build_date_label(story.date_start, story.date_end),
+            status=story.status,
+            visibility=story.visibility,
+            created_at=story.created_at,
+        )
+        for story, author_username in rows
+    ]
+
+    return StoryListResponse(stories=stories, total=len(stories))

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -1,10 +1,36 @@
+import uuid
+from pathlib import Path
+
+from fastapi import HTTPException, UploadFile, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.enums import StoryStatus, StoryVisibility
+from app.db.media_file import MediaFile
 from app.db.story import Story
 from app.db.user import User
-from app.models.story import StoryListResponse, StoryResponse
+from app.models.story import (
+    MediaFileResponse,
+    MediaUploadRequest,
+    MediaUploadResponse,
+    StoryListResponse,
+    StoryResponse,
+)
+from app.services.storage import delete_object, get_bucket_for_media_type, upload_bytes
+
+MAX_MEDIA_UPLOAD_BYTES = 20 * 1024 * 1024  # 20 MB
+
+ALLOWED_MIME_TYPES = {
+    "image": {"image/jpeg", "image/png", "image/webp", "image/gif"},
+    "audio": {"audio/mpeg", "audio/wav", "audio/ogg", "audio/mp4"},
+    "video": {"video/mp4", "video/webm", "video/quicktime"},
+    "document": {
+        "application/pdf",
+        "text/plain",
+        "application/msword",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    },
+}
 
 
 def _map_story_rows(rows: list[tuple[Story, str]]) -> StoryListResponse:
@@ -13,6 +39,35 @@ def _map_story_rows(rows: list[tuple[Story, str]]) -> StoryListResponse:
         for story, author_username in rows
     ]
     return StoryListResponse(stories=stories, total=len(stories))
+
+
+def _validate_media_upload(file: UploadFile, payload: MediaUploadRequest) -> None:
+    if not file.filename:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Filename is required",
+        )
+
+    if not file.content_type:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Content type is required",
+        )
+
+    allowed_for_type = ALLOWED_MIME_TYPES[payload.media_type.value]
+    if file.content_type not in allowed_for_type:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                f"Unsupported mime type '{file.content_type}' for media type "
+                f"'{payload.media_type.value}'"
+            ),
+        )
+
+
+def _build_media_storage_key(story_id: uuid.UUID, filename: str) -> str:
+    ext = Path(filename).suffix.lower()
+    return f"stories/{story_id}/media/{uuid.uuid4()}{ext}"
 
 
 async def list_available_stories(db: AsyncSession) -> StoryListResponse:
@@ -51,3 +106,80 @@ async def search_available_stories_by_place(
     rows = result.all()
 
     return _map_story_rows(rows)
+
+
+async def upload_media_for_story(
+    db: AsyncSession,
+    story_id: uuid.UUID,
+    file: UploadFile,
+    payload: MediaUploadRequest,
+) -> MediaUploadResponse:
+    _validate_media_upload(file, payload)
+
+    story_result = await db.execute(select(Story).where(Story.id == story_id))
+    story = story_result.scalar_one_or_none()
+    if story is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Story not found",
+        )
+
+    file_bytes = await file.read()
+    if not file_bytes:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Uploaded file is empty",
+        )
+
+    file_size = len(file_bytes)
+    if file_size > MAX_MEDIA_UPLOAD_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"File size exceeds {MAX_MEDIA_UPLOAD_BYTES} bytes",
+        )
+
+    bucket_name = get_bucket_for_media_type(payload.media_type)
+    storage_key = _build_media_storage_key(story_id, file.filename)
+
+    try:
+        upload_bytes(
+            bucket_name=bucket_name,
+            storage_key=storage_key,
+            content=file_bytes,
+            content_type=file.content_type,
+        )
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Failed to upload media to storage",
+        )
+
+    media = MediaFile(
+        story_id=story_id,
+        bucket_name=bucket_name,
+        storage_key=storage_key,
+        original_filename=file.filename,
+        mime_type=file.content_type,
+        media_type=payload.media_type,
+        file_size_bytes=file_size,
+        sort_order=payload.sort_order,
+        alt_text=payload.alt_text,
+        caption=payload.caption,
+    )
+
+    try:
+        db.add(media)
+        await db.commit()
+        await db.refresh(media)
+    except Exception:
+        await db.rollback()
+        try:
+            delete_object(bucket_name=bucket_name, storage_key=storage_key)
+        except Exception:
+            pass
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to persist media metadata",
+        )
+
+    return MediaUploadResponse(media=MediaFileResponse.model_validate(media))

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -331,4 +331,4 @@ async def upload_media_for_story(
             detail="Failed to persist media metadata",
         )
 
-    return MediaUploadResponse(media=MediaFileResponse.model_validate(media))
+    return MediaUploadResponse(media=_map_media_file(media))

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -12,15 +12,20 @@ from app.db.story import Story
 from app.db.user import User
 from app.models.story import (
     MediaFileResponse,
-    StoryDetailResponse,
-    StoryCreateRequest,
-    StoryUpdateRequest,
     MediaUploadRequest,
     MediaUploadResponse,
+    StoryCreateRequest,
+    StoryDetailResponse,
     StoryListResponse,
     StoryResponse,
+    StoryUpdateRequest,
 )
-from app.services.storage import delete_object, get_bucket_for_media_type, upload_bytes
+from app.services.storage import (
+    build_public_object_url,
+    delete_object,
+    get_bucket_for_media_type,
+    upload_bytes,
+)
 
 MAX_MEDIA_UPLOAD_BYTES = 20 * 1024 * 1024  # 20 MB
 
@@ -45,9 +50,30 @@ def _map_story_rows(rows: list[tuple[Story, str]]) -> StoryListResponse:
     return StoryListResponse(stories=stories, total=len(stories))
 
 
+def _map_media_file(media: MediaFile) -> MediaFileResponse:
+    return MediaFileResponse(
+        id=media.id,
+        story_id=media.story_id,
+        bucket_name=media.bucket_name,
+        storage_key=media.storage_key,
+        media_url=build_public_object_url(
+            bucket_name=media.bucket_name,
+            storage_key=media.storage_key,
+        ),
+        original_filename=media.original_filename,
+        mime_type=media.mime_type,
+        media_type=media.media_type,
+        file_size_bytes=media.file_size_bytes,
+        sort_order=media.sort_order,
+        alt_text=media.alt_text,
+        caption=media.caption,
+        created_at=media.created_at,
+    )
+
+
 def _map_story_detail(story: Story, author_username: str) -> StoryDetailResponse:
     story_response = StoryResponse.from_orm_with_author(story, author_username)
-    media_files = [MediaFileResponse.model_validate(media) for media in story.media_files]
+    media_files = [_map_media_file(media) for media in story.media_files]
     return StoryDetailResponse(**story_response.model_dump(), media_files=media_files)
 
 
@@ -287,4 +313,4 @@ async def upload_media_for_story(
             detail="Failed to persist media metadata",
         )
 
-    return MediaUploadResponse(media=MediaFileResponse.model_validate(media))
+    return MediaUploadResponse(media=_map_media_file(media))

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -12,15 +12,20 @@ from app.db.story import Story
 from app.db.user import User
 from app.models.story import (
     MediaFileResponse,
-    StoryDetailResponse,
-    StoryCreateRequest,
-    StoryUpdateRequest,
     MediaUploadRequest,
     MediaUploadResponse,
+    StoryCreateRequest,
+    StoryDetailResponse,
     StoryListResponse,
     StoryResponse,
+    StoryUpdateRequest,
 )
-from app.services.storage import delete_object, get_bucket_for_media_type, upload_bytes
+from app.services.storage import (
+    build_public_object_url,
+    delete_object,
+    get_bucket_for_media_type,
+    upload_bytes,
+)
 
 MAX_MEDIA_UPLOAD_BYTES = 20 * 1024 * 1024  # 20 MB
 
@@ -45,9 +50,30 @@ def _map_story_rows(rows: list[tuple[Story, str]]) -> StoryListResponse:
     return StoryListResponse(stories=stories, total=len(stories))
 
 
+def _map_media_file(media: MediaFile) -> MediaFileResponse:
+    return MediaFileResponse(
+        id=media.id,
+        story_id=media.story_id,
+        bucket_name=media.bucket_name,
+        storage_key=media.storage_key,
+        media_url=build_public_object_url(
+            bucket_name=media.bucket_name,
+            storage_key=media.storage_key,
+        ),
+        original_filename=media.original_filename,
+        mime_type=media.mime_type,
+        media_type=media.media_type,
+        file_size_bytes=media.file_size_bytes,
+        sort_order=media.sort_order,
+        alt_text=media.alt_text,
+        caption=media.caption,
+        created_at=media.created_at,
+    )
+
+
 def _map_story_detail(story: Story, author_username: str) -> StoryDetailResponse:
     story_response = StoryResponse.from_orm_with_author(story, author_username)
-    media_files = [MediaFileResponse.model_validate(media) for media in story.media_files]
+    media_files = [_map_media_file(media) for media in story.media_files]
     return StoryDetailResponse(**story_response.model_dump(), media_files=media_files)
 
 

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -12,20 +12,15 @@ from app.db.story import Story
 from app.db.user import User
 from app.models.story import (
     MediaFileResponse,
+    StoryDetailResponse,
+    StoryCreateRequest,
+    StoryUpdateRequest,
     MediaUploadRequest,
     MediaUploadResponse,
-    StoryCreateRequest,
-    StoryDetailResponse,
     StoryListResponse,
     StoryResponse,
-    StoryUpdateRequest,
 )
-from app.services.storage import (
-    build_public_object_url,
-    delete_object,
-    get_bucket_for_media_type,
-    upload_bytes,
-)
+from app.services.storage import delete_object, get_bucket_for_media_type, upload_bytes
 
 MAX_MEDIA_UPLOAD_BYTES = 20 * 1024 * 1024  # 20 MB
 
@@ -50,30 +45,9 @@ def _map_story_rows(rows: list[tuple[Story, str]]) -> StoryListResponse:
     return StoryListResponse(stories=stories, total=len(stories))
 
 
-def _map_media_file(media: MediaFile) -> MediaFileResponse:
-    return MediaFileResponse(
-        id=media.id,
-        story_id=media.story_id,
-        bucket_name=media.bucket_name,
-        storage_key=media.storage_key,
-        media_url=build_public_object_url(
-            bucket_name=media.bucket_name,
-            storage_key=media.storage_key,
-        ),
-        original_filename=media.original_filename,
-        mime_type=media.mime_type,
-        media_type=media.media_type,
-        file_size_bytes=media.file_size_bytes,
-        sort_order=media.sort_order,
-        alt_text=media.alt_text,
-        caption=media.caption,
-        created_at=media.created_at,
-    )
-
-
 def _map_story_detail(story: Story, author_username: str) -> StoryDetailResponse:
     story_response = StoryResponse.from_orm_with_author(story, author_username)
-    media_files = [_map_media_file(media) for media in story.media_files]
+    media_files = [MediaFileResponse.model_validate(media) for media in story.media_files]
     return StoryDetailResponse(**story_response.model_dump(), media_files=media_files)
 
 

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -159,6 +159,8 @@ async def create_story_with_location(
         title=payload.title,
         summary=payload.summary,
         content=payload.content,
+        status=StoryStatus.PUBLISHED,
+        visibility=StoryVisibility.PUBLIC,
         place_name=place_name,
         latitude=payload.latitude,
         longitude=payload.longitude,

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import date
 from pathlib import Path
 
 from fastapi import HTTPException, UploadFile, status
@@ -86,6 +87,8 @@ async def list_available_stories(
     max_lat: float | None = None,
     min_lng: float | None = None,
     max_lng: float | None = None,
+    query_start: date | None = None,
+    query_end: date | None = None,
 ) -> StoryListResponse:
     stmt = (
         select(Story, User.username)
@@ -107,6 +110,14 @@ async def list_available_stories(
             Story.longitude <= max_lng,
         )
 
+    if query_start is not None and query_end is not None:
+        stmt = stmt.where(
+            Story.date_start.is_not(None),
+            Story.date_end.is_not(None),
+            Story.date_start <= query_end,
+            Story.date_end >= query_start,
+        )
+
     result = await db.execute(stmt)
     rows = result.all()
 
@@ -116,6 +127,8 @@ async def list_available_stories(
 async def search_available_stories_by_place(
     db: AsyncSession,
     place_name: str,
+    query_start: date | None = None,
+    query_end: date | None = None,
 ) -> StoryListResponse:
     stmt = (
         select(Story, User.username)
@@ -127,6 +140,14 @@ async def search_available_stories_by_place(
         )
         .order_by(Story.created_at.desc())
     )
+
+    if query_start is not None and query_end is not None:
+        stmt = stmt.where(
+            Story.date_start.is_not(None),
+            Story.date_end.is_not(None),
+            Story.date_start <= query_end,
+            Story.date_end >= query_start,
+        )
 
     result = await db.execute(stmt)
     rows = result.all()
@@ -170,6 +191,10 @@ async def create_story_with_location(
             detail="place_name is required for story location binding",
         )
 
+    normalized_date_start, normalized_date_end, normalized_date_precision = (
+        payload.normalize_date_range()
+    )
+
     story = Story(
         user_id=current_user.id,
         title=payload.title,
@@ -180,8 +205,9 @@ async def create_story_with_location(
         place_name=place_name,
         latitude=payload.latitude,
         longitude=payload.longitude,
-        date_start=payload.date_start,
-        date_end=payload.date_end,
+        date_start=normalized_date_start,
+        date_end=normalized_date_end,
+        date_precision=normalized_date_precision,
     )
 
     db.add(story)
@@ -215,14 +241,19 @@ async def update_story_with_location_and_dates(
             detail="place_name is required for story location binding",
         )
 
+    normalized_date_start, normalized_date_end, normalized_date_precision = (
+        payload.normalize_date_range()
+    )
+
     story.title = payload.title
     story.summary = payload.summary
     story.content = payload.content
     story.place_name = place_name
     story.latitude = payload.latitude
     story.longitude = payload.longitude
-    story.date_start = payload.date_start
-    story.date_end = payload.date_end
+    story.date_start = normalized_date_start
+    story.date_end = normalized_date_end
+    story.date_precision = normalized_date_precision
 
     await db.commit()
     await db.refresh(story)

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -13,6 +13,7 @@ from app.db.user import User
 from app.models.story import (
     MediaFileResponse,
     StoryDetailResponse,
+    StoryCreateRequest,
     MediaUploadRequest,
     MediaUploadResponse,
     StoryListResponse,
@@ -138,6 +139,38 @@ async def get_story_detail_by_id(
 
     story, author_username = row
     return _map_story_detail(story, author_username)
+
+
+async def create_story_with_location(
+    db: AsyncSession,
+    current_user: User,
+    payload: StoryCreateRequest,
+) -> StoryDetailResponse:
+    place_name = payload.place_name.strip() if payload.place_name else None
+    if not place_name:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="place_name is required for story location binding",
+        )
+
+    story = Story(
+        user_id=current_user.id,
+        title=payload.title,
+        summary=payload.summary,
+        content=payload.content,
+        place_name=place_name,
+        latitude=payload.latitude,
+        longitude=payload.longitude,
+        date_start=payload.date_start,
+        date_end=payload.date_end,
+    )
+
+    db.add(story)
+    await db.commit()
+    await db.refresh(story)
+
+    story_response = StoryResponse.from_orm_with_author(story, current_user.username)
+    return StoryDetailResponse(**story_response.model_dump(), media_files=[])
 
 
 async def upload_media_for_story(

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -7,14 +7,6 @@ from app.db.user import User
 from app.models.story import StoryListResponse, StoryResponse
 
 
-def _build_date_label(date_start: int | None, date_end: int | None) -> str | None:
-    if date_start is not None and date_end is not None:
-        return f"{date_start} - {date_end}"
-    if date_start is not None:
-        return str(date_start)
-    return None
-
-
 async def list_available_stories(db: AsyncSession) -> StoryListResponse:
     stmt = (
         select(Story, User.username)
@@ -29,24 +21,6 @@ async def list_available_stories(db: AsyncSession) -> StoryListResponse:
     result = await db.execute(stmt)
     rows = result.all()
 
-    stories = [
-        StoryResponse(
-            id=story.id,
-            title=story.title,
-            summary=story.summary,
-            content=story.content,
-            author=author_username,
-            place_name=story.place_name,
-            latitude=story.latitude,
-            longitude=story.longitude,
-            date_start=story.date_start,
-            date_end=story.date_end,
-            date_label=_build_date_label(story.date_start, story.date_end),
-            status=story.status,
-            visibility=story.visibility,
-            created_at=story.created_at,
-        )
-        for story, author_username in rows
-    ]
+    stories = [StoryResponse.from_orm_with_author(story, author_username) for story, author_username in rows]
 
     return StoryListResponse(stories=stories, total=len(stories))

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -7,6 +7,14 @@ from app.db.user import User
 from app.models.story import StoryListResponse, StoryResponse
 
 
+def _map_story_rows(rows: list[tuple[Story, str]]) -> StoryListResponse:
+    stories = [
+        StoryResponse.from_orm_with_author(story, author_username)
+        for story, author_username in rows
+    ]
+    return StoryListResponse(stories=stories, total=len(stories))
+
+
 async def list_available_stories(db: AsyncSession) -> StoryListResponse:
     stmt = (
         select(Story, User.username)
@@ -21,6 +29,25 @@ async def list_available_stories(db: AsyncSession) -> StoryListResponse:
     result = await db.execute(stmt)
     rows = result.all()
 
-    stories = [StoryResponse.from_orm_with_author(story, author_username) for story, author_username in rows]
+    return _map_story_rows(rows)
 
-    return StoryListResponse(stories=stories, total=len(stories))
+
+async def search_available_stories_by_place(
+    db: AsyncSession,
+    place_name: str,
+) -> StoryListResponse:
+    stmt = (
+        select(Story, User.username)
+        .join(User, Story.user_id == User.id)
+        .where(
+            Story.status == StoryStatus.PUBLISHED,
+            Story.visibility == StoryVisibility.PUBLIC,
+            Story.place_name.ilike(f"%{place_name}%"),
+        )
+        .order_by(Story.created_at.desc())
+    )
+
+    result = await db.execute(stmt)
+    rows = result.all()
+
+    return _map_story_rows(rows)

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -80,7 +80,13 @@ def _build_media_storage_key(story_id: uuid.UUID, filename: str) -> str:
     return f"stories/{story_id}/media/{uuid.uuid4()}{ext}"
 
 
-async def list_available_stories(db: AsyncSession) -> StoryListResponse:
+async def list_available_stories(
+    db: AsyncSession,
+    min_lat: float | None = None,
+    max_lat: float | None = None,
+    min_lng: float | None = None,
+    max_lng: float | None = None,
+) -> StoryListResponse:
     stmt = (
         select(Story, User.username)
         .join(User, Story.user_id == User.id)
@@ -90,6 +96,16 @@ async def list_available_stories(db: AsyncSession) -> StoryListResponse:
         )
         .order_by(Story.created_at.desc())
     )
+
+    if all(v is not None for v in (min_lat, max_lat, min_lng, max_lng)):
+        stmt = stmt.where(
+            Story.latitude.is_not(None),
+            Story.longitude.is_not(None),
+            Story.latitude >= min_lat,
+            Story.latitude <= max_lat,
+            Story.longitude >= min_lng,
+            Story.longitude <= max_lng,
+        )
 
     result = await db.execute(stmt)
     rows = result.all()

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -14,6 +14,7 @@ from app.models.story import (
     MediaFileResponse,
     StoryDetailResponse,
     StoryCreateRequest,
+    StoryUpdateRequest,
     MediaUploadRequest,
     MediaUploadResponse,
     StoryListResponse,
@@ -166,6 +167,45 @@ async def create_story_with_location(
     )
 
     db.add(story)
+    await db.commit()
+    await db.refresh(story)
+
+    story_response = StoryResponse.from_orm_with_author(story, current_user.username)
+    return StoryDetailResponse(**story_response.model_dump(), media_files=[])
+
+
+async def update_story_with_location_and_dates(
+    db: AsyncSession,
+    story_id: uuid.UUID,
+    current_user: User,
+    payload: StoryUpdateRequest,
+) -> StoryDetailResponse:
+    story_result = await db.execute(
+        select(Story).where(Story.id == story_id, Story.user_id == current_user.id)
+    )
+    story = story_result.scalar_one_or_none()
+    if story is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Story not found",
+        )
+
+    place_name = payload.place_name.strip() if payload.place_name else None
+    if not place_name:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="place_name is required for story location binding",
+        )
+
+    story.title = payload.title
+    story.summary = payload.summary
+    story.content = payload.content
+    story.place_name = place_name
+    story.latitude = payload.latitude
+    story.longitude = payload.longitude
+    story.date_start = payload.date_start
+    story.date_end = payload.date_end
+
     await db.commit()
     await db.refresh(story)
 

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+pythonpath = .

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,6 +10,7 @@ alembic
 
 # Config
 pydantic-settings
+pydantic[email]
 python-dotenv
 
 # Object storage (S3-compatible — works with MinIO locally and Supabase Storage in prod)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,5 +13,9 @@ pydantic-settings
 pydantic[email]
 python-dotenv
 
+# Auth
+passlib[bcrypt]
+bcrypt==4.2.1
+
 # Object storage (S3-compatible — works with MinIO locally and Supabase Storage in prod)
 boto3

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,6 +18,7 @@ python-dotenv
 passlib[bcrypt]
 bcrypt==4.2.1
 pyjwt
+python-multipart
 
 # Object storage (S3-compatible — works with MinIO locally and Supabase Storage in prod)
 boto3

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,6 +16,7 @@ python-dotenv
 # Auth
 passlib[bcrypt]
 bcrypt==4.2.1
+pyjwt
 
 # Object storage (S3-compatible — works with MinIO locally and Supabase Storage in prod)
 boto3

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,7 @@
 fastapi
 uvicorn
 pytest
+pytest-asyncio==0.25.3
 httpx
 
 # Database

--- a/backend/tests/api/test_auth_api.py
+++ b/backend/tests/api/test_auth_api.py
@@ -1,17 +1,20 @@
 import pytest
 
+from tests.factories.user_factory import make_login_payload, make_user_payload
+
 
 @pytest.mark.asyncio
 class TestRegistrationAPI:
     """API test for registration endpoint. Covers #130."""
 
     async def test_register_success(self, client):
-        resp = await client.post("/auth/register", json={
-            "username": "apiuser",
-            "email": "api@example.com",
-            "password": "ApiPass1!",
-            "display_name": "API User",
-        })
+        payload = make_user_payload(
+            username="apiuser",
+            email="api@example.com",
+            password="ApiPass1!",
+            display_name="API User",
+        )
+        resp = await client.post("/auth/register", json=payload)
         assert resp.status_code == 201
         data = resp.json()
         assert data["username"] == "apiuser"
@@ -24,32 +27,48 @@ class TestRegistrationAPI:
         assert "password_hash" not in data
 
     async def test_register_duplicate_email(self, client):
-        await client.post("/auth/register", json={
-            "username": "first",
-            "email": "same@example.com",
-            "password": "ApiPass1!",
-        })
-        resp = await client.post("/auth/register", json={
-            "username": "second",
-            "email": "same@example.com",
-            "password": "ApiPass1!",
-        })
+        await client.post(
+            "/auth/register",
+            json=make_user_payload(
+                username="first",
+                email="same@example.com",
+                password="ApiPass1!",
+                display_name=None,
+            ),
+        )
+        resp = await client.post(
+            "/auth/register",
+            json=make_user_payload(
+                username="second",
+                email="same@example.com",
+                password="ApiPass1!",
+                display_name=None,
+            ),
+        )
         assert resp.status_code == 409
 
     async def test_register_weak_password(self, client):
-        resp = await client.post("/auth/register", json={
-            "username": "weakuser",
-            "email": "weak@example.com",
-            "password": "nodigits",
-        })
+        resp = await client.post(
+            "/auth/register",
+            json=make_user_payload(
+                username="weakuser",
+                email="weak@example.com",
+                password="nodigits",
+                display_name=None,
+            ),
+        )
         assert resp.status_code == 422
 
     async def test_register_invalid_email(self, client):
-        resp = await client.post("/auth/register", json={
-            "username": "bademail",
-            "email": "not-valid",
-            "password": "ApiPass1!",
-        })
+        resp = await client.post(
+            "/auth/register",
+            json=make_user_payload(
+                username="bademail",
+                email="not-valid",
+                password="ApiPass1!",
+                display_name=None,
+            ),
+        )
         assert resp.status_code == 422
 
     async def test_register_missing_fields(self, client):
@@ -81,37 +100,45 @@ class TestLoginAPI:
 
     async def test_login_success(self, client):
         # Register first
-        await client.post("/auth/register", json={
-            "username": "loginuser",
-            "email": "login@example.com",
-            "password": "LoginPass1!",
-        })
-        resp = await client.post("/auth/login", json={
-            "email": "login@example.com",
-            "password": "LoginPass1!",
-        })
+        await client.post(
+            "/auth/register",
+            json=make_user_payload(
+                username="loginuser",
+                email="login@example.com",
+                password="LoginPass1!",
+                display_name=None,
+            ),
+        )
+        resp = await client.post(
+            "/auth/login",
+            json=make_login_payload(email="login@example.com", password="LoginPass1!"),
+        )
         assert resp.status_code == 200
         data = resp.json()
         assert "access_token" in data
         assert data["token_type"] == "bearer"
 
     async def test_login_wrong_password(self, client):
-        await client.post("/auth/register", json={
-            "username": "wrongpw",
-            "email": "wrongpw@example.com",
-            "password": "CorrectPass1!",
-        })
-        resp = await client.post("/auth/login", json={
-            "email": "wrongpw@example.com",
-            "password": "WrongPass1!",
-        })
+        await client.post(
+            "/auth/register",
+            json=make_user_payload(
+                username="wrongpw",
+                email="wrongpw@example.com",
+                password="CorrectPass1!",
+                display_name=None,
+            ),
+        )
+        resp = await client.post(
+            "/auth/login",
+            json=make_login_payload(email="wrongpw@example.com", password="WrongPass1!"),
+        )
         assert resp.status_code == 401
 
     async def test_login_nonexistent_email(self, client):
-        resp = await client.post("/auth/login", json={
-            "email": "ghost@example.com",
-            "password": "AnyPass1!",
-        })
+        resp = await client.post(
+            "/auth/login",
+            json=make_login_payload(email="ghost@example.com", password="AnyPass1!"),
+        )
         assert resp.status_code == 401
 
     async def test_login_missing_fields(self, client):
@@ -133,15 +160,19 @@ class TestTokenVerificationAPI:
     """API test for token verification middleware. Covers #132."""
 
     async def test_me_with_valid_token(self, client):
-        await client.post("/auth/register", json={
-            "username": "meuser",
-            "email": "me@example.com",
-            "password": "MePass1!",
-        })
-        login_resp = await client.post("/auth/login", json={
-            "email": "me@example.com",
-            "password": "MePass1!",
-        })
+        await client.post(
+            "/auth/register",
+            json=make_user_payload(
+                username="meuser",
+                email="me@example.com",
+                password="MePass1!",
+                display_name=None,
+            ),
+        )
+        login_resp = await client.post(
+            "/auth/login",
+            json=make_login_payload(email="me@example.com", password="MePass1!"),
+        )
         token = login_resp.json()["access_token"]
 
         resp = await client.get(

--- a/backend/tests/api/test_auth_api.py
+++ b/backend/tests/api/test_auth_api.py
@@ -1,0 +1,182 @@
+import pytest
+
+
+@pytest.mark.asyncio
+class TestRegistrationAPI:
+    """API test for registration endpoint. Covers #130."""
+
+    async def test_register_success(self, client):
+        resp = await client.post("/auth/register", json={
+            "username": "apiuser",
+            "email": "api@example.com",
+            "password": "ApiPass1!",
+            "display_name": "API User",
+        })
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["username"] == "apiuser"
+        assert data["email"] == "api@example.com"
+        assert data["display_name"] == "API User"
+        assert data["role"] == "user"
+        assert "id" in data
+        assert "created_at" in data
+        assert "password" not in data
+        assert "password_hash" not in data
+
+    async def test_register_duplicate_email(self, client):
+        await client.post("/auth/register", json={
+            "username": "first",
+            "email": "same@example.com",
+            "password": "ApiPass1!",
+        })
+        resp = await client.post("/auth/register", json={
+            "username": "second",
+            "email": "same@example.com",
+            "password": "ApiPass1!",
+        })
+        assert resp.status_code == 409
+
+    async def test_register_weak_password(self, client):
+        resp = await client.post("/auth/register", json={
+            "username": "weakuser",
+            "email": "weak@example.com",
+            "password": "nodigits",
+        })
+        assert resp.status_code == 422
+
+    async def test_register_invalid_email(self, client):
+        resp = await client.post("/auth/register", json={
+            "username": "bademail",
+            "email": "not-valid",
+            "password": "ApiPass1!",
+        })
+        assert resp.status_code == 422
+
+    async def test_register_missing_fields(self, client):
+        # Missing username
+        resp = await client.post("/auth/register", json={
+            "email": "missing@example.com",
+            "password": "ApiPass1!",
+        })
+        assert resp.status_code == 422
+
+        # Missing email
+        resp = await client.post("/auth/register", json={
+            "username": "missingmail",
+            "password": "ApiPass1!",
+        })
+        assert resp.status_code == 422
+
+        # Missing password
+        resp = await client.post("/auth/register", json={
+            "username": "misspwd",
+            "email": "misspwd@example.com",
+        })
+        assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+class TestLoginAPI:
+    """API test for login endpoint. Covers #131."""
+
+    async def test_login_success(self, client):
+        # Register first
+        await client.post("/auth/register", json={
+            "username": "loginuser",
+            "email": "login@example.com",
+            "password": "LoginPass1!",
+        })
+        resp = await client.post("/auth/login", json={
+            "email": "login@example.com",
+            "password": "LoginPass1!",
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "access_token" in data
+        assert data["token_type"] == "bearer"
+
+    async def test_login_wrong_password(self, client):
+        await client.post("/auth/register", json={
+            "username": "wrongpw",
+            "email": "wrongpw@example.com",
+            "password": "CorrectPass1!",
+        })
+        resp = await client.post("/auth/login", json={
+            "email": "wrongpw@example.com",
+            "password": "WrongPass1!",
+        })
+        assert resp.status_code == 401
+
+    async def test_login_nonexistent_email(self, client):
+        resp = await client.post("/auth/login", json={
+            "email": "ghost@example.com",
+            "password": "AnyPass1!",
+        })
+        assert resp.status_code == 401
+
+    async def test_login_missing_fields(self, client):
+        # Missing email
+        resp = await client.post("/auth/login", json={
+            "password": "AnyPass1!",
+        })
+        assert resp.status_code == 422
+
+        # Missing password
+        resp = await client.post("/auth/login", json={
+            "email": "some@example.com",
+        })
+        assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+class TestTokenVerificationAPI:
+    """API test for token verification middleware. Covers #132."""
+
+    async def test_me_with_valid_token(self, client):
+        await client.post("/auth/register", json={
+            "username": "meuser",
+            "email": "me@example.com",
+            "password": "MePass1!",
+        })
+        login_resp = await client.post("/auth/login", json={
+            "email": "me@example.com",
+            "password": "MePass1!",
+        })
+        token = login_resp.json()["access_token"]
+
+        resp = await client.get(
+            "/auth/me", headers={"Authorization": f"Bearer {token}"}
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["username"] == "meuser"
+        assert data["email"] == "me@example.com"
+
+    async def test_me_without_token(self, client):
+        resp = await client.get("/auth/me")
+        assert resp.status_code == 401 or resp.status_code == 403
+
+    async def test_me_with_invalid_token(self, client):
+        resp = await client.get(
+            "/auth/me", headers={"Authorization": "Bearer invalid.token.here"}
+        )
+        assert resp.status_code == 401
+
+    async def test_me_with_expired_token(self, client):
+        import jwt
+        from datetime import datetime, timedelta, timezone
+        from app.core.config import settings
+
+        expired_payload = {
+            "sub": "00000000-0000-0000-0000-000000000000",
+            "email": "expired@example.com",
+            "role": "user",
+            "exp": datetime.now(timezone.utc) - timedelta(hours=1),
+        }
+        expired_token = jwt.encode(
+            expired_payload, settings.JWT_SECRET_KEY, algorithm=settings.JWT_ALGORITHM
+        )
+        resp = await client.get(
+            "/auth/me", headers={"Authorization": f"Bearer {expired_token}"}
+        )
+        assert resp.status_code == 401

--- a/backend/tests/api/test_story_api.py
+++ b/backend/tests/api/test_story_api.py
@@ -71,3 +71,110 @@ class TestStoryListingAPI:
         assert resp.status_code == 200
         data = resp.json()
         assert data == {"stories": [], "total": 0}
+
+
+@pytest.mark.asyncio
+class TestStoryMediaUploadAPI:
+    async def _create_user_and_token(self, client):
+        await client.post(
+            "/auth/register",
+            json={
+                "username": "mediauser",
+                "email": "media@example.com",
+                "password": "MediaPass1!",
+            },
+        )
+        login_resp = await client.post(
+            "/auth/login",
+            json={
+                "email": "media@example.com",
+                "password": "MediaPass1!",
+            },
+        )
+        return login_resp.json()["access_token"]
+
+    async def test_upload_media_success(self, client, db_session, monkeypatch):
+        token = await self._create_user_and_token(client)
+
+        user = User(
+            username="storyowner",
+            email="storyowner@example.com",
+            password_hash=hash_password("StoryOwner1!"),
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        story = Story(
+            user_id=user.id,
+            title="Story with media",
+            summary="summary",
+            content="content",
+            status=StoryStatus.PUBLISHED,
+            visibility=StoryVisibility.PUBLIC,
+        )
+        db_session.add(story)
+        await db_session.commit()
+
+        monkeypatch.setattr("app.services.story_service.upload_bytes", lambda **kwargs: None)
+
+        resp = await client.post(
+            f"/stories/{story.id}/media",
+            headers={"Authorization": f"Bearer {token}"},
+            data={
+                "media_type": "image",
+                "alt_text": "alt",
+                "caption": "caption",
+                "sort_order": "1",
+            },
+            files={"file": ("photo.png", b"png-bytes", "image/png")},
+        )
+
+        assert resp.status_code == 201
+        payload = resp.json()
+        media = payload["media"]
+        assert media["story_id"] == str(story.id)
+        assert media["original_filename"] == "photo.png"
+        assert media["mime_type"] == "image/png"
+        assert media["media_type"] == "image"
+        assert media["file_size_bytes"] == len(b"png-bytes")
+        assert media["sort_order"] == 1
+        assert media["alt_text"] == "alt"
+        assert media["caption"] == "caption"
+        assert "id" in media
+        assert "storage_key" in media
+        assert "bucket_name" in media
+        assert "created_at" in media
+
+    async def test_upload_media_invalid_mime_type(self, client, db_session, monkeypatch):
+        token = await self._create_user_and_token(client)
+
+        user = User(
+            username="storyowner2",
+            email="storyowner2@example.com",
+            password_hash=hash_password("StoryOwner2!"),
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        story = Story(
+            user_id=user.id,
+            title="Story invalid media",
+            summary="summary",
+            content="content",
+            status=StoryStatus.PUBLISHED,
+            visibility=StoryVisibility.PUBLIC,
+        )
+        db_session.add(story)
+        await db_session.commit()
+
+        monkeypatch.setattr("app.services.story_service.upload_bytes", lambda **kwargs: None)
+
+        resp = await client.post(
+            f"/stories/{story.id}/media",
+            headers={"Authorization": f"Bearer {token}"},
+            data={"media_type": "image"},
+            files={"file": ("clip.mp4", b"video-bytes", "video/mp4")},
+        )
+
+        assert resp.status_code == 422
+        assert "Unsupported mime type" in resp.json()["detail"]

--- a/backend/tests/api/test_story_api.py
+++ b/backend/tests/api/test_story_api.py
@@ -74,6 +74,73 @@ class TestStoryListingAPI:
         data = resp.json()
         assert data == {"stories": [], "total": 0}
 
+    async def test_list_stories_with_bounds_filters_results(self, client, db_session):
+        user = User(
+            username="mapauthor",
+            email="mapauthor@example.com",
+            password_hash=hash_password("StoryPass1!"),
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        in_bounds_story = Story(
+            user_id=user.id,
+            title="In Bounds",
+            summary="Visible in viewport",
+            content="content",
+            status=StoryStatus.PUBLISHED,
+            visibility=StoryVisibility.PUBLIC,
+            place_name="Istanbul",
+            latitude=41.00,
+            longitude=29.00,
+        )
+        out_bounds_story = Story(
+            user_id=user.id,
+            title="Out Bounds",
+            summary="Outside viewport",
+            content="content",
+            status=StoryStatus.PUBLISHED,
+            visibility=StoryVisibility.PUBLIC,
+            place_name="Ankara",
+            latitude=39.93,
+            longitude=32.85,
+        )
+        null_coord_story = Story(
+            user_id=user.id,
+            title="Null Coord",
+            summary="No location",
+            content="content",
+            status=StoryStatus.PUBLISHED,
+            visibility=StoryVisibility.PUBLIC,
+            place_name="Unknown",
+            latitude=None,
+            longitude=None,
+        )
+        db_session.add_all([in_bounds_story, out_bounds_story, null_coord_story])
+        await db_session.commit()
+
+        resp = await client.get(
+            "/stories?min_lat=40.9&max_lat=41.1&min_lng=28.9&max_lng=29.1"
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert len(data["stories"]) == 1
+        assert data["stories"][0]["title"] == "In Bounds"
+
+    async def test_list_stories_with_incomplete_bounds_returns_422(self, client):
+        resp = await client.get("/stories?min_lat=40.9&max_lat=41.1")
+
+        assert resp.status_code == 422
+
+    async def test_list_stories_with_invalid_bounds_order_returns_422(self, client):
+        resp = await client.get(
+            "/stories?min_lat=41.1&max_lat=40.9&min_lng=28.9&max_lng=29.1"
+        )
+
+        assert resp.status_code == 422
+
 
 @pytest.mark.asyncio
 class TestStoryMediaUploadAPI:

--- a/backend/tests/api/test_story_api.py
+++ b/backend/tests/api/test_story_api.py
@@ -212,7 +212,6 @@ class TestStoryMediaUploadAPI:
         assert "id" in media
         assert "storage_key" in media
         assert "bucket_name" in media
-        assert media["media_url"].endswith(f'/{media["bucket_name"]}/{media["storage_key"]}')
         assert "created_at" in media
 
     async def test_upload_media_invalid_mime_type(self, client, db_session, monkeypatch):
@@ -314,7 +313,6 @@ class TestStoryDetailAPI:
         assert media_item["mime_type"] == "image/png"
         assert media_item["media_type"] == "image"
         assert media_item["file_size_bytes"] == 777
-        assert media_item["media_url"].endswith("/images/stories/test/photo.png")
 
     async def test_get_story_detail_not_found(self, client):
         resp = await client.get(f"/stories/{uuid.uuid4()}")

--- a/backend/tests/api/test_story_api.py
+++ b/backend/tests/api/test_story_api.py
@@ -145,6 +145,7 @@ class TestStoryMediaUploadAPI:
         assert "id" in media
         assert "storage_key" in media
         assert "bucket_name" in media
+        assert media["media_url"].endswith(f'/{media["bucket_name"]}/{media["storage_key"]}')
         assert "created_at" in media
 
     async def test_upload_media_invalid_mime_type(self, client, db_session, monkeypatch):
@@ -246,6 +247,7 @@ class TestStoryDetailAPI:
         assert media_item["mime_type"] == "image/png"
         assert media_item["media_type"] == "image"
         assert media_item["file_size_bytes"] == 777
+        assert media_item["media_url"].endswith("/images/stories/test/photo.png")
 
     async def test_get_story_detail_not_found(self, client):
         resp = await client.get(f"/stories/{uuid.uuid4()}")

--- a/backend/tests/api/test_story_api.py
+++ b/backend/tests/api/test_story_api.py
@@ -253,3 +253,76 @@ class TestStoryDetailAPI:
         assert resp.status_code == 404
         data = resp.json()
         assert data["detail"] == "Story not found"
+
+
+@pytest.mark.asyncio
+class TestStoryCreateAPI:
+    async def _create_user_and_token(self, client):
+        await client.post(
+            "/auth/register",
+            json={
+                "username": "createuser",
+                "email": "create@example.com",
+                "password": "CreatePass1!",
+            },
+        )
+        login_resp = await client.post(
+            "/auth/login",
+            json={
+                "email": "create@example.com",
+                "password": "CreatePass1!",
+            },
+        )
+        return login_resp.json()["access_token"]
+
+    async def test_create_story_with_location_success(self, client):
+        token = await self._create_user_and_token(client)
+
+        resp = await client.post(
+            "/stories",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "title": "Created Story",
+                "content": "Created content",
+                "summary": "Created summary",
+                "place_name": "Istanbul",
+                "latitude": 41.0082,
+                "longitude": 28.9784,
+                "date_start": 1453,
+                "date_end": 1453,
+            },
+        )
+
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["title"] == "Created Story"
+        assert data["content"] == "Created content"
+        assert data["summary"] == "Created summary"
+        assert data["author"] == "createuser"
+        assert data["place_name"] == "Istanbul"
+        assert data["latitude"] == 41.0082
+        assert data["longitude"] == 28.9784
+        assert data["date_label"] == "1453 - 1453"
+        assert data["status"] == "draft"
+        assert data["visibility"] == "private"
+        assert data["media_files"] == []
+        assert "id" in data
+        assert "created_at" in data
+
+    async def test_create_story_with_blank_place_name_returns_422(self, client):
+        token = await self._create_user_and_token(client)
+
+        resp = await client.post(
+            "/stories",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "title": "Created Story",
+                "content": "Created content",
+                "place_name": "   ",
+                "latitude": 41.0082,
+                "longitude": 28.9784,
+            },
+        )
+
+        assert resp.status_code == 422
+        assert "place_name is required" in resp.json()["detail"]

--- a/backend/tests/api/test_story_api.py
+++ b/backend/tests/api/test_story_api.py
@@ -1,0 +1,73 @@
+import pytest
+
+from app.db.enums import StoryStatus, StoryVisibility
+from app.db.story import Story
+from app.db.user import User
+from app.services.auth_service import hash_password
+
+
+@pytest.mark.asyncio
+class TestStoryListingAPI:
+    async def test_list_stories_success(self, client, db_session):
+        user = User(
+            username="storyauthor",
+            email="storyauthor@example.com",
+            password_hash=hash_password("StoryPass1!"),
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        published_public_story = Story(
+            user_id=user.id,
+            title="Published Story",
+            summary="A short summary",
+            content="Story content",
+            status=StoryStatus.PUBLISHED,
+            visibility=StoryVisibility.PUBLIC,
+            place_name="Istanbul",
+            latitude=41.0082,
+            longitude=28.9784,
+            date_start=1453,
+            date_end=1453,
+        )
+        hidden_story = Story(
+            user_id=user.id,
+            title="Draft Story",
+            summary="Should not be listed",
+            content="Draft content",
+            status=StoryStatus.DRAFT,
+            visibility=StoryVisibility.PRIVATE,
+        )
+        db_session.add_all([published_public_story, hidden_story])
+        await db_session.commit()
+
+        resp = await client.get("/stories")
+
+        assert resp.status_code == 200
+        data = resp.json()
+
+        assert data["total"] == 1
+        assert len(data["stories"]) == 1
+
+        item = data["stories"][0]
+        assert item["title"] == "Published Story"
+        assert item["summary"] == "A short summary"
+        assert item["content"] == "Story content"
+        assert item["author"] == "storyauthor"
+        assert item["place_name"] == "Istanbul"
+        assert item["latitude"] == 41.0082
+        assert item["longitude"] == 28.9784
+        assert item["date_start"] == 1453
+        assert item["date_end"] == 1453
+        assert item["date_label"] == "1453 - 1453"
+        assert item["status"] == "published"
+        assert item["visibility"] == "public"
+        assert "id" in item
+        assert "created_at" in item
+
+    async def test_list_stories_empty(self, client):
+        resp = await client.get("/stories")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data == {"stories": [], "total": 0}

--- a/backend/tests/api/test_story_api.py
+++ b/backend/tests/api/test_story_api.py
@@ -326,3 +326,154 @@ class TestStoryCreateAPI:
 
         assert resp.status_code == 422
         assert "place_name is required" in resp.json()["detail"]
+
+    async def test_create_story_with_single_start_date_returns_single_date_label(self, client):
+        token = await self._create_user_and_token(client)
+
+        resp = await client.post(
+            "/stories",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "title": "Created Story",
+                "content": "Created content",
+                "summary": "Created summary",
+                "place_name": "Istanbul",
+                "latitude": 41.0082,
+                "longitude": 28.9784,
+                "date_start": 1453,
+            },
+        )
+
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["date_start"] == 1453
+        assert data["date_end"] is None
+        assert data["date_label"] == "1453"
+
+
+@pytest.mark.asyncio
+class TestStoryUpdateAPI:
+    async def _create_user_and_token(self, client):
+        await client.post(
+            "/auth/register",
+            json={
+                "username": "updateuser",
+                "email": "update@example.com",
+                "password": "UpdatePass1!",
+            },
+        )
+        login_resp = await client.post(
+            "/auth/login",
+            json={
+                "email": "update@example.com",
+                "password": "UpdatePass1!",
+            },
+        )
+        return login_resp.json()["access_token"]
+
+    async def test_update_story_success(self, client):
+        token = await self._create_user_and_token(client)
+
+        create_resp = await client.post(
+            "/stories",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "title": "Original Story",
+                "content": "Original content",
+                "summary": "Original summary",
+                "place_name": "Istanbul",
+                "latitude": 41.0082,
+                "longitude": 28.9784,
+                "date_start": 1400,
+                "date_end": 1453,
+            },
+        )
+        assert create_resp.status_code == 201
+        story_id = create_resp.json()["id"]
+
+        update_resp = await client.put(
+            f"/stories/{story_id}",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "title": "Updated Story",
+                "content": "Updated content",
+                "summary": "Updated summary",
+                "place_name": "Ankara",
+                "latitude": 39.9334,
+                "longitude": 32.8597,
+                "date_start": 1920,
+                "date_end": 1923,
+            },
+        )
+
+        assert update_resp.status_code == 200
+        data = update_resp.json()
+        assert data["id"] == story_id
+        assert data["title"] == "Updated Story"
+        assert data["content"] == "Updated content"
+        assert data["summary"] == "Updated summary"
+        assert data["place_name"] == "Ankara"
+        assert data["latitude"] == 39.9334
+        assert data["longitude"] == 32.8597
+        assert data["date_start"] == 1920
+        assert data["date_end"] == 1923
+        assert data["date_label"] == "1920 - 1923"
+
+    async def test_update_story_invalid_date_range_returns_422(self, client):
+        token = await self._create_user_and_token(client)
+
+        create_resp = await client.post(
+            "/stories",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "title": "Original Story",
+                "content": "Original content",
+                "summary": "Original summary",
+                "place_name": "Istanbul",
+                "latitude": 41.0082,
+                "longitude": 28.9784,
+                "date_start": 1400,
+                "date_end": 1453,
+            },
+        )
+        assert create_resp.status_code == 201
+        story_id = create_resp.json()["id"]
+
+        update_resp = await client.put(
+            f"/stories/{story_id}",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "title": "Updated Story",
+                "content": "Updated content",
+                "summary": "Updated summary",
+                "place_name": "Ankara",
+                "latitude": 39.9334,
+                "longitude": 32.8597,
+                "date_start": 1923,
+                "date_end": 1920,
+            },
+        )
+
+        assert update_resp.status_code == 422
+        assert "date_end must be greater than or equal to date_start" in str(update_resp.json())
+
+    async def test_update_story_not_found_returns_404(self, client):
+        token = await self._create_user_and_token(client)
+
+        update_resp = await client.put(
+            f"/stories/{uuid.uuid4()}",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "title": "Updated Story",
+                "content": "Updated content",
+                "summary": "Updated summary",
+                "place_name": "Ankara",
+                "latitude": 39.9334,
+                "longitude": 32.8597,
+                "date_start": 1920,
+                "date_end": 1923,
+            },
+        )
+
+        assert update_resp.status_code == 404
+        assert update_resp.json()["detail"] == "Story not found"

--- a/backend/tests/api/test_story_api.py
+++ b/backend/tests/api/test_story_api.py
@@ -212,6 +212,7 @@ class TestStoryMediaUploadAPI:
         assert "id" in media
         assert "storage_key" in media
         assert "bucket_name" in media
+        assert media["media_url"].endswith(f'/{media["bucket_name"]}/{media["storage_key"]}')
         assert "created_at" in media
 
     async def test_upload_media_invalid_mime_type(self, client, db_session, monkeypatch):
@@ -313,6 +314,7 @@ class TestStoryDetailAPI:
         assert media_item["mime_type"] == "image/png"
         assert media_item["media_type"] == "image"
         assert media_item["file_size_bytes"] == 777
+        assert media_item["media_url"].endswith("/images/stories/test/photo.png")
 
     async def test_get_story_detail_not_found(self, client):
         resp = await client.get(f"/stories/{uuid.uuid4()}")

--- a/backend/tests/api/test_story_api.py
+++ b/backend/tests/api/test_story_api.py
@@ -303,8 +303,8 @@ class TestStoryCreateAPI:
         assert data["latitude"] == 41.0082
         assert data["longitude"] == 28.9784
         assert data["date_label"] == "1453 - 1453"
-        assert data["status"] == "draft"
-        assert data["visibility"] == "private"
+        assert data["status"] == "published"
+        assert data["visibility"] == "public"
         assert data["media_files"] == []
         assert "id" in data
         assert "created_at" in data

--- a/backend/tests/api/test_story_api.py
+++ b/backend/tests/api/test_story_api.py
@@ -1,6 +1,8 @@
 import pytest
+import uuid
 
-from app.db.enums import StoryStatus, StoryVisibility
+from app.db.enums import MediaType, StoryStatus, StoryVisibility
+from app.db.media_file import MediaFile
 from app.db.story import Story
 from app.db.user import User
 from app.services.auth_service import hash_password
@@ -178,3 +180,76 @@ class TestStoryMediaUploadAPI:
 
         assert resp.status_code == 422
         assert "Unsupported mime type" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+class TestStoryDetailAPI:
+    async def test_get_story_detail_success(self, client, db_session):
+        user = User(
+            username="detailauthor",
+            email="detailauthor@example.com",
+            password_hash=hash_password("DetailPass1!"),
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        story = Story(
+            user_id=user.id,
+            title="Detail Story",
+            summary="Detail summary",
+            content="Detail content",
+            status=StoryStatus.PUBLISHED,
+            visibility=StoryVisibility.PUBLIC,
+            place_name="Ankara",
+            latitude=39.9334,
+            longitude=32.8597,
+            date_start=1923,
+            date_end=1923,
+        )
+        db_session.add(story)
+        await db_session.flush()
+
+        media = MediaFile(
+            story_id=story.id,
+            bucket_name="images",
+            storage_key="stories/test/photo.png",
+            original_filename="photo.png",
+            mime_type="image/png",
+            media_type=MediaType.IMAGE,
+            file_size_bytes=777,
+            sort_order=0,
+            alt_text="test alt",
+            caption="test caption",
+        )
+        db_session.add(media)
+        await db_session.commit()
+
+        resp = await client.get(f"/stories/{story.id}")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["id"] == str(story.id)
+        assert data["title"] == "Detail Story"
+        assert data["summary"] == "Detail summary"
+        assert data["content"] == "Detail content"
+        assert data["author"] == "detailauthor"
+        assert data["place_name"] == "Ankara"
+        assert data["date_label"] == "1923 - 1923"
+        assert data["status"] == "published"
+        assert data["visibility"] == "public"
+        assert "created_at" in data
+
+        assert len(data["media_files"]) == 1
+        media_item = data["media_files"][0]
+        assert media_item["story_id"] == str(story.id)
+        assert media_item["original_filename"] == "photo.png"
+        assert media_item["mime_type"] == "image/png"
+        assert media_item["media_type"] == "image"
+        assert media_item["file_size_bytes"] == 777
+
+    async def test_get_story_detail_not_found(self, client):
+        resp = await client.get(f"/stories/{uuid.uuid4()}")
+
+        assert resp.status_code == 404
+        data = resp.json()
+        assert data["detail"] == "Story not found"

--- a/backend/tests/api/test_story_api.py
+++ b/backend/tests/api/test_story_api.py
@@ -1,7 +1,8 @@
 import pytest
 import uuid
+from datetime import date
 
-from app.db.enums import MediaType, StoryStatus, StoryVisibility
+from app.db.enums import DatePrecision, MediaType, StoryStatus, StoryVisibility
 from app.db.media_file import MediaFile
 from app.db.story import Story
 from app.db.user import User
@@ -29,8 +30,9 @@ class TestStoryListingAPI:
             place_name="Istanbul",
             latitude=41.0082,
             longitude=28.9784,
-            date_start=1453,
-            date_end=1453,
+            date_start=date(1453, 1, 1),
+            date_end=date(1453, 12, 31),
+            date_precision=DatePrecision.YEAR,
         )
         hidden_story = Story(
             user_id=user.id,
@@ -59,9 +61,10 @@ class TestStoryListingAPI:
         assert item["place_name"] == "Istanbul"
         assert item["latitude"] == 41.0082
         assert item["longitude"] == 28.9784
-        assert item["date_start"] == 1453
-        assert item["date_end"] == 1453
-        assert item["date_label"] == "1453 - 1453"
+        assert item["date_start"] == "1453-01-01"
+        assert item["date_end"] == "1453-12-31"
+        assert item["date_precision"] == "year"
+        assert item["date_label"] == "1453"
         assert item["status"] == "published"
         assert item["visibility"] == "public"
         assert "id" in item
@@ -128,6 +131,55 @@ class TestStoryListingAPI:
         assert data["total"] == 1
         assert len(data["stories"]) == 1
         assert data["stories"][0]["title"] == "In Bounds"
+
+    async def test_list_stories_with_date_overlap_filters_results(self, client, db_session):
+        user = User(
+            username="timeauthor",
+            email="timeauthor@example.com",
+            password_hash=hash_password("StoryPass1!"),
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        in_range_story = Story(
+            user_id=user.id,
+            title="Year 2025 Story",
+            summary="story in 2025",
+            content="content",
+            status=StoryStatus.PUBLISHED,
+            visibility=StoryVisibility.PUBLIC,
+            place_name="Istanbul",
+            latitude=41.00,
+            longitude=29.00,
+            date_start=date(2025, 1, 1),
+            date_end=date(2025, 12, 31),
+            date_precision=DatePrecision.YEAR,
+        )
+        out_range_story = Story(
+            user_id=user.id,
+            title="Year 1800 Story",
+            summary="story in 1800",
+            content="content",
+            status=StoryStatus.PUBLISHED,
+            visibility=StoryVisibility.PUBLIC,
+            place_name="Ankara",
+            latitude=39.93,
+            longitude=32.85,
+            date_start=date(1800, 1, 1),
+            date_end=date(1800, 12, 31),
+            date_precision=DatePrecision.YEAR,
+        )
+        db_session.add_all([in_range_story, out_range_story])
+        await db_session.commit()
+
+        resp = await client.get(
+            "/stories?query_start=2025-08-01&query_end=2025-08-31&query_precision=date"
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["stories"][0]["title"] == "Year 2025 Story"
 
     async def test_list_stories_with_incomplete_bounds_returns_422(self, client):
         resp = await client.get("/stories?min_lat=40.9&max_lat=41.1")
@@ -270,8 +322,9 @@ class TestStoryDetailAPI:
             place_name="Ankara",
             latitude=39.9334,
             longitude=32.8597,
-            date_start=1923,
-            date_end=1923,
+            date_start=date(1923, 1, 1),
+            date_end=date(1923, 12, 31),
+            date_precision=DatePrecision.YEAR,
         )
         db_session.add(story)
         await db_session.flush()
@@ -301,7 +354,10 @@ class TestStoryDetailAPI:
         assert data["content"] == "Detail content"
         assert data["author"] == "detailauthor"
         assert data["place_name"] == "Ankara"
-        assert data["date_label"] == "1923 - 1923"
+        assert data["date_start"] == "1923-01-01"
+        assert data["date_end"] == "1923-12-31"
+        assert data["date_precision"] == "year"
+        assert data["date_label"] == "1923"
         assert data["status"] == "published"
         assert data["visibility"] == "public"
         assert "created_at" in data
@@ -369,7 +425,10 @@ class TestStoryCreateAPI:
         assert data["place_name"] == "Istanbul"
         assert data["latitude"] == 41.0082
         assert data["longitude"] == 28.9784
-        assert data["date_label"] == "1453 - 1453"
+        assert data["date_start"] == "1453-01-01"
+        assert data["date_end"] == "1453-12-31"
+        assert data["date_precision"] == "year"
+        assert data["date_label"] == "1453"
         assert data["status"] == "published"
         assert data["visibility"] == "public"
         assert data["media_files"] == []
@@ -413,8 +472,9 @@ class TestStoryCreateAPI:
 
         assert resp.status_code == 201
         data = resp.json()
-        assert data["date_start"] == 1453
-        assert data["date_end"] is None
+        assert data["date_start"] == "1453-01-01"
+        assert data["date_end"] == "1453-12-31"
+        assert data["date_precision"] == "year"
         assert data["date_label"] == "1453"
 
 
@@ -482,8 +542,9 @@ class TestStoryUpdateAPI:
         assert data["place_name"] == "Ankara"
         assert data["latitude"] == 39.9334
         assert data["longitude"] == 32.8597
-        assert data["date_start"] == 1920
-        assert data["date_end"] == 1923
+        assert data["date_start"] == "1920-01-01"
+        assert data["date_end"] == "1923-12-31"
+        assert data["date_precision"] == "year"
         assert data["date_label"] == "1920 - 1923"
 
     async def test_update_story_invalid_date_range_returns_422(self, client):

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,70 @@
+from unittest.mock import MagicMock
+
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.core.config import settings
+from app.db.base import Base
+from app.db.session import get_db
+
+# Import all models so Base.metadata knows about them
+from app.db.user import User  # noqa: F401
+from app.db.story import Story  # noqa: F401
+from app.db.media_file import MediaFile  # noqa: F401
+
+
+# Build the async DB URL
+_url = settings.DATABASE_URL
+if _url.startswith("postgresql://"):
+    _url = _url.replace("postgresql://", "postgresql+asyncpg://", 1)
+elif _url.startswith("postgres://"):
+    _url = _url.replace("postgres://", "postgresql+asyncpg://", 1)
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    """Provide a per-test engine + session so everything shares one event loop."""
+    engine = create_async_engine(_url, echo=False)
+
+    # Create tables
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    session_factory = async_sessionmaker(
+        bind=engine, class_=AsyncSession, expire_on_commit=False
+    )
+    session = session_factory()
+
+    yield session
+
+    # Teardown: close session, drop tables, dispose engine
+    await session.close()
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def client(db_session):
+    """Async HTTP client wired to the FastAPI app with test DB session."""
+    from app.main import app
+
+    # Override storage check so tests don't need MinIO
+    from app.services import storage
+    original_check = storage.check_connection
+    storage.check_connection = MagicMock()
+
+    async def _override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override_get_db
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as ac:
+        yield ac
+
+    app.dependency_overrides.clear()
+    storage.check_connection = original_check

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -27,8 +27,10 @@ async def db_session():
     """Provide a per-test engine + session so everything shares one event loop."""
     engine = create_async_engine(_url, echo=False)
 
-    # Create tables
+    # Reset the schema first so stale tables from earlier runs don't survive
+    # and silently bypass new columns added to the ORM models.
     async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
         await conn.run_sync(Base.metadata.create_all)
 
     session_factory = async_sessionmaker(

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -27,10 +27,8 @@ async def db_session():
     """Provide a per-test engine + session so everything shares one event loop."""
     engine = create_async_engine(_url, echo=False)
 
-    # Reset the schema first so stale tables from earlier runs don't survive
-    # and silently bypass new columns added to the ORM models.
+    # Create tables
     async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.drop_all)
         await conn.run_sync(Base.metadata.create_all)
 
     session_factory = async_sessionmaker(

--- a/backend/tests/factories/__init__.py
+++ b/backend/tests/factories/__init__.py
@@ -1,0 +1,1 @@
+"""Reusable test factories for backend tests."""

--- a/backend/tests/factories/media_file_factory.py
+++ b/backend/tests/factories/media_file_factory.py
@@ -1,0 +1,69 @@
+import uuid
+from io import BytesIO
+
+from starlette.datastructures import Headers, UploadFile
+
+from app.db.enums import MediaType
+from app.db.media_file import MediaFile
+
+# Minimal valid PNG (67-byte 1×1 pixel) — small enough to be fast,
+# valid enough to pass content-type checks in the upload flow.
+_MINIMAL_PNG = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01"
+    b"\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde\x00\x00"
+    b"\x00\x0cIDATx\x9cc\xf8\x0f\x00\x00\x01\x01\x00\x05\x18"
+    b"\xd8N\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+DEFAULT_FILENAME = "test_photo.png"
+DEFAULT_CONTENT_TYPE = "image/png"
+DEFAULT_BUCKET_NAME = "images"
+DEFAULT_STORAGE_KEY_PREFIX = "stories"
+
+
+def make_upload_file(
+    *,
+    filename: str = DEFAULT_FILENAME,
+    content: bytes = _MINIMAL_PNG,
+    content_type: str = DEFAULT_CONTENT_TYPE,
+) -> UploadFile:
+    """Return an in-memory UploadFile for use in service-level unit tests.
+
+    No real file or cloud storage is involved — the content lives entirely
+    in a BytesIO buffer, so tests stay fast and isolated.
+    """
+    return UploadFile(
+        file=BytesIO(content),
+        filename=filename,
+        headers=Headers({"content-type": content_type}),
+    )
+
+
+def make_media_file_entity(
+    *,
+    story_id: uuid.UUID,
+    bucket_name: str = DEFAULT_BUCKET_NAME,
+    storage_key: str | None = None,
+    original_filename: str = DEFAULT_FILENAME,
+    mime_type: str = DEFAULT_CONTENT_TYPE,
+    media_type: MediaType = MediaType.IMAGE,
+    file_size_bytes: int = len(_MINIMAL_PNG),
+    sort_order: int = 0,
+    alt_text: str | None = None,
+    caption: str | None = None,
+) -> MediaFile:
+    """Return a MediaFile ORM object for direct insertion into a test DB session."""
+    if storage_key is None:
+        storage_key = f"{DEFAULT_STORAGE_KEY_PREFIX}/{story_id}/media/{uuid.uuid4()}.png"
+    return MediaFile(
+        story_id=story_id,
+        bucket_name=bucket_name,
+        storage_key=storage_key,
+        original_filename=original_filename,
+        mime_type=mime_type,
+        media_type=media_type,
+        file_size_bytes=file_size_bytes,
+        sort_order=sort_order,
+        alt_text=alt_text,
+        caption=caption,
+    )

--- a/backend/tests/factories/story_factory.py
+++ b/backend/tests/factories/story_factory.py
@@ -1,6 +1,7 @@
 import uuid
+from datetime import date
 
-from app.db.enums import StoryStatus, StoryVisibility
+from app.db.enums import DatePrecision, StoryStatus, StoryVisibility
 from app.db.story import Story
 
 # Fixed default coordinates: Çeliktepe, Istanbul — used as the primary
@@ -11,8 +12,16 @@ DEFAULT_SUMMARY = "A childhood memory from the Çeliktepe neighbourhood of Istan
 DEFAULT_PLACE_NAME = "Çeliktepe, Istanbul"
 DEFAULT_LATITUDE = 41.0739
 DEFAULT_LONGITUDE = 28.9606
+
+# Payload defaults: integers, because StoryCreateRequest accepts year integers
+# and normalises them internally before writing to the DB.
 DEFAULT_DATE_START = 1960
 DEFAULT_DATE_END = 1980
+
+# Entity defaults: full date objects, because the Story ORM column is DATE.
+# Year-precision stories are stored as Jan 1 (start) and Dec 31 (end).
+DEFAULT_ENTITY_DATE_START = date(1960, 1, 1)
+DEFAULT_ENTITY_DATE_END = date(1980, 12, 31)
 
 
 def make_story_payload(
@@ -84,13 +93,20 @@ def make_story_entity(
     place_name: str | None = DEFAULT_PLACE_NAME,
     latitude: float | None = DEFAULT_LATITUDE,
     longitude: float | None = DEFAULT_LONGITUDE,
-    date_start: int | None = DEFAULT_DATE_START,
-    date_end: int | None = DEFAULT_DATE_END,
+    date_start: date | None = DEFAULT_ENTITY_DATE_START,
+    date_end: date | None = DEFAULT_ENTITY_DATE_END,
+    date_precision: DatePrecision | None = DatePrecision.YEAR,
     status: StoryStatus = StoryStatus.PUBLISHED,
     visibility: StoryVisibility = StoryVisibility.PUBLIC,
     suffix: int | str | None = None,
 ) -> Story:
-    """Return a Story ORM object for direct insertion into a test DB session."""
+    """Return a Story ORM object for direct insertion into a test DB session.
+
+    date_start and date_end must be Python date objects matching the DATE
+    column type. Use year-precision stories as: date(1960, 1, 1) / date(1980, 12, 31).
+    The payload factories (make_story_payload) accept integers — that is correct
+    because StoryCreateRequest normalises them before writing to the DB.
+    """
     if suffix is not None:
         title = f"{title} {suffix}"
         if place_name is not None:
@@ -105,6 +121,7 @@ def make_story_entity(
         longitude=longitude,
         date_start=date_start,
         date_end=date_end,
+        date_precision=date_precision,
         status=status,
         visibility=visibility,
     )

--- a/backend/tests/factories/story_factory.py
+++ b/backend/tests/factories/story_factory.py
@@ -1,0 +1,110 @@
+import uuid
+
+from app.db.enums import StoryStatus, StoryVisibility
+from app.db.story import Story
+
+# Fixed default coordinates: Çeliktepe, Istanbul — used as the primary
+# demo location and kept constant so map-related tests are deterministic.
+DEFAULT_TITLE = "A Story from Çeliktepe"
+DEFAULT_CONTENT = "Children used to play in the narrow streets between the gecekondu houses."
+DEFAULT_SUMMARY = "A childhood memory from the Çeliktepe neighbourhood of Istanbul."
+DEFAULT_PLACE_NAME = "Çeliktepe, Istanbul"
+DEFAULT_LATITUDE = 41.0739
+DEFAULT_LONGITUDE = 28.9606
+DEFAULT_DATE_START = 1960
+DEFAULT_DATE_END = 1980
+
+
+def make_story_payload(
+    *,
+    title: str = DEFAULT_TITLE,
+    content: str = DEFAULT_CONTENT,
+    summary: str | None = DEFAULT_SUMMARY,
+    place_name: str = DEFAULT_PLACE_NAME,
+    latitude: float = DEFAULT_LATITUDE,
+    longitude: float = DEFAULT_LONGITUDE,
+    date_start: int | None = DEFAULT_DATE_START,
+    date_end: int | None = DEFAULT_DATE_END,
+    suffix: int | str | None = None,
+) -> dict:
+    """Return a dict that matches StoryCreateRequest, for use in API-level tests."""
+    if suffix is not None:
+        title = f"{title} {suffix}"
+        place_name = f"{place_name} {suffix}"
+    payload = {
+        "title": title,
+        "content": content,
+        "place_name": place_name,
+        "latitude": latitude,
+        "longitude": longitude,
+    }
+    if summary is not None:
+        payload["summary"] = summary
+    if date_start is not None:
+        payload["date_start"] = date_start
+    if date_end is not None:
+        payload["date_end"] = date_end
+    return payload
+
+
+def make_story_update_payload(
+    *,
+    title: str = "An Updated Story from Çeliktepe",
+    content: str = "The neighbourhood changed a lot after the 1980s.",
+    summary: str | None = "An updated memory from Çeliktepe.",
+    place_name: str = DEFAULT_PLACE_NAME,
+    latitude: float = DEFAULT_LATITUDE,
+    longitude: float = DEFAULT_LONGITUDE,
+    date_start: int | None = DEFAULT_DATE_START,
+    date_end: int | None = DEFAULT_DATE_END,
+) -> dict:
+    """Return a dict that matches StoryUpdateRequest, for use in update API tests."""
+    payload = {
+        "title": title,
+        "content": content,
+        "place_name": place_name,
+        "latitude": latitude,
+        "longitude": longitude,
+    }
+    if summary is not None:
+        payload["summary"] = summary
+    if date_start is not None:
+        payload["date_start"] = date_start
+    if date_end is not None:
+        payload["date_end"] = date_end
+    return payload
+
+
+def make_story_entity(
+    *,
+    user_id: uuid.UUID,
+    title: str = DEFAULT_TITLE,
+    content: str = DEFAULT_CONTENT,
+    summary: str | None = DEFAULT_SUMMARY,
+    place_name: str | None = DEFAULT_PLACE_NAME,
+    latitude: float | None = DEFAULT_LATITUDE,
+    longitude: float | None = DEFAULT_LONGITUDE,
+    date_start: int | None = DEFAULT_DATE_START,
+    date_end: int | None = DEFAULT_DATE_END,
+    status: StoryStatus = StoryStatus.PUBLISHED,
+    visibility: StoryVisibility = StoryVisibility.PUBLIC,
+    suffix: int | str | None = None,
+) -> Story:
+    """Return a Story ORM object for direct insertion into a test DB session."""
+    if suffix is not None:
+        title = f"{title} {suffix}"
+        if place_name is not None:
+            place_name = f"{place_name} {suffix}"
+    return Story(
+        user_id=user_id,
+        title=title,
+        content=content,
+        summary=summary,
+        place_name=place_name,
+        latitude=latitude,
+        longitude=longitude,
+        date_start=date_start,
+        date_end=date_end,
+        status=status,
+        visibility=visibility,
+    )

--- a/backend/tests/factories/user_factory.py
+++ b/backend/tests/factories/user_factory.py
@@ -9,13 +9,31 @@ DEFAULT_PASSWORD = "ValidPass1!"
 DEFAULT_DISPLAY_NAME = "Test User"
 
 
+def _with_suffix(base_value: str, suffix: int | str | None) -> str:
+    if suffix is None:
+        return base_value
+    return f"{base_value}{suffix}"
+
+
+def _email_with_suffix(base_email: str, suffix: int | str | None) -> str:
+    if suffix is None:
+        return base_email
+    local, at, domain = base_email.partition("@")
+    if at:
+        return f"{local}+{suffix}@{domain}"
+    return f"{base_email}{suffix}"
+
+
 def make_user_payload(
     *,
     username: str = DEFAULT_USERNAME,
     email: str = DEFAULT_EMAIL,
     password: str = DEFAULT_PASSWORD,
     display_name: str | None = DEFAULT_DISPLAY_NAME,
+    suffix: int | str | None = None,
 ) -> dict:
+    username = _with_suffix(username, suffix)
+    email = _email_with_suffix(email, suffix)
     payload = {
         "username": username,
         "email": email,
@@ -30,7 +48,9 @@ def make_login_payload(
     *,
     email: str = DEFAULT_EMAIL,
     password: str = DEFAULT_PASSWORD,
+    suffix: int | str | None = None,
 ) -> dict:
+    email = _email_with_suffix(email, suffix)
     return {
         "email": email,
         "password": password,
@@ -47,7 +67,10 @@ def make_user_entity(
     bio: str | None = None,
     is_active: bool = True,
     password_hash: str | None = None,
+    suffix: int | str | None = None,
 ) -> User:
+    username = _with_suffix(username, suffix)
+    email = _email_with_suffix(email, suffix)
     return User(
         username=username,
         email=email,

--- a/backend/tests/factories/user_factory.py
+++ b/backend/tests/factories/user_factory.py
@@ -1,0 +1,59 @@
+from app.db.enums import UserRole
+from app.db.user import User
+from app.services.auth_service import hash_password
+
+
+DEFAULT_USERNAME = "testuser"
+DEFAULT_EMAIL = "test@example.com"
+DEFAULT_PASSWORD = "ValidPass1!"
+DEFAULT_DISPLAY_NAME = "Test User"
+
+
+def make_user_payload(
+    *,
+    username: str = DEFAULT_USERNAME,
+    email: str = DEFAULT_EMAIL,
+    password: str = DEFAULT_PASSWORD,
+    display_name: str | None = DEFAULT_DISPLAY_NAME,
+) -> dict:
+    payload = {
+        "username": username,
+        "email": email,
+        "password": password,
+    }
+    if display_name is not None:
+        payload["display_name"] = display_name
+    return payload
+
+
+def make_login_payload(
+    *,
+    email: str = DEFAULT_EMAIL,
+    password: str = DEFAULT_PASSWORD,
+) -> dict:
+    return {
+        "email": email,
+        "password": password,
+    }
+
+
+def make_user_entity(
+    *,
+    username: str = DEFAULT_USERNAME,
+    email: str = DEFAULT_EMAIL,
+    password: str = DEFAULT_PASSWORD,
+    role: UserRole = UserRole.USER,
+    display_name: str | None = DEFAULT_DISPLAY_NAME,
+    bio: str | None = None,
+    is_active: bool = True,
+    password_hash: str | None = None,
+) -> User:
+    return User(
+        username=username,
+        email=email,
+        password_hash=password_hash or hash_password(password),
+        display_name=display_name,
+        bio=bio,
+        role=role,
+        is_active=is_active,
+    )

--- a/backend/tests/integration/test_auth_flow.py
+++ b/backend/tests/integration/test_auth_flow.py
@@ -1,0 +1,104 @@
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+
+from app.db.user import User
+from app.models.user import UserLoginRequest, UserRegisterRequest
+from app.services.auth_service import login_user, register_user, verify_password
+
+
+@pytest.mark.asyncio
+class TestRegisterAndLoginFlow:
+    """Integration test: register a user, then log in. Covers #113."""
+
+    async def test_register_then_login(self, db_session):
+        # Register
+        reg_payload = UserRegisterRequest(
+            username="flowuser",
+            email="flow@example.com",
+            password="FlowPass1!",
+        )
+        user_resp = await register_user(db_session, reg_payload)
+        assert user_resp.username == "flowuser"
+        assert user_resp.email == "flow@example.com"
+
+        # Verify password stored as hash
+        result = await db_session.execute(
+            select(User).where(User.email == "flow@example.com")
+        )
+        db_user = result.scalar_one()
+        assert db_user.password_hash != "FlowPass1!"
+        assert verify_password("FlowPass1!", db_user.password_hash) is True
+
+        # Login
+        login_payload = UserLoginRequest(
+            email="flow@example.com", password="FlowPass1!"
+        )
+        token_resp = await login_user(db_session, login_payload)
+        assert token_resp.access_token is not None
+        assert token_resp.token_type == "bearer"
+
+
+@pytest.mark.asyncio
+class TestDuplicateEmailRejection:
+    """Integration test: duplicate email is rejected. Covers #115."""
+
+    async def test_duplicate_email_raises_409(self, db_session):
+        payload = UserRegisterRequest(
+            username="user1",
+            email="dupe@example.com",
+            password="ValidPass1!",
+        )
+        await register_user(db_session, payload)
+
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            payload2 = UserRegisterRequest(
+                username="user2",
+                email="dupe@example.com",
+                password="ValidPass1!",
+            )
+            await register_user(db_session, payload2)
+        assert exc_info.value.status_code == 409
+        assert "Email already registered" in exc_info.value.detail
+
+        # Confirm no duplicate user record was created
+        from sqlalchemy import func
+
+        count = await db_session.execute(
+            select(func.count()).where(User.email == "dupe@example.com")
+        )
+        assert count.scalar_one() == 1
+
+
+@pytest.mark.asyncio
+class TestInvalidCredentialsRejection:
+    """Integration test: invalid credentials are rejected. Covers #116."""
+
+    async def test_wrong_password_raises_401(self, db_session):
+        payload = UserRegisterRequest(
+            username="creduser",
+            email="cred@example.com",
+            password="ValidPass1!",
+        )
+        await register_user(db_session, payload)
+
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            login_payload = UserLoginRequest(
+                email="cred@example.com", password="WrongPass1!"
+            )
+            await login_user(db_session, login_payload)
+        assert exc_info.value.status_code == 401
+
+    async def test_nonexistent_email_raises_401(self, db_session):
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            login_payload = UserLoginRequest(
+                email="nobody@example.com", password="AnyPass1!"
+            )
+            await login_user(db_session, login_payload)
+        assert exc_info.value.status_code == 401

--- a/backend/tests/integration/test_story_time_filter_flow.py
+++ b/backend/tests/integration/test_story_time_filter_flow.py
@@ -1,0 +1,50 @@
+import pytest
+
+
+@pytest.mark.asyncio
+class TestStoryTimeOverlapFlow:
+    async def _create_user_and_token(self, client):
+        await client.post(
+            "/auth/register",
+            json={
+                "username": "timelineuser",
+                "email": "timeline@example.com",
+                "password": "TimelinePass1!",
+            },
+        )
+        login_resp = await client.post(
+            "/auth/login",
+            json={
+                "email": "timeline@example.com",
+                "password": "TimelinePass1!",
+            },
+        )
+        return login_resp.json()["access_token"]
+
+    async def test_year_story_overlaps_date_query(self, client):
+        token = await self._create_user_and_token(client)
+
+        create_resp = await client.post(
+            "/stories",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "title": "Story in 2025",
+                "content": "content",
+                "summary": "summary",
+                "place_name": "Istanbul",
+                "latitude": 41.0082,
+                "longitude": 28.9784,
+                "date_start": 2025,
+                "date_end": 2025,
+            },
+        )
+        assert create_resp.status_code == 201
+
+        list_resp = await client.get(
+            "/stories?query_start=2025-08-01&query_end=2025-08-31&query_precision=date"
+        )
+
+        assert list_resp.status_code == 200
+        payload = list_resp.json()
+        assert payload["total"] == 1
+        assert payload["stories"][0]["title"] == "Story in 2025"

--- a/backend/tests/unit/test_jwt.py
+++ b/backend/tests/unit/test_jwt.py
@@ -1,0 +1,80 @@
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import jwt
+import pytest
+
+from app.core.config import settings
+from app.services.auth_service import create_access_token, hash_password, verify_password
+
+
+class TestPasswordHashing:
+    def test_hash_and_verify(self):
+        password = "TestPass1!"
+        hashed = hash_password(password)
+        assert hashed != password
+        assert verify_password(password, hashed) is True
+
+    def test_wrong_password_fails(self):
+        hashed = hash_password("TestPass1!")
+        assert verify_password("WrongPass1!", hashed) is False
+
+    def test_hash_is_not_deterministic(self):
+        h1 = hash_password("TestPass1!")
+        h2 = hash_password("TestPass1!")
+        assert h1 != h2  # bcrypt uses random salt
+
+
+class TestJWTTokenCreation:
+    def _make_mock_user(self):
+        user = MagicMock()
+        user.id = uuid.uuid4()
+        user.email = "test@example.com"
+        user.role.value = "user"
+        return user
+
+    def test_token_contains_correct_claims(self):
+        user = self._make_mock_user()
+        token = create_access_token(user)
+        payload = jwt.decode(
+            token, settings.JWT_SECRET_KEY, algorithms=[settings.JWT_ALGORITHM]
+        )
+        assert payload["sub"] == str(user.id)
+        assert payload["email"] == "test@example.com"
+        assert payload["role"] == "user"
+        assert "exp" in payload
+
+    def test_token_has_expiration(self):
+        user = self._make_mock_user()
+        token = create_access_token(user)
+        payload = jwt.decode(
+            token, settings.JWT_SECRET_KEY, algorithms=[settings.JWT_ALGORITHM]
+        )
+        exp = datetime.fromtimestamp(payload["exp"], tz=timezone.utc)
+        now = datetime.now(timezone.utc)
+        assert exp > now
+        assert exp <= now + timedelta(minutes=settings.JWT_EXPIRE_MINUTES + 1)
+
+    def test_token_is_verifiable(self):
+        user = self._make_mock_user()
+        token = create_access_token(user)
+        # Should not raise
+        jwt.decode(
+            token, settings.JWT_SECRET_KEY, algorithms=[settings.JWT_ALGORITHM]
+        )
+
+    def test_token_fails_with_wrong_secret(self):
+        user = self._make_mock_user()
+        token = create_access_token(user)
+        with pytest.raises(jwt.InvalidSignatureError):
+            jwt.decode(token, "wrong-secret", algorithms=[settings.JWT_ALGORITHM])
+
+    def test_token_does_not_contain_password(self):
+        user = self._make_mock_user()
+        token = create_access_token(user)
+        payload = jwt.decode(
+            token, settings.JWT_SECRET_KEY, algorithms=[settings.JWT_ALGORITHM]
+        )
+        assert "password" not in payload
+        assert "password_hash" not in payload

--- a/backend/tests/unit/test_media_file_factory.py
+++ b/backend/tests/unit/test_media_file_factory.py
@@ -1,0 +1,120 @@
+import uuid
+
+from starlette.datastructures import UploadFile
+
+from app.db.enums import MediaType
+from app.db.media_file import MediaFile
+from tests.factories.media_file_factory import (
+    DEFAULT_BUCKET_NAME,
+    DEFAULT_CONTENT_TYPE,
+    DEFAULT_FILENAME,
+    make_media_file_entity,
+    make_upload_file,
+)
+
+
+class TestMakeUploadFile:
+    def test_returns_upload_file_instance(self):
+        upload = make_upload_file()
+        assert isinstance(upload, UploadFile)
+
+    def test_defaults_are_a_valid_png(self):
+        upload = make_upload_file()
+        assert upload.filename == DEFAULT_FILENAME
+        assert upload.content_type == DEFAULT_CONTENT_TYPE
+
+    def test_content_is_readable_and_non_empty(self):
+        upload = make_upload_file()
+        content = upload.file.read()
+        assert len(content) > 0
+
+    def test_filename_override(self):
+        upload = make_upload_file(filename="archive.jpg", content_type="image/jpeg")
+        assert upload.filename == "archive.jpg"
+        assert upload.content_type == "image/jpeg"
+
+    def test_content_override(self):
+        custom_bytes = b"fake-audio-data"
+        upload = make_upload_file(
+            filename="clip.mp3",
+            content=custom_bytes,
+            content_type="audio/mpeg",
+        )
+        assert upload.file.read() == custom_bytes
+
+    def test_each_call_produces_independent_buffer(self):
+        u1 = make_upload_file()
+        u2 = make_upload_file()
+        # Reading one should not affect the other
+        u1.file.read()
+        assert len(u2.file.read()) > 0
+
+    def test_no_external_dependencies(self):
+        # Simply constructing the upload file must not raise — confirming
+        # no network or filesystem access occurs.
+        upload = make_upload_file()
+        assert upload is not None
+
+
+class TestMakeMediaFileEntity:
+    def test_returns_media_file_instance(self):
+        story_id = uuid.uuid4()
+        media = make_media_file_entity(story_id=story_id)
+        assert isinstance(media, MediaFile)
+
+    def test_story_id_is_set_correctly(self):
+        story_id = uuid.uuid4()
+        media = make_media_file_entity(story_id=story_id)
+        assert media.story_id == story_id
+
+    def test_defaults_match_factory_constants(self):
+        story_id = uuid.uuid4()
+        media = make_media_file_entity(story_id=story_id)
+        assert media.bucket_name == DEFAULT_BUCKET_NAME
+        assert media.original_filename == DEFAULT_FILENAME
+        assert media.mime_type == DEFAULT_CONTENT_TYPE
+        assert media.media_type == MediaType.IMAGE
+        assert media.file_size_bytes > 0
+        assert media.sort_order == 0
+
+    def test_storage_key_is_auto_generated_and_unique(self):
+        story_id = uuid.uuid4()
+        m1 = make_media_file_entity(story_id=story_id)
+        m2 = make_media_file_entity(story_id=story_id)
+        assert m1.storage_key != m2.storage_key
+
+    def test_storage_key_contains_story_id(self):
+        story_id = uuid.uuid4()
+        media = make_media_file_entity(story_id=story_id)
+        assert str(story_id) in media.storage_key
+
+    def test_custom_storage_key_is_respected(self):
+        story_id = uuid.uuid4()
+        custom_key = "stories/custom/path/file.png"
+        media = make_media_file_entity(story_id=story_id, storage_key=custom_key)
+        assert media.storage_key == custom_key
+
+    def test_field_overrides_are_applied(self):
+        story_id = uuid.uuid4()
+        media = make_media_file_entity(
+            story_id=story_id,
+            original_filename="voice_memo.mp3",
+            mime_type="audio/mpeg",
+            media_type=MediaType.AUDIO,
+            file_size_bytes=5000,
+            sort_order=2,
+            alt_text="A voice recording",
+            caption="Recorded in 1978",
+        )
+        assert media.original_filename == "voice_memo.mp3"
+        assert media.mime_type == "audio/mpeg"
+        assert media.media_type == MediaType.AUDIO
+        assert media.file_size_bytes == 5000
+        assert media.sort_order == 2
+        assert media.alt_text == "A voice recording"
+        assert media.caption == "Recorded in 1978"
+
+    def test_optional_fields_default_to_none(self):
+        media = make_media_file_entity(story_id=uuid.uuid4())
+        assert media.alt_text is None
+        assert media.caption is None

--- a/backend/tests/unit/test_password_validation.py
+++ b/backend/tests/unit/test_password_validation.py
@@ -1,0 +1,47 @@
+import pytest
+from pydantic import ValidationError
+
+from app.models.user import UserRegisterRequest
+
+
+def _make_payload(**overrides):
+    base = {
+        "username": "testuser",
+        "email": "test@example.com",
+        "password": "ValidPass1!",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestPasswordStrengthValidation:
+    def test_valid_password(self):
+        req = UserRegisterRequest(**_make_payload(password="StrongPass1!"))
+        assert req.password == "StrongPass1!"
+
+    def test_missing_uppercase(self):
+        with pytest.raises(ValidationError, match="one uppercase letter"):
+            UserRegisterRequest(**_make_payload(password="weakpass1!"))
+
+    def test_missing_lowercase(self):
+        with pytest.raises(ValidationError, match="one lowercase letter"):
+            UserRegisterRequest(**_make_payload(password="ALLCAPS1!"))
+
+    def test_missing_digit(self):
+        with pytest.raises(ValidationError, match="one digit"):
+            UserRegisterRequest(**_make_payload(password="NoDigits!"))
+
+    def test_missing_special_character(self):
+        with pytest.raises(ValidationError, match="one special character"):
+            UserRegisterRequest(**_make_payload(password="NoSpecial1"))
+
+    def test_too_short(self):
+        with pytest.raises(ValidationError):
+            UserRegisterRequest(**_make_payload(password="Sh1!"))
+
+    def test_multiple_missing(self):
+        with pytest.raises(ValidationError, match="one uppercase letter") as exc_info:
+            UserRegisterRequest(**_make_payload(password="nouppernodigit"))
+        error_msg = str(exc_info.value)
+        assert "one digit" in error_msg
+        assert "one special character" in error_msg

--- a/backend/tests/unit/test_schemas.py
+++ b/backend/tests/unit/test_schemas.py
@@ -1,0 +1,56 @@
+import pytest
+from pydantic import ValidationError
+
+from app.models.user import UserRegisterRequest, UserLoginRequest
+
+
+class TestUserRegisterRequestSchema:
+    def test_valid_payload(self):
+        req = UserRegisterRequest(
+            username="john", email="john@example.com", password="MyPass1!"
+        )
+        assert req.username == "john"
+        assert req.email == "john@example.com"
+
+    def test_username_too_short(self):
+        with pytest.raises(ValidationError):
+            UserRegisterRequest(
+                username="ab", email="a@b.com", password="MyPass1!"
+            )
+
+    def test_username_too_long(self):
+        with pytest.raises(ValidationError):
+            UserRegisterRequest(
+                username="a" * 51, email="a@b.com", password="MyPass1!"
+            )
+
+    def test_invalid_email(self):
+        with pytest.raises(ValidationError):
+            UserRegisterRequest(
+                username="john", email="not-an-email", password="MyPass1!"
+            )
+
+    def test_display_name_optional(self):
+        req = UserRegisterRequest(
+            username="john", email="john@example.com", password="MyPass1!"
+        )
+        assert req.display_name is None
+
+    def test_display_name_provided(self):
+        req = UserRegisterRequest(
+            username="john",
+            email="john@example.com",
+            password="MyPass1!",
+            display_name="John Doe",
+        )
+        assert req.display_name == "John Doe"
+
+
+class TestUserLoginRequestSchema:
+    def test_valid_payload(self):
+        req = UserLoginRequest(email="john@example.com", password="anypass")
+        assert req.email == "john@example.com"
+
+    def test_invalid_email(self):
+        with pytest.raises(ValidationError):
+            UserLoginRequest(email="bad", password="anypass")

--- a/backend/tests/unit/test_schemas.py
+++ b/backend/tests/unit/test_schemas.py
@@ -1,7 +1,9 @@
 import pytest
+from datetime import date
 from pydantic import ValidationError
 
-from app.models.story import StoryCreateRequest, StoryUpdateRequest
+from app.db.enums import DatePrecision
+from app.models.story import StoryCreateRequest, StoryDateRangeFilter, StoryUpdateRequest
 from app.models.user import UserRegisterRequest, UserLoginRequest
 
 
@@ -74,6 +76,10 @@ class TestStoryDateSchemaValidation:
 
         assert req.date_start == 1400
         assert req.date_end == 1453
+        normalized_start, normalized_end, normalized_precision = req.normalize_date_range()
+        assert normalized_start == date(1400, 1, 1)
+        assert normalized_end == date(1453, 12, 31)
+        assert normalized_precision == DatePrecision.YEAR
 
     def test_create_accepts_single_date_start_only(self):
         payload = self._base_story_payload() | {"date_start": 1453, "date_end": None}
@@ -81,6 +87,19 @@ class TestStoryDateSchemaValidation:
 
         assert req.date_start == 1453
         assert req.date_end is None
+        normalized_start, normalized_end, normalized_precision = req.normalize_date_range()
+        assert normalized_start == date(1453, 1, 1)
+        assert normalized_end == date(1453, 12, 31)
+        assert normalized_precision == DatePrecision.YEAR
+
+    def test_create_accepts_single_exact_date(self):
+        payload = self._base_story_payload() | {"date_start": "1453-05-29"}
+        req = StoryCreateRequest(**payload)
+
+        normalized_start, normalized_end, normalized_precision = req.normalize_date_range()
+        assert normalized_start == date(1453, 5, 29)
+        assert normalized_end == date(1453, 5, 29)
+        assert normalized_precision == DatePrecision.DATE
 
     def test_create_rejects_invalid_date_range(self):
         payload = self._base_story_payload() | {"date_start": 1453, "date_end": 1400}
@@ -95,6 +114,24 @@ class TestStoryDateSchemaValidation:
         with pytest.raises(ValidationError):
             StoryCreateRequest(**payload)
 
+    def test_create_rejects_mixed_type_range(self):
+        payload = self._base_story_payload() | {
+            "date_start": 1453,
+            "date_end": "1453-05-29",
+        }
+
+        with pytest.raises(ValidationError, match="must use the same type"):
+            StoryCreateRequest(**payload)
+
+    def test_create_rejects_wrong_precision_for_date_inputs(self):
+        payload = self._base_story_payload() | {
+            "date_start": "1453-05-29",
+            "date_precision": "year",
+        }
+
+        with pytest.raises(ValidationError, match="must be 'date'"):
+            StoryCreateRequest(**payload)
+
     def test_update_accepts_valid_date_range(self):
         payload = self._base_story_payload() | {"date_start": 1900, "date_end": 1910}
         req = StoryUpdateRequest(**payload)
@@ -107,3 +144,21 @@ class TestStoryDateSchemaValidation:
 
         with pytest.raises(ValidationError, match="date_end must be greater than or equal to date_start"):
             StoryUpdateRequest(**payload)
+
+
+class TestStoryDateRangeFilter:
+    def test_normalizes_year_query_range(self):
+        req = StoryDateRangeFilter(query_start=2025, query_end=2025)
+        normalized_start, normalized_end, precision = req.normalize_query_range()
+
+        assert normalized_start == date(2025, 1, 1)
+        assert normalized_end == date(2025, 12, 31)
+        assert precision == DatePrecision.YEAR
+
+    def test_normalizes_date_query_range(self):
+        req = StoryDateRangeFilter(query_start="2025-08-01", query_end="2025-08-31")
+        normalized_start, normalized_end, precision = req.normalize_query_range()
+
+        assert normalized_start == date(2025, 8, 1)
+        assert normalized_end == date(2025, 8, 31)
+        assert precision == DatePrecision.DATE

--- a/backend/tests/unit/test_schemas.py
+++ b/backend/tests/unit/test_schemas.py
@@ -1,6 +1,7 @@
 import pytest
 from pydantic import ValidationError
 
+from app.models.story import StoryCreateRequest, StoryUpdateRequest
 from app.models.user import UserRegisterRequest, UserLoginRequest
 
 
@@ -54,3 +55,55 @@ class TestUserLoginRequestSchema:
     def test_invalid_email(self):
         with pytest.raises(ValidationError):
             UserLoginRequest(email="bad", password="anypass")
+
+
+class TestStoryDateSchemaValidation:
+    def _base_story_payload(self) -> dict:
+        return {
+            "title": "Conquest of Constantinople",
+            "content": "Historical event details",
+            "summary": "A key turning point",
+            "latitude": 41.0082,
+            "longitude": 28.9784,
+            "place_name": "Istanbul",
+        }
+
+    def test_create_accepts_valid_date_range(self):
+        payload = self._base_story_payload() | {"date_start": 1400, "date_end": 1453}
+        req = StoryCreateRequest(**payload)
+
+        assert req.date_start == 1400
+        assert req.date_end == 1453
+
+    def test_create_accepts_single_date_start_only(self):
+        payload = self._base_story_payload() | {"date_start": 1453, "date_end": None}
+        req = StoryCreateRequest(**payload)
+
+        assert req.date_start == 1453
+        assert req.date_end is None
+
+    def test_create_rejects_invalid_date_range(self):
+        payload = self._base_story_payload() | {"date_start": 1453, "date_end": 1400}
+
+        with pytest.raises(ValidationError, match="date_end must be greater than or equal to date_start"):
+            StoryCreateRequest(**payload)
+
+    @pytest.mark.parametrize("field_name, field_value", [("date_start", 0), ("date_end", 10000)])
+    def test_create_rejects_out_of_bounds_dates(self, field_name: str, field_value: int):
+        payload = self._base_story_payload() | {field_name: field_value}
+
+        with pytest.raises(ValidationError):
+            StoryCreateRequest(**payload)
+
+    def test_update_accepts_valid_date_range(self):
+        payload = self._base_story_payload() | {"date_start": 1900, "date_end": 1910}
+        req = StoryUpdateRequest(**payload)
+
+        assert req.date_start == 1900
+        assert req.date_end == 1910
+
+    def test_update_rejects_invalid_date_range(self):
+        payload = self._base_story_payload() | {"date_start": 1910, "date_end": 1900}
+
+        with pytest.raises(ValidationError, match="date_end must be greater than or equal to date_start"):
+            StoryUpdateRequest(**payload)

--- a/backend/tests/unit/test_story_factory.py
+++ b/backend/tests/unit/test_story_factory.py
@@ -1,12 +1,15 @@
 import uuid
+from datetime import date
 
 import pytest
 
-from app.db.enums import StoryStatus, StoryVisibility
+from app.db.enums import DatePrecision, StoryStatus, StoryVisibility
 from app.db.story import Story
 from tests.factories.story_factory import (
     DEFAULT_DATE_END,
     DEFAULT_DATE_START,
+    DEFAULT_ENTITY_DATE_END,
+    DEFAULT_ENTITY_DATE_START,
     DEFAULT_LATITUDE,
     DEFAULT_LONGITUDE,
     DEFAULT_PLACE_NAME,
@@ -100,8 +103,17 @@ class TestMakeStoryEntity:
         assert story.place_name == DEFAULT_PLACE_NAME
         assert story.latitude == DEFAULT_LATITUDE
         assert story.longitude == DEFAULT_LONGITUDE
-        assert story.date_start == DEFAULT_DATE_START
-        assert story.date_end == DEFAULT_DATE_END
+        assert story.date_start == DEFAULT_ENTITY_DATE_START
+        assert story.date_end == DEFAULT_ENTITY_DATE_END
+
+    def test_default_dates_are_date_objects(self):
+        story = make_story_entity(user_id=uuid.uuid4())
+        assert isinstance(story.date_start, date)
+        assert isinstance(story.date_end, date)
+
+    def test_default_date_precision_is_year(self):
+        story = make_story_entity(user_id=uuid.uuid4())
+        assert story.date_precision == DatePrecision.YEAR
 
     def test_default_status_is_published_and_public(self):
         story = make_story_entity(user_id=uuid.uuid4())
@@ -122,14 +134,26 @@ class TestMakeStoryEntity:
             title="Override Title",
             status=StoryStatus.DRAFT,
             visibility=StoryVisibility.PRIVATE,
-            date_start=1970,
-            date_end=1975,
+            date_start=date(1970, 1, 1),
+            date_end=date(1975, 12, 31),
+            date_precision=DatePrecision.YEAR,
         )
         assert story.title == "Override Title"
         assert story.status == StoryStatus.DRAFT
         assert story.visibility == StoryVisibility.PRIVATE
-        assert story.date_start == 1970
-        assert story.date_end == 1975
+        assert story.date_start == date(1970, 1, 1)
+        assert story.date_end == date(1975, 12, 31)
+        assert story.date_precision == DatePrecision.YEAR
+
+    def test_exact_date_precision_accepted(self):
+        story = make_story_entity(
+            user_id=uuid.uuid4(),
+            date_start=date(1965, 6, 12),
+            date_end=date(1965, 6, 12),
+            date_precision=DatePrecision.DATE,
+        )
+        assert story.date_start == date(1965, 6, 12)
+        assert story.date_precision == DatePrecision.DATE
 
     def test_optional_fields_can_be_none(self):
         story = make_story_entity(
@@ -140,6 +164,7 @@ class TestMakeStoryEntity:
             longitude=None,
             date_start=None,
             date_end=None,
+            date_precision=None,
         )
         assert story.summary is None
         assert story.place_name is None
@@ -147,3 +172,4 @@ class TestMakeStoryEntity:
         assert story.longitude is None
         assert story.date_start is None
         assert story.date_end is None
+        assert story.date_precision is None

--- a/backend/tests/unit/test_story_factory.py
+++ b/backend/tests/unit/test_story_factory.py
@@ -1,0 +1,149 @@
+import uuid
+
+import pytest
+
+from app.db.enums import StoryStatus, StoryVisibility
+from app.db.story import Story
+from tests.factories.story_factory import (
+    DEFAULT_DATE_END,
+    DEFAULT_DATE_START,
+    DEFAULT_LATITUDE,
+    DEFAULT_LONGITUDE,
+    DEFAULT_PLACE_NAME,
+    DEFAULT_TITLE,
+    make_story_entity,
+    make_story_payload,
+    make_story_update_payload,
+)
+
+
+class TestMakeStoryPayload:
+    def test_defaults_produce_valid_create_request_fields(self):
+        payload = make_story_payload()
+        assert payload["title"] == DEFAULT_TITLE
+        assert payload["place_name"] == DEFAULT_PLACE_NAME
+        assert payload["latitude"] == DEFAULT_LATITUDE
+        assert payload["longitude"] == DEFAULT_LONGITUDE
+        assert payload["date_start"] == DEFAULT_DATE_START
+        assert payload["date_end"] == DEFAULT_DATE_END
+        assert "content" in payload
+
+    def test_coordinates_are_within_valid_bounds(self):
+        payload = make_story_payload()
+        assert -90.0 <= payload["latitude"] <= 90.0
+        assert -180.0 <= payload["longitude"] <= 180.0
+
+    def test_date_range_is_valid(self):
+        payload = make_story_payload()
+        assert payload["date_start"] <= payload["date_end"]
+
+    def test_suffix_makes_title_and_place_name_unique(self):
+        p1 = make_story_payload(suffix=1)
+        p2 = make_story_payload(suffix=2)
+        assert p1["title"] != p2["title"]
+        assert p1["place_name"] != p2["place_name"]
+
+    def test_field_overrides_are_applied(self):
+        payload = make_story_payload(
+            title="Custom Title",
+            place_name="Beyoğlu, Istanbul",
+            latitude=41.0335,
+            longitude=28.9775,
+            date_start=1950,
+            date_end=1960,
+        )
+        assert payload["title"] == "Custom Title"
+        assert payload["place_name"] == "Beyoğlu, Istanbul"
+        assert payload["latitude"] == 41.0335
+        assert payload["longitude"] == 28.9775
+        assert payload["date_start"] == 1950
+        assert payload["date_end"] == 1960
+
+    def test_optional_summary_omitted_when_none(self):
+        payload = make_story_payload(summary=None)
+        assert "summary" not in payload
+
+    def test_optional_dates_omitted_when_none(self):
+        payload = make_story_payload(date_start=None, date_end=None)
+        assert "date_start" not in payload
+        assert "date_end" not in payload
+
+
+class TestMakeStoryUpdatePayload:
+    def test_defaults_produce_valid_update_fields(self):
+        payload = make_story_update_payload()
+        assert "title" in payload
+        assert "content" in payload
+        assert "place_name" in payload
+        assert "latitude" in payload
+        assert "longitude" in payload
+
+    def test_field_overrides_are_applied(self):
+        payload = make_story_update_payload(
+            title="Updated Title",
+            place_name="Karaköy, Istanbul",
+        )
+        assert payload["title"] == "Updated Title"
+        assert payload["place_name"] == "Karaköy, Istanbul"
+
+
+class TestMakeStoryEntity:
+    def test_returns_story_instance(self):
+        story = make_story_entity(user_id=uuid.uuid4())
+        assert isinstance(story, Story)
+
+    def test_defaults_match_factory_constants(self):
+        user_id = uuid.uuid4()
+        story = make_story_entity(user_id=user_id)
+        assert story.user_id == user_id
+        assert story.title == DEFAULT_TITLE
+        assert story.place_name == DEFAULT_PLACE_NAME
+        assert story.latitude == DEFAULT_LATITUDE
+        assert story.longitude == DEFAULT_LONGITUDE
+        assert story.date_start == DEFAULT_DATE_START
+        assert story.date_end == DEFAULT_DATE_END
+
+    def test_default_status_is_published_and_public(self):
+        story = make_story_entity(user_id=uuid.uuid4())
+        assert story.status == StoryStatus.PUBLISHED
+        assert story.visibility == StoryVisibility.PUBLIC
+
+    def test_suffix_makes_title_and_place_name_unique(self):
+        uid = uuid.uuid4()
+        s1 = make_story_entity(user_id=uid, suffix=1)
+        s2 = make_story_entity(user_id=uid, suffix=2)
+        assert s1.title != s2.title
+        assert s1.place_name != s2.place_name
+
+    def test_field_overrides_are_applied(self):
+        user_id = uuid.uuid4()
+        story = make_story_entity(
+            user_id=user_id,
+            title="Override Title",
+            status=StoryStatus.DRAFT,
+            visibility=StoryVisibility.PRIVATE,
+            date_start=1970,
+            date_end=1975,
+        )
+        assert story.title == "Override Title"
+        assert story.status == StoryStatus.DRAFT
+        assert story.visibility == StoryVisibility.PRIVATE
+        assert story.date_start == 1970
+        assert story.date_end == 1975
+
+    def test_optional_fields_can_be_none(self):
+        story = make_story_entity(
+            user_id=uuid.uuid4(),
+            summary=None,
+            place_name=None,
+            latitude=None,
+            longitude=None,
+            date_start=None,
+            date_end=None,
+        )
+        assert story.summary is None
+        assert story.place_name is None
+        assert story.latitude is None
+        assert story.longitude is None
+        assert story.date_start is None
+        assert story.date_end is None

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -247,6 +247,8 @@ class TestGetStoryDetailByIdService:
         assert len(result.media_files) == 2
         assert result.media_files[0].original_filename == "photo1.png"
         assert result.media_files[1].original_filename == "photo2.png"
+        assert result.media_files[0].media_url.endswith("/images/stories/key.png")
+        assert result.media_files[1].media_url.endswith("/images/stories/key.png")
         db.execute.assert_awaited_once()
 
     async def test_raises_404_when_story_not_found(self):

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime, timezone
 from io import BytesIO
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
@@ -147,7 +147,14 @@ class TestUploadMediaForStoryService:
         file = _make_upload_file("photo.png", b"fake-image-bytes", "image/png")
 
         db = AsyncMock()
+        db.add = MagicMock()
         db.execute.return_value.scalar_one_or_none = lambda: story
+
+        async def _refresh_side_effect(media_obj):
+            media_obj.id = uuid.uuid4()
+            media_obj.created_at = datetime.now(timezone.utc)
+
+        db.refresh.side_effect = _refresh_side_effect
 
         with patch("app.services.story_service.upload_bytes") as mock_upload:
             result = await upload_media_for_story(db, story_id, file, payload)
@@ -165,6 +172,7 @@ class TestUploadMediaForStoryService:
 
         mock_upload.assert_called_once()
         assert mock_upload.call_args.kwargs["content_type"] == "image/png"
+        db.add.assert_called_once()
         db.commit.assert_awaited_once()
         db.refresh.assert_awaited_once()
 

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -269,6 +269,8 @@ class TestGetStoryDetailByIdService:
         assert len(result.media_files) == 2
         assert result.media_files[0].original_filename == "photo1.png"
         assert result.media_files[1].original_filename == "photo2.png"
+        assert result.media_files[0].media_url.endswith("/images/stories/key.png")
+        assert result.media_files[1].media_url.endswith("/images/stories/key.png")
         db.execute.assert_awaited_once()
 
     async def test_raises_404_when_story_not_found(self):

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -281,8 +281,8 @@ class TestCreateStoryWithLocationService:
         async def _refresh_side_effect(story_obj):
             story_obj.id = uuid.uuid4()
             story_obj.created_at = datetime.now(timezone.utc)
-            story_obj.status = StoryStatus.DRAFT
-            story_obj.visibility = StoryVisibility.PRIVATE
+            story_obj.status = StoryStatus.PUBLISHED
+            story_obj.visibility = StoryVisibility.PUBLIC
 
         db.refresh.side_effect = _refresh_side_effect
 
@@ -293,6 +293,8 @@ class TestCreateStoryWithLocationService:
         assert result.place_name == "Istanbul"
         assert result.latitude == 41.0082
         assert result.longitude == 28.9784
+        assert result.status == StoryStatus.PUBLISHED
+        assert result.visibility == StoryVisibility.PUBLIC
         assert result.media_files == []
         db.add.assert_called_once()
         db.commit.assert_awaited_once()

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -9,12 +9,13 @@ from fastapi import HTTPException
 from starlette.datastructures import Headers, UploadFile
 
 from app.db.enums import MediaType, StoryStatus, StoryVisibility
-from app.models.story import MediaUploadRequest, StoryCreateRequest
+from app.models.story import MediaUploadRequest, StoryCreateRequest, StoryUpdateRequest
 from app.services.story_service import (
     create_story_with_location,
     get_story_detail_by_id,
     list_available_stories,
     search_available_stories_by_place,
+    update_story_with_location_and_dates,
     upload_media_for_story,
 )
 
@@ -315,3 +316,88 @@ class TestCreateStoryWithLocationService:
         assert exc_info.value.status_code == 422
         assert "place_name is required" in exc_info.value.detail
         db.add.assert_not_called()
+
+
+@pytest.mark.asyncio
+class TestUpdateStoryWithLocationAndDatesService:
+    async def test_update_story_success(self):
+        story_id = uuid.uuid4()
+        story = _make_story(id=story_id, user_id=uuid.uuid4())
+
+        payload = StoryUpdateRequest(
+            title="Updated Story",
+            content="Updated content",
+            summary="Updated summary",
+            place_name="Ankara",
+            latitude=39.9334,
+            longitude=32.8597,
+            date_start=1920,
+            date_end=1923,
+        )
+        current_user = SimpleNamespace(id=story.user_id, username="authoruser")
+
+        db = AsyncMock()
+        db.execute.return_value.scalar_one_or_none = lambda: story
+
+        result = await update_story_with_location_and_dates(db, story_id, current_user, payload)
+
+        assert result.id == story_id
+        assert result.title == "Updated Story"
+        assert result.content == "Updated content"
+        assert result.summary == "Updated summary"
+        assert result.place_name == "Ankara"
+        assert result.latitude == 39.9334
+        assert result.longitude == 32.8597
+        assert result.date_start == 1920
+        assert result.date_end == 1923
+        assert result.date_label == "1920 - 1923"
+        assert result.media_files == []
+        db.commit.assert_awaited_once()
+        db.refresh.assert_awaited_once_with(story)
+
+    async def test_update_story_not_found(self):
+        payload = StoryUpdateRequest(
+            title="Updated Story",
+            content="Updated content",
+            summary="Updated summary",
+            place_name="Ankara",
+            latitude=39.9334,
+            longitude=32.8597,
+            date_start=1920,
+            date_end=1923,
+        )
+        current_user = SimpleNamespace(id=uuid.uuid4(), username="authoruser")
+
+        db = AsyncMock()
+        db.execute.return_value.scalar_one_or_none = lambda: None
+
+        with pytest.raises(HTTPException) as exc_info:
+            await update_story_with_location_and_dates(db, uuid.uuid4(), current_user, payload)
+
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "Story not found"
+        db.commit.assert_not_awaited()
+
+    async def test_update_story_rejects_blank_place_name(self):
+        story = _make_story(id=uuid.uuid4(), user_id=uuid.uuid4())
+        payload = StoryUpdateRequest(
+            title="Updated Story",
+            content="Updated content",
+            summary="Updated summary",
+            place_name="   ",
+            latitude=39.9334,
+            longitude=32.8597,
+            date_start=1920,
+            date_end=1923,
+        )
+        current_user = SimpleNamespace(id=story.user_id, username="authoruser")
+
+        db = AsyncMock()
+        db.execute.return_value.scalar_one_or_none = lambda: story
+
+        with pytest.raises(HTTPException) as exc_info:
+            await update_story_with_location_and_dates(db, story.id, current_user, payload)
+
+        assert exc_info.value.status_code == 422
+        assert "place_name is required" in exc_info.value.detail
+        db.commit.assert_not_awaited()

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -269,8 +269,6 @@ class TestGetStoryDetailByIdService:
         assert len(result.media_files) == 2
         assert result.media_files[0].original_filename == "photo1.png"
         assert result.media_files[1].original_filename == "photo2.png"
-        assert result.media_files[0].media_url.endswith("/images/stories/key.png")
-        assert result.media_files[1].media_url.endswith("/images/stories/key.png")
         db.execute.assert_awaited_once()
 
     async def test_raises_404_when_story_not_found(self):

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -1,14 +1,19 @@
 import uuid
 from datetime import datetime, timezone
+from io import BytesIO
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
+from fastapi import HTTPException
+from starlette.datastructures import Headers, UploadFile
 
-from app.db.enums import StoryStatus, StoryVisibility
+from app.db.enums import MediaType, StoryStatus, StoryVisibility
+from app.models.story import MediaUploadRequest
 from app.services.story_service import (
     list_available_stories,
     search_available_stories_by_place,
+    upload_media_for_story,
 )
 
 
@@ -29,6 +34,14 @@ def _make_story(**overrides):
     }
     base.update(overrides)
     return SimpleNamespace(**base)
+
+
+def _make_upload_file(filename: str, content: bytes, content_type: str) -> UploadFile:
+    return UploadFile(
+        file=BytesIO(content),
+        filename=filename,
+        headers=Headers({"content-type": content_type}),
+    )
 
 
 @pytest.mark.asyncio
@@ -118,3 +131,68 @@ class TestSearchAvailableStoriesByPlaceService:
         assert result.total == 0
         assert result.stories == []
         db.execute.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+class TestUploadMediaForStoryService:
+    async def test_upload_successful(self):
+        story_id = uuid.uuid4()
+        story = _make_story(id=story_id)
+        payload = MediaUploadRequest(
+            media_type=MediaType.IMAGE,
+            alt_text="an image",
+            caption="caption",
+            sort_order=2,
+        )
+        file = _make_upload_file("photo.png", b"fake-image-bytes", "image/png")
+
+        db = AsyncMock()
+        db.execute.return_value.scalar_one_or_none = lambda: story
+
+        with patch("app.services.story_service.upload_bytes") as mock_upload:
+            result = await upload_media_for_story(db, story_id, file, payload)
+
+        assert result.media.story_id == story_id
+        assert result.media.original_filename == "photo.png"
+        assert result.media.mime_type == "image/png"
+        assert result.media.media_type == MediaType.IMAGE
+        assert result.media.alt_text == "an image"
+        assert result.media.caption == "caption"
+        assert result.media.sort_order == 2
+        assert result.media.file_size_bytes == len(b"fake-image-bytes")
+        assert result.media.storage_key.startswith(f"stories/{story_id}/media/")
+        assert result.media.storage_key.endswith(".png")
+
+        mock_upload.assert_called_once()
+        assert mock_upload.call_args.kwargs["content_type"] == "image/png"
+        db.commit.assert_awaited_once()
+        db.refresh.assert_awaited_once()
+
+    async def test_upload_rejects_unsupported_mime_type(self):
+        payload = MediaUploadRequest(media_type=MediaType.IMAGE)
+        file = _make_upload_file("clip.mp4", b"video-bytes", "video/mp4")
+        db = AsyncMock()
+
+        with patch("app.services.story_service.upload_bytes") as mock_upload:
+            with pytest.raises(HTTPException) as exc_info:
+                await upload_media_for_story(db, uuid.uuid4(), file, payload)
+
+        assert exc_info.value.status_code == 422
+        mock_upload.assert_not_called()
+        db.execute.assert_not_awaited()
+
+    async def test_upload_rejects_empty_file(self):
+        story_id = uuid.uuid4()
+        story = _make_story(id=story_id)
+        payload = MediaUploadRequest(media_type=MediaType.IMAGE)
+        file = _make_upload_file("empty.png", b"", "image/png")
+
+        db = AsyncMock()
+        db.execute.return_value.scalar_one_or_none = lambda: story
+
+        with patch("app.services.story_service.upload_bytes") as mock_upload:
+            with pytest.raises(HTTPException) as exc_info:
+                await upload_media_for_story(db, story_id, file, payload)
+
+        assert exc_info.value.status_code == 400
+        mock_upload.assert_not_called()

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from io import BytesIO
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -8,7 +8,7 @@ import pytest
 from fastapi import HTTPException
 from starlette.datastructures import Headers, UploadFile
 
-from app.db.enums import MediaType, StoryStatus, StoryVisibility
+from app.db.enums import DatePrecision, MediaType, StoryStatus, StoryVisibility
 from app.models.story import MediaUploadRequest, StoryCreateRequest, StoryUpdateRequest
 from app.services.story_service import (
     create_story_with_location,
@@ -29,8 +29,9 @@ def _make_story(**overrides):
         "place_name": "Istanbul",
         "latitude": 41.0082,
         "longitude": 28.9784,
-        "date_start": 1453,
-        "date_end": 1453,
+        "date_start": date(1453, 1, 1),
+        "date_end": date(1453, 12, 31),
+        "date_precision": DatePrecision.YEAR,
         "status": StoryStatus.PUBLISHED,
         "visibility": StoryVisibility.PUBLIC,
         "created_at": datetime.now(timezone.utc),
@@ -88,9 +89,9 @@ class TestListAvailableStoriesService:
         assert item.place_name == "Istanbul"
         assert item.latitude == 41.0082
         assert item.longitude == 28.9784
-        assert item.date_start == 1453
-        assert item.date_end == 1453
-        assert item.date_label == "1453 - 1453"
+        assert item.date_start == date(1453, 1, 1)
+        assert item.date_end == date(1453, 12, 31)
+        assert item.date_label == "1453"
         assert item.status == StoryStatus.PUBLISHED
         assert item.visibility == StoryVisibility.PUBLIC
         assert item.created_at == story.created_at
@@ -144,6 +145,24 @@ class TestListAvailableStoriesService:
         assert "stories.longitude >=" in sql
         assert "stories.longitude <=" in sql
 
+    async def test_query_includes_date_overlap_filters_when_query_range_provided(self):
+        db = AsyncMock()
+        db.execute.return_value.all = lambda: []
+
+        await list_available_stories(
+            db,
+            query_start=date(2025, 8, 1),
+            query_end=date(2025, 8, 31),
+        )
+
+        stmt = db.execute.await_args.args[0]
+        sql = str(stmt)
+
+        assert "stories.date_start IS NOT NULL" in sql
+        assert "stories.date_end IS NOT NULL" in sql
+        assert "stories.date_start <=" in sql
+        assert "stories.date_end >=" in sql
+
 
 @pytest.mark.asyncio
 class TestSearchAvailableStoriesByPlaceService:
@@ -175,6 +194,23 @@ class TestSearchAvailableStoriesByPlaceService:
         assert result.total == 0
         assert result.stories == []
         db.execute.assert_awaited_once()
+
+    async def test_search_query_includes_date_overlap_filters(self):
+        db = AsyncMock()
+        db.execute.return_value.all = lambda: []
+
+        await search_available_stories_by_place(
+            db,
+            "ankara",
+            query_start=date(1900, 1, 1),
+            query_end=date(1950, 12, 31),
+        )
+
+        stmt = db.execute.await_args.args[0]
+        sql = str(stmt)
+
+        assert "stories.date_start <=" in sql
+        assert "stories.date_end >=" in sql
 
 
 @pytest.mark.asyncio
@@ -315,6 +351,9 @@ class TestCreateStoryWithLocationService:
         assert result.place_name == "Istanbul"
         assert result.latitude == 41.0082
         assert result.longitude == 28.9784
+        assert result.date_start == date(1453, 1, 1)
+        assert result.date_end == date(1453, 12, 31)
+        assert result.date_precision == DatePrecision.YEAR
         assert result.status == StoryStatus.PUBLISHED
         assert result.visibility == StoryVisibility.PUBLIC
         assert result.media_files == []
@@ -372,8 +411,9 @@ class TestUpdateStoryWithLocationAndDatesService:
         assert result.place_name == "Ankara"
         assert result.latitude == 39.9334
         assert result.longitude == 32.8597
-        assert result.date_start == 1920
-        assert result.date_end == 1923
+        assert result.date_start == date(1920, 1, 1)
+        assert result.date_end == date(1923, 12, 31)
+        assert result.date_precision == DatePrecision.YEAR
         assert result.date_label == "1920 - 1923"
         assert result.media_files == []
         db.commit.assert_awaited_once()

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -11,6 +11,7 @@ from starlette.datastructures import Headers, UploadFile
 from app.db.enums import MediaType, StoryStatus, StoryVisibility
 from app.models.story import MediaUploadRequest
 from app.services.story_service import (
+    get_story_detail_by_id,
     list_available_stories,
     search_available_stories_by_place,
     upload_media_for_story,
@@ -42,6 +43,25 @@ def _make_upload_file(filename: str, content: bytes, content_type: str) -> Uploa
         filename=filename,
         headers=Headers({"content-type": content_type}),
     )
+
+
+def _make_media_file(**overrides):
+    base = {
+        "id": uuid.uuid4(),
+        "story_id": uuid.uuid4(),
+        "bucket_name": "images",
+        "storage_key": "stories/key.png",
+        "original_filename": "key.png",
+        "mime_type": "image/png",
+        "media_type": MediaType.IMAGE,
+        "file_size_bytes": 1234,
+        "sort_order": 0,
+        "alt_text": None,
+        "caption": None,
+        "created_at": datetime.now(timezone.utc),
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
 
 
 @pytest.mark.asyncio
@@ -204,3 +224,35 @@ class TestUploadMediaForStoryService:
 
         assert exc_info.value.status_code == 400
         mock_upload.assert_not_called()
+
+
+@pytest.mark.asyncio
+class TestGetStoryDetailByIdService:
+    async def test_returns_story_detail_with_media_files(self):
+        story_id = uuid.uuid4()
+        media_1 = _make_media_file(story_id=story_id, original_filename="photo1.png")
+        media_2 = _make_media_file(story_id=story_id, original_filename="photo2.png")
+        story = _make_story(id=story_id, media_files=[media_1, media_2])
+
+        db = AsyncMock()
+        db.execute.return_value.one_or_none = lambda: (story, "storyauthor")
+
+        result = await get_story_detail_by_id(db, story_id)
+
+        assert result.id == story_id
+        assert result.author == "storyauthor"
+        assert result.title == "Story Title"
+        assert len(result.media_files) == 2
+        assert result.media_files[0].original_filename == "photo1.png"
+        assert result.media_files[1].original_filename == "photo2.png"
+        db.execute.assert_awaited_once()
+
+    async def test_raises_404_when_story_not_found(self):
+        db = AsyncMock()
+        db.execute.return_value.one_or_none = lambda: None
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_story_detail_by_id(db, uuid.uuid4())
+
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "Story not found"

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -1,0 +1,85 @@
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.db.enums import StoryStatus, StoryVisibility
+from app.services.story_service import list_available_stories
+
+
+def _make_story(**overrides):
+    base = {
+        "id": uuid.uuid4(),
+        "title": "Story Title",
+        "summary": "Story summary",
+        "content": "Story content",
+        "place_name": "Istanbul",
+        "latitude": 41.0082,
+        "longitude": 28.9784,
+        "date_start": 1453,
+        "date_end": 1453,
+        "status": StoryStatus.PUBLISHED,
+        "visibility": StoryVisibility.PUBLIC,
+        "created_at": datetime.now(timezone.utc),
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+@pytest.mark.asyncio
+class TestListAvailableStoriesService:
+    async def test_returns_mapped_stories_and_total(self):
+        story = _make_story()
+
+        db = AsyncMock()
+        db.execute.return_value.all.return_value = [(story, "storyauthor")]
+
+        result = await list_available_stories(db)
+
+        assert result.total == 1
+        assert len(result.stories) == 1
+
+        item = result.stories[0]
+        assert item.id == story.id
+        assert item.title == "Story Title"
+        assert item.summary == "Story summary"
+        assert item.content == "Story content"
+        assert item.author == "storyauthor"
+        assert item.place_name == "Istanbul"
+        assert item.latitude == 41.0082
+        assert item.longitude == 28.9784
+        assert item.date_start == 1453
+        assert item.date_end == 1453
+        assert item.date_label == "1453 - 1453"
+        assert item.status == StoryStatus.PUBLISHED
+        assert item.visibility == StoryVisibility.PUBLIC
+        assert item.created_at == story.created_at
+
+        db.execute.assert_awaited_once()
+
+    async def test_returns_empty_response_when_no_rows(self):
+        db = AsyncMock()
+        db.execute.return_value.all.return_value = []
+
+        result = await list_available_stories(db)
+
+        assert result.total == 0
+        assert result.stories == []
+        db.execute.assert_awaited_once()
+
+    async def test_query_contains_expected_filters_and_sorting(self):
+        db = AsyncMock()
+        db.execute.return_value.all.return_value = []
+
+        await list_available_stories(db)
+
+        stmt = db.execute.await_args.args[0]
+        sql = str(stmt)
+
+        assert "FROM stories" in sql
+        assert "JOIN users" in sql
+        assert "stories.status" in sql
+        assert "stories.visibility" in sql
+        assert "ORDER BY stories.created_at DESC" in sql

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -9,8 +9,9 @@ from fastapi import HTTPException
 from starlette.datastructures import Headers, UploadFile
 
 from app.db.enums import MediaType, StoryStatus, StoryVisibility
-from app.models.story import MediaUploadRequest
+from app.models.story import MediaUploadRequest, StoryCreateRequest
 from app.services.story_service import (
+    create_story_with_location,
     get_story_detail_by_id,
     list_available_stories,
     search_available_stories_by_place,
@@ -256,3 +257,61 @@ class TestGetStoryDetailByIdService:
 
         assert exc_info.value.status_code == 404
         assert exc_info.value.detail == "Story not found"
+
+
+@pytest.mark.asyncio
+class TestCreateStoryWithLocationService:
+    async def test_create_story_with_valid_location(self):
+        payload = StoryCreateRequest(
+            title="New Story",
+            content="Story content",
+            summary="Summary",
+            place_name="Istanbul",
+            latitude=41.0082,
+            longitude=28.9784,
+            date_start=1453,
+            date_end=1453,
+        )
+        current_user = SimpleNamespace(id=uuid.uuid4(), username="authoruser")
+
+        db = AsyncMock()
+        db.add = MagicMock()
+
+        async def _refresh_side_effect(story_obj):
+            story_obj.id = uuid.uuid4()
+            story_obj.created_at = datetime.now(timezone.utc)
+            story_obj.status = StoryStatus.DRAFT
+            story_obj.visibility = StoryVisibility.PRIVATE
+
+        db.refresh.side_effect = _refresh_side_effect
+
+        result = await create_story_with_location(db, current_user, payload)
+
+        assert result.title == "New Story"
+        assert result.author == "authoruser"
+        assert result.place_name == "Istanbul"
+        assert result.latitude == 41.0082
+        assert result.longitude == 28.9784
+        assert result.media_files == []
+        db.add.assert_called_once()
+        db.commit.assert_awaited_once()
+        db.refresh.assert_awaited_once()
+
+    async def test_create_story_rejects_missing_place_name(self):
+        payload = StoryCreateRequest(
+            title="New Story",
+            content="Story content",
+            summary="Summary",
+            place_name="   ",
+            latitude=41.0082,
+            longitude=28.9784,
+        )
+        current_user = SimpleNamespace(id=uuid.uuid4(), username="authoruser")
+        db = AsyncMock()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await create_story_with_location(db, current_user, payload)
+
+        assert exc_info.value.status_code == 422
+        assert "place_name is required" in exc_info.value.detail
+        db.add.assert_not_called()

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -122,6 +122,28 @@ class TestListAvailableStoriesService:
         assert "stories.visibility" in sql
         assert "ORDER BY stories.created_at DESC" in sql
 
+    async def test_query_includes_bounds_filters_when_provided(self):
+        db = AsyncMock()
+        db.execute.return_value.all = lambda: []
+
+        await list_available_stories(
+            db,
+            min_lat=40.9,
+            max_lat=41.1,
+            min_lng=28.8,
+            max_lng=29.1,
+        )
+
+        stmt = db.execute.await_args.args[0]
+        sql = str(stmt)
+
+        assert "stories.latitude IS NOT NULL" in sql
+        assert "stories.longitude IS NOT NULL" in sql
+        assert "stories.latitude >=" in sql
+        assert "stories.latitude <=" in sql
+        assert "stories.longitude >=" in sql
+        assert "stories.longitude <=" in sql
+
 
 @pytest.mark.asyncio
 class TestSearchAvailableStoriesByPlaceService:

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -6,7 +6,10 @@ from unittest.mock import AsyncMock
 import pytest
 
 from app.db.enums import StoryStatus, StoryVisibility
-from app.services.story_service import list_available_stories
+from app.services.story_service import (
+    list_available_stories,
+    search_available_stories_by_place,
+)
 
 
 def _make_story(**overrides):
@@ -83,3 +86,35 @@ class TestListAvailableStoriesService:
         assert "stories.status" in sql
         assert "stories.visibility" in sql
         assert "ORDER BY stories.created_at DESC" in sql
+
+
+@pytest.mark.asyncio
+class TestSearchAvailableStoriesByPlaceService:
+    async def test_returns_matching_stories_and_total(self):
+        story = _make_story(place_name="Istanbul, Fatih")
+
+        db = AsyncMock()
+        db.execute.return_value.all = lambda: [(story, "storyauthor")]
+
+        result = await search_available_stories_by_place(db, "ist")
+
+        assert result.total == 1
+        assert len(result.stories) == 1
+
+        item = result.stories[0]
+        assert item.id == story.id
+        assert item.title == "Story Title"
+        assert item.place_name == "Istanbul, Fatih"
+        assert item.author == "storyauthor"
+
+        db.execute.assert_awaited_once()
+
+    async def test_returns_empty_response_when_no_match(self):
+        db = AsyncMock()
+        db.execute.return_value.all = lambda: []
+
+        result = await search_available_stories_by_place(db, "ankara")
+
+        assert result.total == 0
+        assert result.stories == []
+        db.execute.assert_awaited_once()

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -34,7 +34,7 @@ class TestListAvailableStoriesService:
         story = _make_story()
 
         db = AsyncMock()
-        db.execute.return_value.all.return_value = [(story, "storyauthor")]
+        db.execute.return_value.all = lambda: [(story, "storyauthor")]
 
         result = await list_available_stories(db)
 
@@ -61,7 +61,7 @@ class TestListAvailableStoriesService:
 
     async def test_returns_empty_response_when_no_rows(self):
         db = AsyncMock()
-        db.execute.return_value.all.return_value = []
+        db.execute.return_value.all = lambda: []
 
         result = await list_available_stories(db)
 
@@ -71,7 +71,7 @@ class TestListAvailableStoriesService:
 
     async def test_query_contains_expected_filters_and_sorting(self):
         db = AsyncMock()
-        db.execute.return_value.all.return_value = []
+        db.execute.return_value.all = lambda: []
 
         await list_available_stories(db)
 

--- a/backend/tests/unit/test_user_factory.py
+++ b/backend/tests/unit/test_user_factory.py
@@ -1,0 +1,62 @@
+from app.db.enums import UserRole
+from app.services.auth_service import verify_password
+from tests.factories.user_factory import (
+    make_login_payload,
+    make_user_entity,
+    make_user_payload,
+)
+
+
+def test_make_user_payload_defaults_are_valid():
+    payload = make_user_payload()
+
+    assert payload["username"] == "testuser"
+    assert payload["email"] == "test@example.com"
+    assert payload["password"] == "ValidPass1!"
+    assert payload["display_name"] == "Test User"
+
+
+def test_make_user_payload_overrides_and_suffix():
+    payload = make_user_payload(
+        username="alice",
+        email="alice@example.com",
+        password="AlicePass1!",
+        display_name=None,
+        suffix=7,
+    )
+
+    assert payload["username"] == "alice7"
+    assert payload["email"] == "alice+7@example.com"
+    assert payload["password"] == "AlicePass1!"
+    assert "display_name" not in payload
+
+
+def test_make_login_payload_defaults_and_suffix():
+    default_payload = make_login_payload()
+    suffix_payload = make_login_payload(email="login@example.com", password="AnyPass1!", suffix="x")
+
+    assert default_payload == {"email": "test@example.com", "password": "ValidPass1!"}
+    assert suffix_payload == {"email": "login+x@example.com", "password": "AnyPass1!"}
+
+
+def test_make_user_entity_defaults_and_role_override():
+    user = make_user_entity()
+    admin = make_user_entity(
+        username="admin",
+        email="admin@example.com",
+        password="AdminPass1!",
+        role=UserRole.ADMIN,
+        suffix=2,
+    )
+
+    assert user.username == "testuser"
+    assert user.email == "test@example.com"
+    assert user.role == UserRole.USER
+    assert user.is_active is True
+    assert user.password_hash != "ValidPass1!"
+    assert verify_password("ValidPass1!", user.password_hash)
+
+    assert admin.username == "admin2"
+    assert admin.email == "admin+2@example.com"
+    assert admin.role == UserRole.ADMIN
+    assert verify_password("AdminPass1!", admin.password_hash)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,8 @@ services:
       context: ./frontend
     ports:
       - "3000:80"
+    environment:
+      API_BASE_URL: http://localhost:8000
     depends_on:
       - backend
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
     ports:
       - "3000:80"
     environment:
-      API_BASE_URL: http://localhost:8000
+      API_BASE_URL: https://bounswe2026group2-backend-dev.onrender.com
     depends_on:
       - backend
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
     ports:
       - "3000:80"
     environment:
-      API_BASE_URL: https://bounswe2026group2-backend-dev.onrender.com
+      API_BASE_URL: http://localhost:8000
     depends_on:
       - backend
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,7 +8,9 @@ COPY story-detail.html /usr/share/nginx/html/story-detail.html
 COPY login.js /usr/share/nginx/html/login.js
 COPY auth.js /usr/share/nginx/html/auth.js
 COPY config.js /usr/share/nginx/html/config.js
+COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 EXPOSE 80
 
+ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,6 +7,8 @@ COPY story-create.html /usr/share/nginx/html/story-create.html
 COPY story-detail.html /usr/share/nginx/html/story-detail.html
 COPY profile.html /usr/share/nginx/html/profile.html
 COPY edit-profile.html /usr/share/nginx/html/edit-profile.html
+COPY profile.js /usr/share/nginx/html/profile.js
+COPY edit-profile.js /usr/share/nginx/html/edit-profile.js
 COPY login.js /usr/share/nginx/html/login.js
 COPY auth.js /usr/share/nginx/html/auth.js
 COPY config.js /usr/share/nginx/html/config.js

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,7 @@
 FROM nginx:alpine
 
 COPY index.html /usr/share/nginx/html/index.html
+COPY forgot-password.html /usr/share/nginx/html/forgot-password.html
 COPY register.html /usr/share/nginx/html/register.html
 COPY map.html /usr/share/nginx/html/map.html
 COPY story-create.html /usr/share/nginx/html/story-create.html

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -6,6 +6,8 @@ COPY map.html /usr/share/nginx/html/map.html
 COPY story-create.html /usr/share/nginx/html/story-create.html
 COPY story-detail.html /usr/share/nginx/html/story-detail.html
 COPY login.js /usr/share/nginx/html/login.js
+COPY auth.js /usr/share/nginx/html/auth.js
+COPY config.js /usr/share/nginx/html/config.js
 
 EXPOSE 80
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,7 @@
 FROM nginx:alpine
 
 COPY index.html /usr/share/nginx/html/index.html
+COPY register.html /usr/share/nginx/html/register.html
 COPY map.html /usr/share/nginx/html/map.html
 COPY story-create.html /usr/share/nginx/html/story-create.html
 COPY story-detail.html /usr/share/nginx/html/story-detail.html

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,6 +2,8 @@ FROM nginx:alpine
 
 COPY index.html /usr/share/nginx/html/index.html
 COPY map.html /usr/share/nginx/html/map.html
+COPY story-create.html /usr/share/nginx/html/story-create.html
+COPY story-detail.html /usr/share/nginx/html/story-detail.html
 COPY login.js /usr/share/nginx/html/login.js
 
 EXPOSE 80

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,6 +5,8 @@ COPY register.html /usr/share/nginx/html/register.html
 COPY map.html /usr/share/nginx/html/map.html
 COPY story-create.html /usr/share/nginx/html/story-create.html
 COPY story-detail.html /usr/share/nginx/html/story-detail.html
+COPY profile.html /usr/share/nginx/html/profile.html
+COPY edit-profile.html /usr/share/nginx/html/edit-profile.html
 COPY login.js /usr/share/nginx/html/login.js
 COPY auth.js /usr/share/nginx/html/auth.js
 COPY config.js /usr/share/nginx/html/config.js

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,6 +2,7 @@ FROM nginx:alpine
 
 COPY index.html /usr/share/nginx/html/index.html
 COPY map.html /usr/share/nginx/html/map.html
+COPY login.js /usr/share/nginx/html/login.js
 
 EXPOSE 80
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,7 @@
 FROM nginx:alpine
 
 COPY index.html /usr/share/nginx/html/index.html
+COPY map.html /usr/share/nginx/html/map.html
 
 EXPOSE 80
 

--- a/frontend/auth.js
+++ b/frontend/auth.js
@@ -1,0 +1,48 @@
+var AUTH_TOKEN_KEY = "auth_token";
+
+function getToken() {
+    return localStorage.getItem(AUTH_TOKEN_KEY);
+}
+
+function isLoggedIn() {
+    return !!getToken();
+}
+
+function saveToken(token) {
+    localStorage.setItem(AUTH_TOKEN_KEY, token);
+}
+
+function logout() {
+    localStorage.removeItem(AUTH_TOKEN_KEY);
+    window.location.assign("index.html");
+}
+
+function authFetch(url, options) {
+    options = options || {};
+    var token = getToken();
+    if (token) {
+        options.headers = options.headers || {};
+        options.headers["Authorization"] = "Bearer " + token;
+    }
+    return fetch(url, options);
+}
+
+function requireAuth() {
+    if (!isLoggedIn()) {
+        window.location.assign("index.html");
+        return false;
+    }
+    return true;
+}
+
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = {
+        getToken: getToken,
+        isLoggedIn: isLoggedIn,
+        saveToken: saveToken,
+        logout: logout,
+        authFetch: authFetch,
+        requireAuth: requireAuth,
+        AUTH_TOKEN_KEY: AUTH_TOKEN_KEY
+    };
+}

--- a/frontend/auth.test.js
+++ b/frontend/auth.test.js
@@ -1,0 +1,95 @@
+const {
+    getToken,
+    isLoggedIn,
+    saveToken,
+    logout,
+    authFetch,
+    requireAuth,
+    AUTH_TOKEN_KEY
+} = require("./auth");
+
+global.fetch = jest.fn();
+
+describe("auth utility", () => {
+    let assignMock;
+    let store;
+
+    beforeEach(() => {
+        store = {};
+        assignMock = jest.fn();
+
+        Object.defineProperty(window, "location", {
+            value: { assign: assignMock, origin: "http://localhost" },
+            writable: true,
+            configurable: true
+        });
+
+        jest.spyOn(Storage.prototype, "getItem").mockImplementation((key) => store[key] || null);
+        jest.spyOn(Storage.prototype, "setItem").mockImplementation((key, val) => { store[key] = val; });
+        jest.spyOn(Storage.prototype, "removeItem").mockImplementation((key) => { delete store[key]; });
+
+        global.fetch.mockReset();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test("getToken returns null when no token stored", () => {
+        expect(getToken()).toBeNull();
+    });
+
+    test("saveToken stores token and getToken retrieves it", () => {
+        saveToken("abc123");
+        expect(store[AUTH_TOKEN_KEY]).toBe("abc123");
+    });
+
+    test("isLoggedIn returns false when no token", () => {
+        expect(isLoggedIn()).toBe(false);
+    });
+
+    test("isLoggedIn returns true when token exists", () => {
+        store[AUTH_TOKEN_KEY] = "abc123";
+        expect(isLoggedIn()).toBe(true);
+    });
+
+    test("logout removes token and redirects to login", () => {
+        store[AUTH_TOKEN_KEY] = "abc123";
+        logout();
+        expect(store[AUTH_TOKEN_KEY]).toBeUndefined();
+        expect(assignMock).toHaveBeenCalledWith("index.html");
+    });
+
+    test("authFetch adds Authorization header when token exists", async () => {
+        store[AUTH_TOKEN_KEY] = "my-token";
+        global.fetch.mockResolvedValueOnce({ ok: true });
+
+        await authFetch("/api/test", { method: "GET" });
+
+        expect(global.fetch).toHaveBeenCalledWith("/api/test", {
+            method: "GET",
+            headers: { "Authorization": "Bearer my-token" }
+        });
+    });
+
+    test("authFetch works without token", async () => {
+        global.fetch.mockResolvedValueOnce({ ok: true });
+
+        await authFetch("/api/test");
+
+        expect(global.fetch).toHaveBeenCalledWith("/api/test", {});
+    });
+
+    test("requireAuth redirects when not logged in", () => {
+        var result = requireAuth();
+        expect(result).toBe(false);
+        expect(assignMock).toHaveBeenCalledWith("index.html");
+    });
+
+    test("requireAuth returns true when logged in", () => {
+        store[AUTH_TOKEN_KEY] = "abc123";
+        var result = requireAuth();
+        expect(result).toBe(true);
+        expect(assignMock).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/config.js
+++ b/frontend/config.js
@@ -1,4 +1,3 @@
 // Backend API base URL (no trailing slash)
-// Dev: https://bounswe2026group2-backend-dev.onrender.com
-// Local: http://localhost:8000
-var API_BASE = "https://bounswe2026group2-backend-dev.onrender.com";
+// Replaced at container startup by docker-entrypoint.sh from $API_BASE_URL env var.
+var API_BASE = "__API_BASE_URL__";

--- a/frontend/config.js
+++ b/frontend/config.js
@@ -1,0 +1,4 @@
+// Backend API base URL (no trailing slash)
+// Dev: https://bounswe2026group2-backend-dev.onrender.com
+// Local: http://localhost:8000
+var API_BASE = "https://bounswe2026group2-backend-dev.onrender.com";

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+# Replace placeholder in config.js with the actual API_BASE_URL env var
+sed -i "s|__API_BASE_URL__|${API_BASE_URL}|g" /usr/share/nginx/html/config.js
+
+exec "$@"

--- a/frontend/edit-profile.html
+++ b/frontend/edit-profile.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Local History Map - Edit Profile</title>
+  <script src="https://cdn.tailwindcss.com?plugins=forms"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Serif:wght@700;800&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet">
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            background: "#fef9f0",
+            surface: "#ffffff",
+            primary: "#775a19",
+            "primary-light": "#c5a059",
+            secondary: "#506169",
+            tertiary: "#35618f",
+            border: "#e7e2d9",
+            textmain: "#1d1c16",
+            textmuted: "#5f584c"
+          },
+          fontFamily: {
+            body: ["Inter", "sans-serif"],
+            headline: ["Noto Serif", "serif"]
+          },
+          boxShadow: {
+            soft: "0 20px 50px rgba(0,0,0,0.08)"
+          }
+        }
+      }
+    };
+  </script>
+  <style>
+    .material-symbols-outlined {
+        font-variation-settings: "FILL" 0, "wght" 400, "GRAD" 0, "opsz" 24;
+    }
+  </style>
+</head>
+<body class="bg-background text-textmain font-body min-h-screen">
+  
+  <!-- Top Navigation Bar -->
+  <header class="fixed top-0 left-0 right-0 z-[1000] bg-[#f8f3ea]/95 backdrop-blur-sm border-b border-border/30">
+    <div class="flex justify-between items-center w-full px-8 py-4 max-w-screen-2xl mx-auto">
+        <div class="flex items-center gap-8">
+            <h1 class="text-2xl font-bold font-headline text-textmain tracking-tight">Local History Map</h1>
+            <nav class="hidden md:flex items-center gap-6">
+                <a class="text-textmain font-medium hover:text-tertiary transition-colors" href="map.html">Map</a>
+                <a class="text-textmain font-medium hover:text-tertiary transition-colors" href="story-detail.html">Archive</a>
+                <a class="text-textmain font-medium hover:text-tertiary transition-colors" href="story-create.html">Create Story</a>
+                <a class="text-textmain font-medium hover:text-tertiary transition-colors" href="index.html">Login</a>
+            </nav>
+        </div>
+        <div class="flex items-center gap-3 sm:gap-4">
+            <a href="profile.html" class="inline-flex h-11 w-11 items-center justify-center rounded-full border border-primary bg-primary/10 text-primary shadow-sm transition hover:bg-primary/20" aria-label="Open profile">
+                <span class="material-symbols-outlined text-[20px] leading-none">account_circle</span>
+            </a>
+        </div>
+    </div>
+  </header>
+
+  <main class="w-full px-4 pt-32 pb-10 lg:px-8 xl:px-10 2xl:px-14 max-w-3xl mx-auto">
+    <header class="mb-10 text-center">
+      <p class="text-sm font-semibold uppercase tracking-[0.2em] text-primary">Settings</p>
+      <h1 class="mt-3 font-headline text-4xl font-extrabold leading-tight text-textmain">Edit Your Profile</h1>
+      <p class="mt-3 text-base leading-7 text-textmuted">
+        Update your personal information and how you appear to the community.
+      </p>
+    </header>
+
+    <form id="edit-profile-form" class="rounded-3xl border border-border bg-surface p-8 shadow-soft">
+      <div class="space-y-8">
+        
+        <!-- Avatar Upload -->
+        <div class="flex flex-col md:flex-row items-center gap-6">
+          <div class="w-24 h-24 md:w-32 md:h-32 bg-primary/20 rounded-full flex items-center justify-center border-4 border-white shadow-sm shrink-0 relative group cursor-pointer overflow-hidden" onclick="document.getElementById('avatar-upload').click()">
+            <span class="material-symbols-outlined text-5xl md:text-6xl text-primary" style="font-variation-settings: 'FILL' 1;">person</span>
+            <div class="absolute inset-0 bg-black/40 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
+                <span class="material-symbols-outlined text-white text-3xl">photo_camera</span>
+            </div>
+            <input type="file" id="avatar-upload" class="hidden" accept="image/*" />
+          </div>
+          <div class="text-center md:text-left">
+             <h3 class="font-semibold text-textmain">Profile Picture</h3>
+             <p class="text-sm text-textmuted mt-1">Upload a new avatar or logo.</p>
+             <button type="button" class="mt-3 px-4 py-2 rounded-xl text-sm font-semibold border border-border bg-white text-textmain hover:bg-stone-50 transition" onclick="document.getElementById('avatar-upload').click()">
+                Change Picture
+             </button>
+          </div>
+        </div>
+
+        <hr class="border-border/50" />
+
+        <!-- Form Fields -->
+        <div class="grid gap-6">
+          <div>
+            <label for="fullName" class="mb-2 block text-sm font-semibold text-textmain">Display Name</label>
+            <input id="fullName" type="text" value="Mehmet Arif" placeholder="Enter your full name" class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary" />
+          </div>
+          
+          <div>
+            <label for="bio" class="mb-2 block text-sm font-semibold text-textmain">Bio</label>
+            <textarea id="bio" rows="4" placeholder="Tell the community a bit about yourself" class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm leading-6 focus:border-primary focus:ring-primary">Historian and native of Galata. Passionate about preserving the auditory and visual memories of old Istanbul.</textarea>
+          </div>
+
+          <div class="grid gap-6 md:grid-cols-2">
+            <div>
+              <label for="location" class="mb-2 block text-sm font-semibold text-textmain">Location</label>
+              <input id="location" type="text" value="Istanbul, Turkey" placeholder="e.g. Istanbul, Turkey" class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary" />
+            </div>
+            <div>
+              <label for="email" class="mb-2 block text-sm font-semibold text-textmain">Email Address</label>
+              <input id="email" type="email" value="mehmet.arif@example.com" placeholder="your@email.com" class="w-full rounded-xl border-border bg-stone-50 px-4 py-3 text-sm text-textmuted focus:border-border focus:ring-0 cursor-not-allowed" readonly />
+              <p class="text-xs text-textmuted mt-2">Email address cannot be changed.</p>
+            </div>
+          </div>
+        </div>
+
+        <hr class="border-border/50" />
+
+        <!-- Change Password -->
+        <div class="grid gap-6">
+          <h3 class="font-headline text-xl font-bold text-textmain">Change Password</h3>
+          <div>
+            <label for="currentPassword" class="mb-2 block text-sm font-semibold text-textmain">Current Password</label>
+            <input id="currentPassword" type="password" placeholder="Enter current password" class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary" />
+          </div>
+          <div class="grid gap-6 md:grid-cols-2">
+            <div>
+              <label for="newPassword" class="mb-2 block text-sm font-semibold text-textmain">New Password</label>
+              <input id="newPassword" type="password" placeholder="Enter new password" class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary" />
+            </div>
+            <div>
+              <label for="confirmPassword" class="mb-2 block text-sm font-semibold text-textmain">Confirm New Password</label>
+              <input id="confirmPassword" type="password" placeholder="Confirm new password" class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary" />
+            </div>
+          </div>
+        </div>
+
+        <!-- Submit & Cancel -->
+        <div class="flex items-center gap-4 justify-end pt-4">
+          <a href="profile.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-white px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">
+            Cancel
+          </a>
+          <button type="submit" class="rounded-xl bg-primary px-6 py-3 text-sm font-semibold text-white transition hover:opacity-95">
+            Save Changes
+          </button>
+        </div>
+        
+      </div>
+    </form>
+  </main>
+
+  <script>
+      document.getElementById('edit-profile-form').addEventListener('submit', function(e) {
+          e.preventDefault();
+          // In a real app, send API request here.
+          // For now, redirect to profile page:
+          window.location.assign('profile.html');
+      });
+  </script>
+</body>
+</html>

--- a/frontend/edit-profile.html
+++ b/frontend/edit-profile.html
@@ -155,13 +155,8 @@
     </form>
   </main>
 
-  <script>
-      document.getElementById('edit-profile-form').addEventListener('submit', function(e) {
-          e.preventDefault();
-          // In a real app, send API request here.
-          // For now, redirect to profile page:
-          window.location.assign('profile.html');
-      });
-  </script>
+  <script src="config.js"></script>
+  <script src="auth.js"></script>
+  <script src="edit-profile.js"></script>
 </body>
 </html>

--- a/frontend/edit-profile.js
+++ b/frontend/edit-profile.js
@@ -1,0 +1,47 @@
+async function loadEditProfile() {
+    if (typeof requireAuth === "function" && !requireAuth()) return;
+
+    try {
+        var res = await authFetch(API_BASE + "/auth/me");
+        if (!res.ok) {
+            if (res.status === 401 && typeof logout === "function") logout();
+            throw new Error("Failed to load profile");
+        }
+        var data = await res.json();
+        
+        var nameEl = document.getElementById("fullName");
+        var emailEl = document.getElementById("email");
+        
+        if (nameEl) nameEl.value = data.display_name || data.username || "";
+        if (emailEl) emailEl.value = data.email || "";
+        
+    } catch(err) {
+        console.error("Error loading edit profile:", err);
+    }
+}
+
+function handleEditProfileSubmit(e) {
+    e.preventDefault();
+    // Cannot submit to backend yet (no endpoint exists), so just redirect for now
+    window.location.assign('profile.html');
+}
+
+function setupEditProfile() {
+    loadEditProfile();
+    var form = document.getElementById('edit-profile-form');
+    if (form) {
+        form.addEventListener('submit', handleEditProfileSubmit);
+    }
+}
+
+if (typeof document !== "undefined") {
+    document.addEventListener("DOMContentLoaded", setupEditProfile);
+}
+
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = {
+        loadEditProfile: loadEditProfile,
+        handleEditProfileSubmit: handleEditProfileSubmit,
+        setupEditProfile: setupEditProfile
+    };
+}

--- a/frontend/edit-profile.test.js
+++ b/frontend/edit-profile.test.js
@@ -1,0 +1,82 @@
+global.API_BASE = "http://localhost";
+global.requireAuth = jest.fn();
+global.authFetch = jest.fn();
+global.logout = jest.fn();
+
+const { loadEditProfile, handleEditProfileSubmit, setupEditProfile } = require("./edit-profile");
+
+describe("edit profile page unit tests", () => {
+    let assignMock;
+
+    beforeEach(() => {
+        document.body.innerHTML = "";
+        global.requireAuth.mockReset().mockReturnValue(true);
+        global.authFetch.mockReset();
+        global.logout.mockReset();
+        
+        assignMock = jest.fn();
+        Object.defineProperty(window, "location", {
+            value: { assign: assignMock, origin: "http://localhost" },
+            writable: true,
+            configurable: true
+        });
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test("loadEditProfile returns early if not authenticated", async () => {
+        global.requireAuth.mockReturnValue(false);
+        await loadEditProfile();
+        expect(global.authFetch).not.toHaveBeenCalled();
+    });
+
+    test("loadEditProfile populates form elements on success", async () => {
+        document.body.innerHTML = `
+            <input id="fullName" value="" />
+            <input id="email" value="" />
+        `;
+        
+        global.authFetch.mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve({ 
+                display_name: "Test Edit User",
+                email: "test@example.com"
+            })
+        });
+
+        await loadEditProfile();
+
+        expect(document.getElementById("fullName").value).toBe("Test Edit User");
+        expect(document.getElementById("email").value).toBe("test@example.com");
+    });
+    
+    test("handleEditProfileSubmit prevents default and redirects", () => {
+        const fakeEvent = {
+            preventDefault: jest.fn()
+        };
+        handleEditProfileSubmit(fakeEvent);
+        expect(fakeEvent.preventDefault).toHaveBeenCalledTimes(1);
+        expect(assignMock).toHaveBeenCalledWith("profile.html");
+    });
+    
+    test("setupEditProfile attaches submit listener", async () => {
+        document.body.innerHTML = `
+            <form id="edit-profile-form">
+                <button type="submit"></button>
+            </form>
+        `;
+        
+        // mock authFetch for loadEditProfile call within setupEditProfile
+        global.authFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
+        
+        setupEditProfile();
+        
+        const form = document.getElementById("edit-profile-form");
+        const submitEvent = new Event("submit", { bubbles: true, cancelable: true });
+        form.dispatchEvent(submitEvent);
+        
+        expect(assignMock).toHaveBeenCalledWith("profile.html");
+    });
+});

--- a/frontend/forgot-password.html
+++ b/frontend/forgot-password.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Local History Map - Forgot Password</title>
+  <script src="https://cdn.tailwindcss.com?plugins=forms"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Serif:wght@700;800&display=swap" rel="stylesheet">
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            background: "#fef9f0",
+            surface: "#ffffff",
+            primary: "#775a19",
+            "primary-light": "#c5a059",
+            secondary: "#506169",
+            tertiary: "#35618f",
+            border: "#e7e2d9",
+            textmain: "#1d1c16",
+            textmuted: "#5f584c"
+          },
+          fontFamily: {
+            body: ["Inter", "sans-serif"],
+            headline: ["Noto Serif", "serif"]
+          },
+          boxShadow: {
+            soft: "0 20px 50px rgba(0,0,0,0.08)"
+          }
+        }
+      }
+    };
+  </script>
+  <style>
+    body {
+      background:
+              linear-gradient(rgba(254, 249, 240, 0.9), rgba(254, 249, 240, 0.9)),
+              url("https://images.unsplash.com/photo-1512453979798-5ea266f8880c?auto=format&fit=crop&w=1600&q=80");
+      background-size: cover;
+      background-position: center;
+      background-attachment: fixed;
+    }
+  </style>
+</head>
+<body class="font-body text-textmain min-h-screen">
+<div class="min-h-screen flex items-center justify-center px-6 py-10">
+  <div class="w-full max-w-5xl grid lg:grid-cols-[1.15fr_0.95fr] bg-white/70 backdrop-blur-md rounded-3xl overflow-hidden shadow-soft border border-white/50">
+
+    <section class="hidden lg:flex flex-col justify-between p-12 bg-[rgba(53,97,143,0.08)]">
+      <div>
+        <div class="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-white/80 text-primary text-sm font-semibold border border-border">
+          <span>Account Recovery</span>
+        </div>
+
+        <h1 class="mt-8 font-headline text-5xl leading-tight font-extrabold text-textmain">
+          Reset access without losing your place on the map.
+        </h1>
+
+        <p class="mt-6 text-lg leading-8 text-textmuted max-w-xl">
+          Enter the email address you use for Local History Map. If password reset is enabled for your account, we will send the next steps there.
+        </p>
+      </div>
+
+      <div class="grid gap-4 sm:grid-cols-2">
+        <div class="rounded-2xl border border-border bg-white/80 p-4">
+          <p class="text-sm font-semibold text-primary">Security-first flow</p>
+          <p class="mt-2 text-sm text-textmuted">We return a generic success message so account recovery does not leak whether an email exists.</p>
+        </div>
+        <div class="rounded-2xl border border-border bg-white/80 p-4">
+          <p class="text-sm font-semibold text-primary">Fast way back</p>
+          <p class="mt-2 text-sm text-textmuted">Use the same email you normally sign in with to continue as soon as reset support is available.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="flex items-center justify-center bg-white/75 p-8 sm:p-12">
+      <div class="w-full max-w-md">
+        <div class="lg:hidden mb-8 text-center">
+          <h1 class="font-headline text-3xl font-extrabold text-textmain">Forgot password</h1>
+          <p class="mt-2 text-sm text-textmuted">Recover access to your account.</p>
+        </div>
+
+        <div class="mb-8">
+          <a href="index.html" class="inline-flex items-center gap-2 text-sm font-semibold text-primary hover:underline">
+            <span aria-hidden="true">&larr;</span>
+            Back to sign in
+          </a>
+          <h2 class="mt-5 text-3xl font-bold text-textmain">Reset your password</h2>
+          <p class="mt-2 text-textmuted">Enter your email and we will send password reset instructions if your account can be recovered.</p>
+        </div>
+
+        <div id="forgot-error" class="hidden mb-4 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700"></div>
+        <div id="forgot-success" class="hidden mb-4 rounded-xl border border-green-200 bg-green-50 p-3 text-sm text-green-700"></div>
+
+        <form id="forgot-password-form" class="space-y-5">
+          <div>
+            <label for="recovery-email" class="block text-sm font-semibold mb-2 text-textmain">Email</label>
+            <input
+                    id="recovery-email"
+                    type="email"
+                    placeholder="you@example.com"
+                    class="w-full rounded-xl border border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary"
+                    required
+            />
+          </div>
+
+          <button
+                  id="forgot-submit"
+                  type="submit"
+                  class="w-full rounded-xl bg-primary px-4 py-3 text-white font-semibold hover:opacity-95 transition"
+          >
+            Send reset link
+          </button>
+        </form>
+
+      </div>
+    </section>
+  </div>
+</div>
+
+<script src="config.js"></script>
+<script>
+  function showForgotMessage(kind, message) {
+    var errorEl = document.getElementById("forgot-error");
+    var successEl = document.getElementById("forgot-success");
+
+    errorEl.classList.add("hidden");
+    successEl.classList.add("hidden");
+
+    if (kind === "success") {
+      successEl.textContent = message;
+      successEl.classList.remove("hidden");
+      return;
+    }
+
+    errorEl.textContent = message;
+    errorEl.classList.remove("hidden");
+  }
+
+  async function handleForgotPassword(event) {
+    event.preventDefault();
+
+    var email = document.getElementById("recovery-email").value.trim();
+    var submitButton = document.getElementById("forgot-submit");
+
+    submitButton.disabled = true;
+    submitButton.textContent = "Sending...";
+
+    try {
+      var response = await fetch(API_BASE + "/auth/forgot-password", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: email })
+      });
+
+      if (response.ok) {
+        showForgotMessage(
+          "success",
+          "If an account exists for this email, reset instructions have been sent."
+        );
+        return;
+      }
+
+      if (response.status === 404 || response.status === 405) {
+        showForgotMessage(
+          "error",
+          "Password reset is not available right now. Please try again later."
+        );
+        return;
+      }
+
+      var data = await response.json().catch(function () { return {}; });
+      showForgotMessage(
+        "error",
+        data.detail || "Unable to start password reset right now. Please try again later."
+      );
+    } catch (err) {
+      showForgotMessage(
+        "error",
+        "Unable to reach the server right now. Please try again later."
+      );
+    } finally {
+      submitButton.disabled = false;
+      submitButton.textContent = "Send reset link";
+    }
+  }
+
+  document.getElementById("forgot-password-form").addEventListener("submit", handleForgotPassword);
+</script>
+</body>
+</html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -158,12 +158,6 @@
           </button>
         </div>
 
-        <div class="mt-6 flex flex-wrap justify-center gap-3">
-          <a href="map.html" class="text-sm font-medium text-primary hover:underline">Open Map</a>
-          <a href="story-create.html" class="text-sm font-medium text-primary hover:underline">Story Creation</a>
-          <a href="story-detail.html" class="text-sm font-medium text-primary hover:underline">Story Detail</a>
-        </div>
-
         <p class="mt-8 text-sm text-textmuted text-center">
           By continuing, you agree to our Terms and Privacy Policy.
         </p>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -107,7 +107,7 @@
           <div>
             <div class="flex items-center justify-between mb-2">
               <label for="password" class="block text-sm font-semibold text-textmain">Password</label>
-              <a href="#" class="text-sm font-medium text-tertiary hover:underline">Forgot password?</a>
+              <a href="forgot-password.html" class="text-sm font-medium text-tertiary hover:underline">Forgot password?</a>
             </div>
             <input
                     id="password"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -7,7 +8,9 @@
   <script src="https://cdn.tailwindcss.com?plugins=forms"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Serif:wght@700;800&display=swap" rel="stylesheet">
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Serif:wght@700;800&display=swap"
+    rel="stylesheet">
   <script>
     tailwind.config = {
       theme: {
@@ -37,143 +40,140 @@
   <style>
     body {
       background:
-              linear-gradient(rgba(254, 249, 240, 0.88), rgba(254, 249, 240, 0.88)),
-              url("https://images.unsplash.com/photo-1512453979798-5ea266f8880c?auto=format&fit=crop&w=1600&q=80");
+        linear-gradient(rgba(254, 249, 240, 0.88), rgba(254, 249, 240, 0.88)),
+        url("https://images.unsplash.com/photo-1512453979798-5ea266f8880c?auto=format&fit=crop&w=1600&q=80");
       background-size: cover;
       background-position: center;
       background-attachment: fixed;
     }
   </style>
 </head>
+
 <body class="font-body text-textmain min-h-screen">
-<div class="min-h-screen flex items-center justify-center px-6 py-10">
-  <div class="w-full max-w-6xl grid lg:grid-cols-2 bg-white/70 backdrop-blur-md rounded-3xl overflow-hidden shadow-soft border border-white/50">
+  <div class="min-h-screen flex items-center justify-center px-6 py-10">
+    <div
+      class="w-full max-w-6xl grid lg:grid-cols-2 bg-white/70 backdrop-blur-md rounded-3xl overflow-hidden shadow-soft border border-white/50">
 
-    <section class="hidden lg:flex flex-col justify-between p-12 bg-[rgba(119,90,25,0.08)]">
-      <div>
-        <div class="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-white/80 text-primary text-sm font-semibold border border-border">
-          <span>Local History Map</span>
+      <section class="hidden lg:flex flex-col justify-between p-12 bg-[rgba(119,90,25,0.08)]">
+        <div>
+          <div
+            class="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-white/80 text-primary text-sm font-semibold border border-border">
+            <span>Local History Map</span>
+          </div>
+
+          <h1 class="mt-8 font-headline text-5xl leading-tight font-extrabold text-textmain">
+            Discover the city through memories, places, and stories.
+          </h1>
+
+          <p class="mt-6 text-lg leading-8 text-textmuted max-w-xl">
+            Explore personal archives, neighborhood memories, and cultural landmarks on an interactive historical map.
+          </p>
         </div>
-
-        <h1 class="mt-8 font-headline text-5xl leading-tight font-extrabold text-textmain">
-          Discover the city through memories, places, and stories.
-        </h1>
-
-        <p class="mt-6 text-lg leading-8 text-textmuted max-w-xl">
-          Explore personal archives, neighborhood memories, and cultural landmarks on an interactive historical map.
-        </p>
-      </div>
 
         <div class="grid sm:grid-cols-3 gap-4 mt-10">
-        <a href="story-detail.html" class="block bg-white/80 rounded-2xl p-4 border border-border transition hover:bg-white">
-          <p class="text-sm font-semibold text-primary">Archive Stories</p>
-          <p class="mt-2 text-sm text-textmuted">Browse memories connected to real places.</p>
-        </a>
-        <a href="map.html" class="block bg-white/80 rounded-2xl p-4 border border-border transition hover:bg-white">
-          <p class="text-sm font-semibold text-primary">Interactive Map</p>
-          <p class="mt-2 text-sm text-textmuted">Navigate history visually across the city.</p>
-        </a>
-        <a href="story-create.html" class="block bg-white/80 rounded-2xl p-4 border border-border transition hover:bg-white">
-          <p class="text-sm font-semibold text-primary">Community Voices</p>
-          <p class="mt-2 text-sm text-textmuted">Read and share local narratives.</p>
-        </a>
-      </div>
-    </section>
-
-    <section class="flex items-center justify-center p-8 sm:p-12 bg-white/75">
-      <div class="w-full max-w-md">
-        <div class="lg:hidden mb-8 text-center">
-          <h1 class="font-headline text-3xl font-extrabold text-textmain">Local History Map</h1>
-          <p class="mt-2 text-sm text-textmuted">Sign in to continue exploring the archive.</p>
+          <a href="story-detail.html"
+            class="block bg-white/80 rounded-2xl p-4 border border-border transition hover:bg-white">
+            <p class="text-sm font-semibold text-primary">Archive Stories</p>
+            <p class="mt-2 text-sm text-textmuted">Browse memories connected to real places.</p>
+          </a>
+          <a href="map.html" class="block bg-white/80 rounded-2xl p-4 border border-border transition hover:bg-white">
+            <p class="text-sm font-semibold text-primary">Interactive Map</p>
+            <p class="mt-2 text-sm text-textmuted">Navigate history visually across the city.</p>
+          </a>
+          <a href="story-create.html"
+            class="block bg-white/80 rounded-2xl p-4 border border-border transition hover:bg-white">
+            <p class="text-sm font-semibold text-primary">Community Voices</p>
+            <p class="mt-2 text-sm text-textmuted">Read and share local narratives.</p>
+          </a>
         </div>
+      </section>
 
-        <div class="mb-8">
-          <h2 class="text-3xl font-bold text-textmain">Welcome back</h2>
-          <p class="mt-2 text-textmuted">Sign in to access your map, stories, and saved archives.</p>
-        </div>
-
-        <form id="login-form" class="space-y-5">
-          <div>
-            <label for="email" class="block text-sm font-semibold mb-2 text-textmain">Email</label>
-            <input
-                    id="email"
-                    type="email"
-                    placeholder="you@example.com"
-                    class="w-full rounded-xl border border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary"
-                    required
-            />
+      <section class="flex items-center justify-center p-8 sm:p-12 bg-white/75">
+        <div class="w-full max-w-md">
+          <div class="lg:hidden mb-8 text-center">
+            <h1 class="font-headline text-3xl font-extrabold text-textmain">Local History Map</h1>
+            <p class="mt-2 text-sm text-textmuted">Sign in to continue exploring the archive.</p>
           </div>
 
-          <div>
-            <div class="flex items-center justify-between mb-2">
-              <label for="password" class="block text-sm font-semibold text-textmain">Password</label>
-              <a href="#" class="text-sm font-medium text-tertiary hover:underline">Forgot password?</a>
+          <div class="mb-8">
+            <h2 class="text-3xl font-bold text-textmain">Welcome back</h2>
+            <p class="mt-2 text-textmuted">Sign in to access your map, stories, and saved archives.</p>
+          </div>
+
+          <form id="login-form" class="space-y-5">
+            <div>
+              <label for="email" class="block text-sm font-semibold mb-2 text-textmain">Email</label>
+              <input id="email" type="email" placeholder="you@example.com"
+                class="w-full rounded-xl border border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary"
+                required />
             </div>
-            <input
-                    id="password"
-                    type="password"
-                    placeholder="Enter your password"
-                    class="w-full rounded-xl border border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary"
-                    required
-            />
+
+            <div>
+              <div class="flex items-center justify-between mb-2">
+                <label for="password" class="block text-sm font-semibold text-textmain">Password</label>
+                <a href="#" class="text-sm font-medium text-tertiary hover:underline">Forgot password?</a>
+              </div>
+              <input id="password" type="password" placeholder="Enter your password"
+                class="w-full rounded-xl border border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary"
+                required />
+            </div>
+
+            <div class="flex items-center gap-3">
+              <input id="remember" type="checkbox" class="rounded border-border text-primary focus:ring-primary" />
+              <label for="remember" class="text-sm text-textmuted">Remember me</label>
+            </div>
+
+            <div id="login-error" class="hidden rounded-xl bg-red-50 border border-red-200 p-3 text-sm text-red-700">
+            </div>
+
+            <button type="submit"
+              class="w-full rounded-xl bg-primary px-4 py-3 text-white font-semibold hover:opacity-95 transition">
+              Sign In
+            </button>
+
+            <a href="map.html"
+              class="block w-full rounded-xl border border-border bg-white px-4 py-3 text-textmain font-semibold hover:bg-gray-50 transition text-center">
+              Browse Map
+            </a>
+          </form>
+
+          <div class="relative my-6">
+            <div class="absolute inset-0 flex items-center">
+              <div class="w-full border-t border-border"></div>
+            </div>
+            <div class="relative flex justify-center text-sm">
+              <span class="bg-white px-4 text-textmuted">or</span>
+            </div>
           </div>
 
-          <div class="flex items-center gap-3">
-            <input id="remember" type="checkbox" class="rounded border-border text-primary focus:ring-primary" />
-            <label for="remember" class="text-sm text-textmuted">Remember me</label>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <a href="story-detail.html"
+              class="inline-flex items-center justify-center rounded-xl border border-border bg-white px-4 py-3 text-sm font-medium hover:bg-gray-50 transition">
+              Continue with Google
+            </a>
+            <button id="register-button" type="button"
+              class="inline-flex items-center justify-center rounded-xl border border-border bg-white px-4 py-3 text-sm font-medium hover:bg-gray-50 transition">
+              Create Account
+            </button>
           </div>
 
-          <div id="login-error" class="hidden rounded-xl bg-red-50 border border-red-200 p-3 text-sm text-red-700"></div>
-
-          <button
-                  type="submit"
-                  class="w-full rounded-xl bg-primary px-4 py-3 text-white font-semibold hover:opacity-95 transition"
-          >
-            Sign In
-          </button>
-
-          <a
-                  href="map.html"
-                  class="block w-full rounded-xl border border-border bg-white px-4 py-3 text-textmain font-semibold hover:bg-gray-50 transition text-center"
-          >
-            Browse Map
-          </a>
-        </form>
-
-        <div class="relative my-6">
-          <div class="absolute inset-0 flex items-center">
-            <div class="w-full border-t border-border"></div>
+          <div class="mt-6 flex flex-wrap justify-center gap-3">
+            <a href="map.html" class="text-sm font-medium text-primary hover:underline">Open Map</a>
+            <a href="story-create.html" class="text-sm font-medium text-primary hover:underline">Story Creation</a>
+            <a href="story-detail.html" class="text-sm font-medium text-primary hover:underline">Story Detail</a>
           </div>
-          <div class="relative flex justify-center text-sm">
-            <span class="bg-white px-4 text-textmuted">or</span>
-          </div>
+
+          <p class="mt-8 text-sm text-textmuted text-center">
+            By continuing, you agree to our Terms and Privacy Policy.
+          </p>
         </div>
-
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          <a href="story-detail.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-white px-4 py-3 text-sm font-medium hover:bg-gray-50 transition">
-            Continue with Google
-          </a>
-          <button id="register-button" type="button" class="inline-flex items-center justify-center rounded-xl border border-border bg-white px-4 py-3 text-sm font-medium hover:bg-gray-50 transition">
-            Create Account
-          </button>
-        </div>
-
-        <div class="mt-6 flex flex-wrap justify-center gap-3">
-          <a href="map.html" class="text-sm font-medium text-primary hover:underline">Open Map</a>
-          <a href="story-create.html" class="text-sm font-medium text-primary hover:underline">Story Creation</a>
-          <a href="story-detail.html" class="text-sm font-medium text-primary hover:underline">Story Detail</a>
-        </div>
-
-        <p class="mt-8 text-sm text-textmuted text-center">
-          By continuing, you agree to our Terms and Privacy Policy.
-        </p>
-      </div>
-    </section>
+      </section>
+    </div>
   </div>
-</div>
 
-<script src="config.js"></script>
-<script src="auth.js"></script>
-<script src="login.js"></script>
+  <script src="config.js"></script>
+  <script src="auth.js"></script>
+  <script src="login.js"></script>
 </body>
+
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,220 +1,180 @@
 <!DOCTYPE html>
-
-<html class="light" lang="en"><head>
-<meta charset="utf-8"/>
-<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>Local History Map - Istanbul Chronicles</title>
-<script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=Noto+Serif:wght@400;700;800&amp;display=swap" rel="stylesheet"/>
-<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
-<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
-<script id="tailwind-config">
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Local History Map - Login</title>
+  <script src="https://cdn.tailwindcss.com?plugins=forms"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Serif:wght@700;800&display=swap" rel="stylesheet">
+  <script>
     tailwind.config = {
-      darkMode: "class",
       theme: {
         extend: {
           colors: {
-            "on-surface": "#1d1c16",
-            "surface": "#fef9f0",
-            "on-tertiary-container": "#043d69",
-            "on-primary-container": "#4e3700",
-            "inverse-primary": "#e9c176",
-            "surface-container-lowest": "#ffffff",
-            "on-primary-fixed-variant": "#5d4201",
-            "background": "#fef9f0",
-            "surface-container-high": "#ece8df",
-            "on-tertiary-fixed-variant": "#194976",
-            "secondary": "#506169",
-            "on-tertiary": "#ffffff",
-            "on-surface-variant": "#4e4639",
-            "on-error": "#ffffff",
-            "surface-bright": "#fef9f0",
-            "on-secondary-fixed": "#0d1e25",
-            "error-container": "#ffdad6",
-            "tertiary": "#35618f",
-            "primary-fixed-dim": "#e9c176",
-            "primary-fixed": "#ffdea5",
-            "surface-variant": "#e7e2d9",
-            "on-primary-fixed": "#261900",
-            "on-primary": "#ffffff",
-            "surface-tint": "#775a19",
-            "on-secondary-fixed-variant": "#394951",
-            "primary-container": "#c5a059",
-            "primary": "#775a19",
-            "outline-variant": "#d1c5b4",
-            "on-secondary-container": "#55656d",
-            "on-error-container": "#93000a",
-            "inverse-surface": "#32302a",
-            "tertiary-container": "#7fa8db",
-            "on-tertiary-fixed": "#001d36",
-            "on-secondary": "#ffffff",
-            "on-background": "#1d1c16",
-            "inverse-on-surface": "#f5f0e7",
-            "surface-dim": "#ded9d1",
-            "outline": "#7f7667",
-            "tertiary-fixed": "#d2e4ff",
-            "secondary-container": "#d1e2ec",
-            "secondary-fixed-dim": "#b8c9d3",
-            "tertiary-fixed-dim": "#a0cafe",
-            "surface-container-highest": "#e7e2d9",
-            "error": "#ba1a1a",
-            "surface-container-low": "#f8f3ea",
-            "secondary-fixed": "#d4e5ef",
-            "surface-container": "#f2ede4"
+            background: "#fef9f0",
+            surface: "#ffffff",
+            primary: "#775a19",
+            "primary-light": "#c5a059",
+            secondary: "#506169",
+            tertiary: "#35618f",
+            border: "#e7e2d9",
+            textmain: "#1d1c16",
+            textmuted: "#5f584c"
           },
           fontFamily: {
-            "headline": ["Noto Serif"],
-            "body": ["Inter"],
-            "label": ["Inter"]
+            body: ["Inter", "sans-serif"],
+            headline: ["Noto Serif", "serif"]
           },
-          borderRadius: {"DEFAULT": "0.25rem", "lg": "0.5rem", "xl": "0.75rem", "full": "9999px"},
-        },
-      },
-    }
+          boxShadow: {
+            soft: "0 20px 50px rgba(0,0,0,0.08)"
+          }
+        }
+      }
+    };
   </script>
-<style>.material-symbols-outlined {
-    font-variation-settings: "FILL" 0, "wght" 400, "GRAD" 0, "opsz" 24
+  <style>
+    body {
+      background:
+              linear-gradient(rgba(254, 249, 240, 0.88), rgba(254, 249, 240, 0.88)),
+              url("https://images.unsplash.com/photo-1512453979798-5ea266f8880c?auto=format&fit=crop&w=1600&q=80");
+      background-size: cover;
+      background-position: center;
+      background-attachment: fixed;
     }
-.map-texture {
-    background-image: url(https://lh3.googleusercontent.com/aida-public/AB6AXuBsvyBsfVlP98qqniSVy9IC69yFiegWc9BydNf_UR9ZqfKaVPL8Vmqg5_yTOImOOSZFGf2L27ovIqxWMYcGn_CSvRc_56j5U1YxCmPN84L8yj7AjvXA-m63hZj7asWzQfuhwr2YaJ4tu-EXlBJnv3oFzShGmyKDhOm_U9oaudW41mt_M4VJRVBuOsqD2eZYddamP9gizUuRl9dx-f_KqPnDMfQ6ejdDyrvQQMPSf7e_vY1nmg_urRrAlpSIB_SqrH2EIVQXFyPmp5Ic);
-    background-size: cover;
-    background-position: center;
-    filter: sepia(20%) contrast(90%) brightness(105%)
-    }
-.glass-panel {
-    background: rgba(254, 249, 240, 0.85);
-    backdrop-filter: blur(12px)
-    }
-.noise-overlay {
-    position: fixed;
-    inset: 0;
-    width: 100%;
-    height: 100%;
-    pointer-events: none;
-    opacity: 0.03;
-    z-index: 50;
-    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E")
-    }</style>
+  </style>
 </head>
-<body class="bg-surface text-on-surface font-body overflow-hidden">
-<div class="noise-overlay"></div>
-<!-- Shared Component: TopNavBar -->
-<header class="fixed top-0 left-0 right-0 z-40 bg-[#f8f3ea] dark:bg-stone-900">
-<div class="flex justify-between items-center w-full px-8 py-4 max-w-screen-2xl mx-auto">
-<div class="flex items-center gap-8">
-<h1 class="text-2xl font-bold font-headline text-[#1d1c16] dark:text-[#f2ede4] tracking-tight">Local History Map</h1>
-<nav class="hidden md:flex items-center gap-6">
-<a class="text-[#775a19] dark:text-[#c5a059] font-bold border-b-2 border-[#775a19] pb-1 font-body" href="#">Map</a>
-<a class="text-[#1d1c16] dark:text-[#f2ede4] font-medium hover:text-[#35618f] transition-colors duration-300 font-body" href="#">Archive</a>
-<a class="text-[#1d1c16] dark:text-[#f2ede4] font-medium hover:text-[#35618f] transition-colors duration-300 font-body" href="#">Chronicles</a>
-<a class="text-[#1d1c16] dark:text-[#f2ede4] font-medium hover:text-[#35618f] transition-colors duration-300 font-body" href="#">About</a>
-</nav>
-</div>
-<div class="flex items-center gap-4">
-<div class="relative group">
-<span class="absolute left-3 top-1/2 -translate-y-1/2 material-symbols-outlined text-outline">search</span>
-<input class="pl-10 pr-4 py-2 bg-surface-container-lowest border-none ring-1 ring-outline-variant/15 focus:ring-2 focus:ring-primary rounded-lg w-64 text-sm transition-all duration-300" placeholder="Explore Istanbul's past..." type="text"/>
-</div>
-<img alt="Curator Profile" class="w-10 h-10 rounded-full object-cover ring-2 ring-primary/20" data-alt="professional portrait of a middle-aged academic curator in a library setting with warm lighting" src="https://lh3.googleusercontent.com/aida-public/AB6AXuDTcsEM3IuePdpPNdjxvKMZTsyJB4h9YpTE9lTNKUyQiRd5IACaoSZBeJH3M--ijNxE2TsO5cVA-J-kXzU_sqY3ZC3FpZmO0vcuHokRpXNap_sC9e5A3Q0J4QOqvf6x5wdpOX1UI2zmXvOmyJCaqQaNWOuVuwi7aYkVz9NLkLG62S80wbSpZHy2rbLi-74YQYHNDEYNBAWZmWITcmAxlpI3KfC06Gcy5MPrbR5gsv5chllEfB1K_6Q27J_mp2hP4nuGM9IVAY39vDvp"/>
-</div>
-</div>
-</header>
-<!-- Main Content: Map Canvas -->
-<main class="relative w-full h-screen pt-16">
-<!-- Map Interface -->
-<div class="absolute inset-0 map-texture" data-location="Istanbul, Turkey" style=""></div>
-<!-- Map UI Controls -->
-<div class="absolute left-8 top-24 flex flex-col gap-3">
-<button class="glass-panel w-12 h-12 flex items-center justify-center rounded-lg text-primary shadow-sm hover:bg-surface transition-colors">
-<span class="material-symbols-outlined">add</span>
-</button>
-<button class="glass-panel w-12 h-12 flex items-center justify-center rounded-lg text-primary shadow-sm hover:bg-surface transition-colors">
-<span class="material-symbols-outlined">remove</span>
-</button>
-<button class="glass-panel w-12 h-12 flex items-center justify-center rounded-lg text-tertiary shadow-sm hover:bg-surface transition-colors">
-<span class="material-symbols-outlined">layers</span>
-</button>
-</div>
-<!-- Map Markers (Story-Specific) -->
-<!-- Marker 1: Passive -->
-<div class="absolute top-1/3 left-1/4 group cursor-pointer">
-<div class="relative">
-<div class="w-10 h-10 rounded-full border-2 border-surface bg-primary shadow-lg overflow-hidden transition-transform group-hover:scale-110">
-<img class="w-full h-full object-cover" data-alt="vintage black and white photo of an old coffee house in istanbul" src="https://lh3.googleusercontent.com/aida-public/AB6AXuDh3_e3fHr3WBJxj6aSSaO_sSsmKynht2RmFPGwP5uTU7DanYj75NJ4BdDKHrYEgFrC9Fb2WbEDm8_gFjn-8xsBTwyysyxhm8hNewkjzTilO641d8B8M46FQJKWOuJx8K0ljfmXbRdfu-30-luzQaRVv91Rfpx3B_DYX4vuqhGdX6R7D3U9c32bHzDuCbWXK2MeMAQ0kgz9h8gdUsfx-H6NqV_fDb8mXqPEpnIq2v6Ye13_cWD9rc7PuuPRe1U_yieeTo3COHM9Mdjx"/>
-</div>
-<div class="absolute -bottom-1 -right-1 w-4 h-4 bg-tertiary rounded-full border-2 border-surface"></div>
-</div>
-</div>
-<!-- Marker 2: Highlighted/Active -->
-<div class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-20">
-<!-- Story Card Preview -->
-<div class="mb-4 bg-surface-container-lowest rounded-xl shadow-2xl w-80 overflow-hidden transform scale-100 animate-in fade-in zoom-in duration-300">
-<div class="relative h-40">
-<img class="w-full h-full object-cover" data-alt="sepia toned 1970s photograph of a small humble storefront in a narrow galata street istanbul" src="https://lh3.googleusercontent.com/aida-public/AB6AXuC1VSYzV0rWnrp7TM_Ar-J9G-rOSMKA-CI9R5aLPGajntO2zYQII7bw3pSp2YkMat0UyA4xXOPsgB7oG7y3PMNOkGQiL3HO574YJqKKRa4WyZkFLoXiX_lCODH6j2VDRcg1l6qkUdZAZ4wSnAcw1kwaTXn12853JyNMky30rnYAo-M6aLt1LSTNyjlrfYxiw030MwzhaLeqHxvcALFQEzClzia_IsTuYVW3SSiudZoqD8I19TwzYKcregHohmSLh2Qy_3eDl-rTQhj6"/>
-<div class="absolute top-3 left-3 px-2 py-1 bg-primary text-surface text-[10px] font-bold uppercase tracking-widest rounded">1970s Era</div>
-</div>
-<div class="p-5">
-<h3 class="font-headline text-xl font-bold text-on-surface mb-2 leading-tight">My Father's First Shop in Galata</h3>
-<p class="text-sm text-on-surface-variant leading-relaxed mb-4 italic">
-            "The smell of fresh timber and roasted coffee always brings me back to that narrow cobblestone alley..."
-          </p>
-<div class="flex items-center justify-between">
-<span class="text-[11px] font-bold text-tertiary flex items-center gap-1">
-<span class="material-symbols-outlined text-sm">history_edu</span>
-              MEMOIR #442
-            </span>
-<button class="text-primary font-bold text-xs hover:underline">Read Archive →</button>
-</div>
-</div>
-</div>
-<!-- Active Marker -->
-<div class="mx-auto w-14 h-14 rounded-full border-4 border-tertiary bg-primary shadow-2xl overflow-hidden scale-110 ring-4 ring-tertiary/20">
-<img class="w-full h-full object-cover" data-alt="close up archive photo snippet of 1970s shop" src="https://lh3.googleusercontent.com/aida-public/AB6AXuBSmcp0kWGb-ABo3SBDsJHe0mKqHWle8Rt04XrK6Or3aJp4a7CGP0fv2kMVA3g0s67cIcrm6K1OGdgD1ueFJumoclE8JSvTk6kZvskaz167dwxe9e70vdxeTocbPpDFkXpkdYdCDkep6s5l8EhPKq9_YhZhwDFvqBZwIJAaxUHOCWtoI9v96Hn-r9H-bPNt_u1b7kfDwBEWgQ1iYUz54wmT8pTrUmT00C7zUQTys3fmcPjk4L_ZPHtyLtQf1TeoDF7Ck962Zxxmeviy"/>
-</div>
-</div>
-<!-- Marker 3: Passive -->
-<div class="absolute bottom-1/4 right-1/3 group cursor-pointer">
-<div class="relative">
-<div class="w-10 h-10 rounded-full border-2 border-surface bg-primary shadow-lg overflow-hidden transition-transform group-hover:scale-110">
-<img class="w-full h-full object-cover" data-alt="old wooden ferry on the bosphorus in grainy vintage style" src="https://lh3.googleusercontent.com/aida-public/AB6AXuANXRIoe6Ih8yrUVmhBh9ThvktRI-2WzkQjb2DfGHBXbI0hNvc6ze4aHewx-OOWaXAqOfxGUPi5htYpG6eiOkrmSGlnq7KzU_7fcbZ4Cqvh_EPFeEbCePOBRvUTx9IKb2xcb_vRigCIQbfxy-N_yGpYnbo5WiojLklJuSUFYGJ_was9Sp5FuHjANZErYpXppvQ9Ca-JOdpI5NzVFy43FLdSVNS47W0BbsK68GJAd6-uzWjkeC7OZ5Bog6Fgv8BmTqb3LmU6m817pKx0"/>
-</div>
-<div class="absolute -bottom-1 -right-1 w-4 h-4 bg-tertiary rounded-full border-2 border-surface"></div>
-</div>
-</div>
-<!-- Contextual FAB -->
-<div class="absolute bottom-8 right-8 flex flex-col items-end gap-4">
-<div class="glass-panel px-4 py-2 rounded-full border border-outline-variant/10 text-xs font-medium text-on-surface-variant flex items-center gap-2 mb-2">
-<span class="w-2 h-2 rounded-full bg-emerald-500"></span>
-        12 new stories shared today near Galata
+<body class="font-body text-textmain min-h-screen">
+<div class="min-h-screen flex items-center justify-center px-6 py-10">
+  <div class="w-full max-w-6xl grid lg:grid-cols-2 bg-white/70 backdrop-blur-md rounded-3xl overflow-hidden shadow-soft border border-white/50">
+
+    <!-- Left Side -->
+    <section class="hidden lg:flex flex-col justify-between p-12 bg-[rgba(119,90,25,0.08)]">
+      <div>
+        <div class="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-white/80 text-primary text-sm font-semibold border border-border">
+          <span>Local History Map</span>
+        </div>
+
+        <h1 class="mt-8 font-headline text-5xl leading-tight font-extrabold text-textmain">
+          Discover the city through memories, places, and stories.
+        </h1>
+
+        <p class="mt-6 text-lg leading-8 text-textmuted max-w-xl">
+          Explore personal archives, neighborhood memories, and cultural landmarks on an interactive historical map.
+        </p>
       </div>
-<button class="bg-gradient-to-br from-primary to-primary-container text-surface px-8 py-4 rounded-xl font-bold flex items-center gap-3 shadow-xl hover:scale-105 active:scale-95 transition-all">
-<span class="material-symbols-outlined" style="font-variation-settings: 'FILL' 1;">my_location</span>
-        Stories Near Me
-      </button>
+
+      <div class="grid sm:grid-cols-3 gap-4 mt-10">
+        <div class="bg-white/80 rounded-2xl p-4 border border-border">
+          <p class="text-sm font-semibold text-primary">Archive Stories</p>
+          <p class="mt-2 text-sm text-textmuted">Browse memories connected to real places.</p>
+        </div>
+        <div class="bg-white/80 rounded-2xl p-4 border border-border">
+          <p class="text-sm font-semibold text-primary">Interactive Map</p>
+          <p class="mt-2 text-sm text-textmuted">Navigate history visually across the city.</p>
+        </div>
+        <div class="bg-white/80 rounded-2xl p-4 border border-border">
+          <p class="text-sm font-semibold text-primary">Community Voices</p>
+          <p class="mt-2 text-sm text-textmuted">Read and share local narratives.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Right Side -->
+    <section class="flex items-center justify-center p-8 sm:p-12 bg-white/75">
+      <div class="w-full max-w-md">
+        <div class="lg:hidden mb-8 text-center">
+          <h1 class="font-headline text-3xl font-extrabold text-textmain">Local History Map</h1>
+          <p class="mt-2 text-sm text-textmuted">Sign in to continue exploring the archive.</p>
+        </div>
+
+        <div class="mb-8">
+          <h2 class="text-3xl font-bold text-textmain">Welcome back</h2>
+          <p class="mt-2 text-textmuted">Sign in to access your map, stories, and saved archives.</p>
+        </div>
+
+        <form class="space-y-5" onsubmit="handleLogin(event)">
+          <div>
+            <label for="email" class="block text-sm font-semibold mb-2 text-textmain">Email</label>
+            <input
+                    id="email"
+                    type="email"
+                    placeholder="you@example.com"
+                    class="w-full rounded-xl border border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary"
+                    required
+            />
+          </div>
+
+          <div>
+            <div class="flex items-center justify-between mb-2">
+              <label for="password" class="block text-sm font-semibold text-textmain">Password</label>
+              <a href="#" class="text-sm font-medium text-tertiary hover:underline">Forgot password?</a>
+            </div>
+            <input
+                    id="password"
+                    type="password"
+                    placeholder="Enter your password"
+                    class="w-full rounded-xl border border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary"
+                    required
+            />
+          </div>
+
+          <div class="flex items-center gap-3">
+            <input id="remember" type="checkbox" class="rounded border-border text-primary focus:ring-primary" />
+            <label for="remember" class="text-sm text-textmuted">Remember me</label>
+          </div>
+
+          <button
+                  type="submit"
+                  class="w-full rounded-xl bg-primary px-4 py-3 text-white font-semibold hover:opacity-95 transition"
+          >
+            Sign In
+          </button>
+
+          <button
+                  type="button"
+                  onclick="window.location.href='map.html'"
+                  class="w-full rounded-xl border border-border bg-white px-4 py-3 text-textmain font-semibold hover:bg-gray-50 transition"
+          >
+            Continue to Demo
+          </button>
+        </form>
+
+        <div class="relative my-6">
+          <div class="absolute inset-0 flex items-center">
+            <div class="w-full border-t border-border"></div>
+          </div>
+          <div class="relative flex justify-center text-sm">
+            <span class="bg-white px-4 text-textmuted">or</span>
+          </div>
+        </div>
+
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <button class="rounded-xl border border-border bg-white px-4 py-3 text-sm font-medium hover:bg-gray-50 transition">
+            Continue with Google
+          </button>
+          <button class="rounded-xl border border-border bg-white px-4 py-3 text-sm font-medium hover:bg-gray-50 transition">
+            Create Account
+          </button>
+        </div>
+
+        <p class="mt-8 text-sm text-textmuted text-center">
+          By continuing, you agree to our Terms and Privacy Policy.
+        </p>
+      </div>
+    </section>
+  </div>
 </div>
-<!-- Discovery Panel (Asymmetric Sidebar) -->
-<aside class="absolute top-24 right-8 w-72 glass-panel rounded-2xl p-6 shadow-sm pointer-events-auto border border-outline-variant/5">
-<div class="flex items-center justify-between mb-6">
-<h2 class="font-headline font-bold text-lg">Curated Focus</h2>
-<span class="material-symbols-outlined text-outline">tune</span>
-</div>
-<div class="space-y-6">
-<div class="group cursor-pointer">
-<div class="text-[10px] font-bold text-tertiary tracking-widest uppercase mb-1">Current Narrative</div>
-<h4 class="font-bold text-sm mb-1 group-hover:text-primary transition-colors">The Levantines of Beyoğlu</h4>
-<p class="text-xs text-on-surface-variant line-clamp-2 leading-relaxed">Tracing the architectural footprint of 19th-century trade families...</p>
-</div>
-<div class="h-px bg-outline-variant/10"></div>
-<div>
-<div class="text-[10px] font-bold text-tertiary tracking-widest uppercase mb-3">Time Filter</div>
-<div class="grid grid-cols-2 gap-2">
-<button class="px-3 py-2 rounded-lg bg-surface-container-high text-xs font-medium text-center hover:bg-primary hover:text-surface transition-all">Modernist</button>
-<button class="px-3 py-2 rounded-lg bg-surface-container-high text-xs font-medium text-center hover:bg-primary hover:text-surface transition-all">Digital Age</button>
-</div>
-</div>
-</div>
-</aside>
-</main>
-<!-- Shared Component: Footer (Suppressed for focused map view, normally would go here) -->
-<!-- Following the Shell Visibility & Relevance rule: Navigation suppressed to prioritize map canvas -->
-</body></html>
+
+<script>
+  function handleLogin(event) {
+    event.preventDefault();
+
+    // Demo flow for now
+    // Later you can replace this with a real fetch() call to backend
+    window.location.href = "map.html";
+  }
+</script>
+</body>
+</html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -64,19 +64,19 @@
         </p>
       </div>
 
-      <div class="grid sm:grid-cols-3 gap-4 mt-10">
-        <div class="bg-white/80 rounded-2xl p-4 border border-border">
+        <div class="grid sm:grid-cols-3 gap-4 mt-10">
+        <a href="story-detail.html" class="block bg-white/80 rounded-2xl p-4 border border-border transition hover:bg-white">
           <p class="text-sm font-semibold text-primary">Archive Stories</p>
           <p class="mt-2 text-sm text-textmuted">Browse memories connected to real places.</p>
-        </div>
-        <div class="bg-white/80 rounded-2xl p-4 border border-border">
+        </a>
+        <a href="map.html" class="block bg-white/80 rounded-2xl p-4 border border-border transition hover:bg-white">
           <p class="text-sm font-semibold text-primary">Interactive Map</p>
           <p class="mt-2 text-sm text-textmuted">Navigate history visually across the city.</p>
-        </div>
-        <div class="bg-white/80 rounded-2xl p-4 border border-border">
+        </a>
+        <a href="story-create.html" class="block bg-white/80 rounded-2xl p-4 border border-border transition hover:bg-white">
           <p class="text-sm font-semibold text-primary">Community Voices</p>
           <p class="mt-2 text-sm text-textmuted">Read and share local narratives.</p>
-        </div>
+        </a>
       </div>
     </section>
 
@@ -149,12 +149,18 @@
         </div>
 
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          <button class="rounded-xl border border-border bg-white px-4 py-3 text-sm font-medium hover:bg-gray-50 transition">
+          <a href="story-detail.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-white px-4 py-3 text-sm font-medium hover:bg-gray-50 transition">
             Continue with Google
-          </button>
-          <button class="rounded-xl border border-border bg-white px-4 py-3 text-sm font-medium hover:bg-gray-50 transition">
+          </a>
+          <a href="story-create.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-white px-4 py-3 text-sm font-medium hover:bg-gray-50 transition">
             Create Account
-          </button>
+          </a>
+        </div>
+
+        <div class="mt-6 flex flex-wrap justify-center gap-3">
+          <a href="map.html" class="text-sm font-medium text-primary hover:underline">Open Map</a>
+          <a href="story-create.html" class="text-sm font-medium text-primary hover:underline">Story Creation</a>
+          <a href="story-detail.html" class="text-sm font-medium text-primary hover:underline">Story Detail</a>
         </div>
 
         <p class="mt-8 text-sm text-textmuted text-center">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -152,9 +152,9 @@
           <a href="story-detail.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-white px-4 py-3 text-sm font-medium hover:bg-gray-50 transition">
             Continue with Google
           </a>
-          <a href="story-create.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-white px-4 py-3 text-sm font-medium hover:bg-gray-50 transition">
+          <button id="register-button" type="button" class="inline-flex items-center justify-center rounded-xl border border-border bg-white px-4 py-3 text-sm font-medium hover:bg-gray-50 transition">
             Create Account
-          </a>
+          </button>
         </div>
 
         <div class="mt-6 flex flex-wrap justify-center gap-3">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -49,7 +49,6 @@
 <div class="min-h-screen flex items-center justify-center px-6 py-10">
   <div class="w-full max-w-6xl grid lg:grid-cols-2 bg-white/70 backdrop-blur-md rounded-3xl overflow-hidden shadow-soft border border-white/50">
 
-    <!-- Left Side -->
     <section class="hidden lg:flex flex-col justify-between p-12 bg-[rgba(119,90,25,0.08)]">
       <div>
         <div class="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-white/80 text-primary text-sm font-semibold border border-border">
@@ -81,7 +80,6 @@
       </div>
     </section>
 
-    <!-- Right Side -->
     <section class="flex items-center justify-center p-8 sm:p-12 bg-white/75">
       <div class="w-full max-w-md">
         <div class="lg:hidden mb-8 text-center">
@@ -94,7 +92,7 @@
           <p class="mt-2 text-textmuted">Sign in to access your map, stories, and saved archives.</p>
         </div>
 
-        <form class="space-y-5" onsubmit="handleLogin(event)">
+        <form id="login-form" class="space-y-5">
           <div>
             <label for="email" class="block text-sm font-semibold mb-2 text-textmain">Email</label>
             <input
@@ -133,8 +131,8 @@
           </button>
 
           <button
+                  id="demo-button"
                   type="button"
-                  onclick="window.location.href='map.html'"
                   class="w-full rounded-xl border border-border bg-white px-4 py-3 text-textmain font-semibold hover:bg-gray-50 transition"
           >
             Continue to Demo
@@ -167,14 +165,6 @@
   </div>
 </div>
 
-<script>
-  function handleLogin(event) {
-    event.preventDefault();
-
-    // Demo flow for now
-    // Later you can replace this with a real fetch() call to backend
-    window.location.href = "map.html";
-  }
-</script>
+<script src="login.js"></script>
 </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -123,6 +123,8 @@
             <label for="remember" class="text-sm text-textmuted">Remember me</label>
           </div>
 
+          <div id="login-error" class="hidden rounded-xl bg-red-50 border border-red-200 p-3 text-sm text-red-700"></div>
+
           <button
                   type="submit"
                   class="w-full rounded-xl bg-primary px-4 py-3 text-white font-semibold hover:opacity-95 transition"
@@ -130,13 +132,12 @@
             Sign In
           </button>
 
-          <button
-                  id="demo-button"
-                  type="button"
-                  class="w-full rounded-xl border border-border bg-white px-4 py-3 text-textmain font-semibold hover:bg-gray-50 transition"
+          <a
+                  href="map.html"
+                  class="block w-full rounded-xl border border-border bg-white px-4 py-3 text-textmain font-semibold hover:bg-gray-50 transition text-center"
           >
-            Continue to Demo
-          </button>
+            Browse Map
+          </a>
         </form>
 
         <div class="relative my-6">
@@ -171,6 +172,8 @@
   </div>
 </div>
 
+<script src="config.js"></script>
+<script src="auth.js"></script>
 <script src="login.js"></script>
 </body>
 </html>

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+    testEnvironment: "jsdom"
+};

--- a/frontend/login.js
+++ b/frontend/login.js
@@ -1,0 +1,38 @@
+function redirectToMap() {
+    window.location.assign("map.html");
+}
+
+function handleLogin(event) {
+    event.preventDefault();
+    redirectToMap();
+}
+
+function handleDemoClick() {
+    redirectToMap();
+}
+
+function setupLoginForm() {
+    const form = document.getElementById("login-form");
+    const demoButton = document.getElementById("demo-button");
+
+    if (form) {
+        form.addEventListener("submit", handleLogin);
+    }
+
+    if (demoButton) {
+        demoButton.addEventListener("click", handleDemoClick);
+    }
+}
+
+if (typeof document !== "undefined") {
+    document.addEventListener("DOMContentLoaded", setupLoginForm);
+}
+
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = {
+        redirectToMap,
+        handleLogin,
+        handleDemoClick,
+        setupLoginForm
+    };
+}

--- a/frontend/login.js
+++ b/frontend/login.js
@@ -6,26 +6,70 @@ function redirectToRegister() {
     window.location.assign("register.html");
 }
 
-function handleLogin(event) {
-    event.preventDefault();
-    redirectToMap();
+function showLoginError(msg) {
+    var el = document.getElementById("login-error");
+    if (el) {
+        el.textContent = msg;
+        el.classList.remove("hidden");
+    }
 }
 
-function handleDemoClick() {
-    redirectToMap();
+function hideLoginError() {
+    var el = document.getElementById("login-error");
+    if (el) {
+        el.classList.add("hidden");
+    }
+}
+
+async function handleLogin(event) {
+    event.preventDefault();
+    hideLoginError();
+
+    var email = document.getElementById("email").value.trim();
+    var password = document.getElementById("password").value;
+
+    if (!email || !password) {
+        showLoginError("Please enter your email and password.");
+        return;
+    }
+
+    var submitBtn = event.target.querySelector('button[type="submit"]');
+    if (submitBtn) {
+        submitBtn.disabled = true;
+        submitBtn.textContent = "Signing in...";
+    }
+
+    try {
+        var res = await fetch(API_BASE + "/auth/login", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ email: email, password: password })
+        });
+
+        if (!res.ok) {
+            var data = await res.json().catch(function () { return {}; });
+            throw new Error(data.detail || "Invalid email or password.");
+        }
+
+        var result = await res.json();
+        localStorage.setItem("auth_token", result.access_token);
+        redirectToMap();
+    } catch (err) {
+        showLoginError(err.message);
+    } finally {
+        if (submitBtn) {
+            submitBtn.disabled = false;
+            submitBtn.textContent = "Sign In";
+        }
+    }
 }
 
 function setupLoginForm() {
-    const form = document.getElementById("login-form");
-    const demoButton = document.getElementById("demo-button");
-    const registerButton = document.getElementById("register-button");
+    var form = document.getElementById("login-form");
+    var registerButton = document.getElementById("register-button");
 
     if (form) {
         form.addEventListener("submit", handleLogin);
-    }
-
-    if (demoButton) {
-        demoButton.addEventListener("click", handleDemoClick);
     }
 
     if (registerButton) {
@@ -39,10 +83,9 @@ if (typeof document !== "undefined") {
 
 if (typeof module !== "undefined" && module.exports) {
     module.exports = {
-        redirectToMap,
-        redirectToRegister,
-        handleLogin,
-        handleDemoClick,
-        setupLoginForm
+        redirectToMap: redirectToMap,
+        redirectToRegister: redirectToRegister,
+        handleLogin: handleLogin,
+        setupLoginForm: setupLoginForm
     };
 }

--- a/frontend/login.js
+++ b/frontend/login.js
@@ -2,6 +2,10 @@ function redirectToMap() {
     window.location.assign("map.html");
 }
 
+function redirectToRegister() {
+    window.location.assign("register.html");
+}
+
 function handleLogin(event) {
     event.preventDefault();
     redirectToMap();
@@ -14,6 +18,7 @@ function handleDemoClick() {
 function setupLoginForm() {
     const form = document.getElementById("login-form");
     const demoButton = document.getElementById("demo-button");
+    const registerButton = document.getElementById("register-button");
 
     if (form) {
         form.addEventListener("submit", handleLogin);
@@ -21,6 +26,10 @@ function setupLoginForm() {
 
     if (demoButton) {
         demoButton.addEventListener("click", handleDemoClick);
+    }
+
+    if (registerButton) {
+        registerButton.addEventListener("click", redirectToRegister);
     }
 }
 
@@ -31,6 +40,7 @@ if (typeof document !== "undefined") {
 if (typeof module !== "undefined" && module.exports) {
     module.exports = {
         redirectToMap,
+        redirectToRegister,
         handleLogin,
         handleDemoClick,
         setupLoginForm

--- a/frontend/login.test.js
+++ b/frontend/login.test.js
@@ -1,7 +1,9 @@
+global.API_BASE = "http://localhost";
+global.fetch = jest.fn();
+
 const {
     redirectToMap,
     handleLogin,
-    handleDemoClick,
     setupLoginForm
 } = require("./login");
 
@@ -12,10 +14,22 @@ describe("login page unit tests", () => {
         document.body.innerHTML = "";
         assignMock = jest.fn();
 
-        delete window.location;
-        window.location = {
-            assign: assignMock
-        };
+        Object.defineProperty(window, "location", {
+            value: { assign: assignMock, origin: "http://localhost" },
+            writable: true,
+            configurable: true
+        });
+
+        global.fetch.mockReset();
+
+        const store = {};
+        jest.spyOn(Storage.prototype, "setItem").mockImplementation((key, val) => { store[key] = val; });
+        jest.spyOn(Storage.prototype, "getItem").mockImplementation((key) => store[key] || null);
+        jest.spyOn(Storage.prototype, "removeItem").mockImplementation((key) => { delete store[key]; });
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
     });
 
     test("redirectToMap sends user to map.html", () => {
@@ -23,20 +37,89 @@ describe("login page unit tests", () => {
         expect(assignMock).toHaveBeenCalledWith("map.html");
     });
 
-    test("handleLogin prevents default and redirects", () => {
+    test("handleLogin calls API and stores token on success", async () => {
+        document.body.innerHTML = `
+      <form id="login-form">
+        <input id="email" type="email" value="test@example.com" />
+        <input id="password" type="password" value="Password1!" />
+        <button type="submit">Sign In</button>
+        <div id="login-error" class="hidden"></div>
+      </form>
+    `;
+
+        global.fetch.mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve({ access_token: "test-jwt-token", token_type: "bearer" })
+        });
+
         const event = {
-            preventDefault: jest.fn()
+            preventDefault: jest.fn(),
+            target: document.getElementById("login-form")
         };
 
-        handleLogin(event);
+        await handleLogin(event);
 
         expect(event.preventDefault).toHaveBeenCalledTimes(1);
+        expect(global.fetch).toHaveBeenCalledWith(
+            "http://localhost/auth/login",
+            expect.objectContaining({
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ email: "test@example.com", password: "Password1!" })
+            })
+        );
+        expect(localStorage.setItem).toHaveBeenCalledWith("auth_token", "test-jwt-token");
         expect(assignMock).toHaveBeenCalledWith("map.html");
     });
 
-    test("handleDemoClick redirects to map.html", () => {
-        handleDemoClick();
-        expect(assignMock).toHaveBeenCalledWith("map.html");
+    test("handleLogin shows error on API failure", async () => {
+        document.body.innerHTML = `
+      <form id="login-form">
+        <input id="email" type="email" value="test@example.com" />
+        <input id="password" type="password" value="wrong" />
+        <button type="submit">Sign In</button>
+        <div id="login-error" class="hidden"></div>
+      </form>
+    `;
+
+        global.fetch.mockResolvedValueOnce({
+            ok: false,
+            json: () => Promise.resolve({ detail: "Invalid email or password" })
+        });
+
+        const event = {
+            preventDefault: jest.fn(),
+            target: document.getElementById("login-form")
+        };
+
+        await handleLogin(event);
+
+        var errorEl = document.getElementById("login-error");
+        expect(errorEl.textContent).toBe("Invalid email or password");
+        expect(errorEl.classList.contains("hidden")).toBe(false);
+        expect(assignMock).not.toHaveBeenCalled();
+    });
+
+    test("handleLogin shows error when fields are empty", async () => {
+        document.body.innerHTML = `
+      <form id="login-form">
+        <input id="email" type="email" value="" />
+        <input id="password" type="password" value="" />
+        <button type="submit">Sign In</button>
+        <div id="login-error" class="hidden"></div>
+      </form>
+    `;
+
+        const event = {
+            preventDefault: jest.fn(),
+            target: document.getElementById("login-form")
+        };
+
+        await handleLogin(event);
+
+        var errorEl = document.getElementById("login-error");
+        expect(errorEl.textContent).toBe("Please enter your email and password.");
+        expect(global.fetch).not.toHaveBeenCalled();
     });
 
     test("setupLoginForm attaches submit listener to form", () => {
@@ -46,7 +129,6 @@ describe("login page unit tests", () => {
         <input id="password" type="password" />
         <button type="submit">Sign In</button>
       </form>
-      <button id="demo-button" type="button">Continue to Demo</button>
     `;
 
         setupLoginForm();
@@ -55,24 +137,6 @@ describe("login page unit tests", () => {
         const submitEvent = new Event("submit", { bubbles: true, cancelable: true });
 
         form.dispatchEvent(submitEvent);
-
-        expect(assignMock).toHaveBeenCalledWith("map.html");
-    });
-
-    test("setupLoginForm attaches click listener to demo button", () => {
-        document.body.innerHTML = `
-      <form id="login-form">
-        <button type="submit">Sign In</button>
-      </form>
-      <button id="demo-button" type="button">Continue to Demo</button>
-    `;
-
-        setupLoginForm();
-
-        const demoButton = document.getElementById("demo-button");
-        demoButton.click();
-
-        expect(assignMock).toHaveBeenCalledWith("map.html");
     });
 
     test("setupLoginForm does not crash if elements are missing", () => {

--- a/frontend/login.test.js
+++ b/frontend/login.test.js
@@ -1,0 +1,81 @@
+const {
+    redirectToMap,
+    handleLogin,
+    handleDemoClick,
+    setupLoginForm
+} = require("./login");
+
+describe("login page unit tests", () => {
+    let assignMock;
+
+    beforeEach(() => {
+        document.body.innerHTML = "";
+        assignMock = jest.fn();
+
+        delete window.location;
+        window.location = {
+            assign: assignMock
+        };
+    });
+
+    test("redirectToMap sends user to map.html", () => {
+        redirectToMap();
+        expect(assignMock).toHaveBeenCalledWith("map.html");
+    });
+
+    test("handleLogin prevents default and redirects", () => {
+        const event = {
+            preventDefault: jest.fn()
+        };
+
+        handleLogin(event);
+
+        expect(event.preventDefault).toHaveBeenCalledTimes(1);
+        expect(assignMock).toHaveBeenCalledWith("map.html");
+    });
+
+    test("handleDemoClick redirects to map.html", () => {
+        handleDemoClick();
+        expect(assignMock).toHaveBeenCalledWith("map.html");
+    });
+
+    test("setupLoginForm attaches submit listener to form", () => {
+        document.body.innerHTML = `
+      <form id="login-form">
+        <input id="email" type="email" />
+        <input id="password" type="password" />
+        <button type="submit">Sign In</button>
+      </form>
+      <button id="demo-button" type="button">Continue to Demo</button>
+    `;
+
+        setupLoginForm();
+
+        const form = document.getElementById("login-form");
+        const submitEvent = new Event("submit", { bubbles: true, cancelable: true });
+
+        form.dispatchEvent(submitEvent);
+
+        expect(assignMock).toHaveBeenCalledWith("map.html");
+    });
+
+    test("setupLoginForm attaches click listener to demo button", () => {
+        document.body.innerHTML = `
+      <form id="login-form">
+        <button type="submit">Sign In</button>
+      </form>
+      <button id="demo-button" type="button">Continue to Demo</button>
+    `;
+
+        setupLoginForm();
+
+        const demoButton = document.getElementById("demo-button");
+        demoButton.click();
+
+        expect(assignMock).toHaveBeenCalledWith("map.html");
+    });
+
+    test("setupLoginForm does not crash if elements are missing", () => {
+        expect(() => setupLoginForm()).not.toThrow();
+    });
+});

--- a/frontend/map.html
+++ b/frontend/map.html
@@ -16,6 +16,131 @@
     <!-- Leaflet CSS -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
     <script>
+        let profileButton;
+        let profileButtonIcon;
+        let profileButtonInitials;
+        let profileMenu;
+        let profileMenuState;
+        let profileMenuActions;
+        let profileMenuUser;
+        let profileMenuName;
+        let profileMenuEmail;
+        let currentUser = null;
+
+        function getProfileLabel(user) {
+            if (!user) return "";
+            return (user.display_name || user.username || user.email || "").trim();
+        }
+
+        function getProfileInitials(user) {
+            var label = getProfileLabel(user);
+            if (!label) return "";
+
+            return label
+                .split(/\s+/)
+                .filter(Boolean)
+                .slice(0, 2)
+                .map(function (part) {
+                    return part.charAt(0).toUpperCase();
+                })
+                .join("");
+        }
+
+        function setProfileButton(user) {
+            var initials = getProfileInitials(user);
+
+            if (initials) {
+                profileButtonIcon.classList.add("hidden");
+                profileButtonInitials.textContent = initials;
+                profileButtonInitials.classList.remove("hidden");
+                profileButtonInitials.classList.add("inline-flex");
+                profileButton.setAttribute("aria-label", "Open account menu for " + getProfileLabel(user));
+                return;
+            }
+
+            profileButtonIcon.classList.remove("hidden");
+            profileButtonInitials.textContent = "";
+            profileButtonInitials.classList.add("hidden");
+            profileButtonInitials.classList.remove("inline-flex");
+            profileButton.setAttribute("aria-label", "Open account menu");
+        }
+
+        function closeProfileMenu() {
+            profileMenu.hidden = true;
+            profileButton.setAttribute("aria-expanded", "false");
+        }
+
+        function openProfileMenu() {
+            profileMenu.hidden = false;
+            profileButton.setAttribute("aria-expanded", "true");
+        }
+
+        function toggleProfileMenu() {
+            if (profileMenu.hidden) {
+                openProfileMenu();
+                return;
+            }
+
+            closeProfileMenu();
+        }
+
+        function renderProfileMenu() {
+            profileMenuActions.innerHTML = "";
+
+            if (!currentUser) {
+                profileMenuState.textContent = "Sign in to create stories and manage your account.";
+                profileMenuUser.classList.add("hidden");
+
+                var signInLink = document.createElement("a");
+                signInLink.href = "index.html";
+                signInLink.className = "flex w-full items-center justify-center rounded-xl bg-primary px-4 py-3 text-sm font-semibold text-white transition hover:opacity-95";
+                signInLink.textContent = "Sign In";
+                signInLink.setAttribute("role", "menuitem");
+                profileMenuActions.appendChild(signInLink);
+                setProfileButton(null);
+                return;
+            }
+
+            profileMenuState.textContent = "Signed in";
+            profileMenuUser.classList.remove("hidden");
+            profileMenuName.textContent = getProfileLabel(currentUser);
+            profileMenuEmail.textContent = currentUser.email || "";
+
+            var signOutButton = document.createElement("button");
+            signOutButton.type = "button";
+            signOutButton.className = "flex w-full items-center justify-between rounded-xl px-4 py-3 text-sm font-medium text-textmain transition hover:bg-background";
+            signOutButton.textContent = "Sign Out";
+            signOutButton.setAttribute("role", "menuitem");
+            signOutButton.addEventListener("click", function () {
+                logout();
+            });
+            profileMenuActions.appendChild(signOutButton);
+            setProfileButton(currentUser);
+        }
+
+        async function loadCurrentUser() {
+            currentUser = null;
+            renderProfileMenu();
+
+            if (!isLoggedIn()) {
+                return;
+            }
+
+            try {
+                var response = await authFetch(API_BASE + "/auth/me");
+                if (!response.ok) {
+                    localStorage.removeItem(AUTH_TOKEN_KEY);
+                    renderProfileMenu();
+                    return;
+                }
+
+                currentUser = await response.json();
+                renderProfileMenu();
+            } catch (err) {
+                profileMenuState.textContent = "Unable to load account details right now.";
+                setProfileButton(null);
+            }
+        }
         tailwind.config = {
             theme: {
                 extend: {
@@ -131,6 +256,10 @@
             background: #c5a059;
             border-radius: 4px;
         }
+
+        #profile-menu[hidden] {
+            display: none;
+        }
     </style>
 </head>
 
@@ -139,17 +268,8 @@
     <!-- Top Navigation Bar -->
     <header class="fixed top-0 left-0 right-0 z-[1000] bg-[#f8f3ea]/95 backdrop-blur-sm border-b border-border/30">
         <div class="flex justify-between items-center w-full px-8 py-4 max-w-screen-2xl mx-auto">
-            <div class="flex items-center gap-8">
+            <div class="flex items-center">
                 <h1 class="text-2xl font-bold font-headline text-textmain tracking-tight">Local History Map</h1>
-                <nav class="hidden md:flex items-center gap-6">
-                    <a class="text-primary font-bold border-b-2 border-primary pb-1" href="map.html">Map</a>
-                    <a class="text-textmain font-medium hover:text-tertiary transition-colors"
-                        href="story-detail.html">Archive</a>
-                    <a class="text-textmain font-medium hover:text-tertiary transition-colors"
-                        href="story-create.html">Create Story</a>
-                    <a class="text-textmain font-medium hover:text-tertiary transition-colors"
-                        href="index.html">Login</a>
-                </nav>
             </div>
             <div class="flex items-center gap-3 sm:gap-4">
                 <!-- Search -->
@@ -163,11 +283,30 @@
                         class="absolute top-full left-0 right-0 mt-1 bg-white border border-border rounded-xl shadow-soft overflow-hidden hidden z-50">
                     </div>
                 </div>
-                <button id="btn-profile" type="button"
-                    class="inline-flex h-11 w-11 items-center justify-center rounded-full border border-border bg-white text-textmain shadow-sm transition hover:bg-stone-50"
-                    aria-label="Open profile">
-                    <span class="material-symbols-outlined text-[20px] leading-none">account_circle</span>
-                </button>
+                <div class="relative">
+                    <button id="btn-profile" type="button"
+                        class="inline-flex h-11 min-w-11 items-center justify-center rounded-full border border-border bg-white px-2 text-textmain shadow-sm transition hover:bg-stone-50"
+                        aria-label="Open account menu"
+                        aria-haspopup="menu"
+                        aria-expanded="false">
+                        <span id="profile-button-icon" class="material-symbols-outlined text-[20px] leading-none">account_circle</span>
+                        <span id="profile-button-initials"
+                            class="hidden h-7 min-w-7 items-center justify-center rounded-full bg-primary text-xs font-bold uppercase text-white"></span>
+                    </button>
+                    <div id="profile-menu" hidden
+                        class="absolute right-0 top-[calc(100%+0.75rem)] w-72 rounded-2xl border border-border bg-white p-2 shadow-soft"
+                        role="menu"
+                        aria-labelledby="btn-profile">
+                        <div id="profile-menu-state" class="px-4 py-3 text-sm text-textmuted">
+                            Checking account status...
+                        </div>
+                        <div id="profile-menu-actions" class="space-y-1"></div>
+                        <div id="profile-menu-user" class="hidden border-t border-border/70 px-4 py-3">
+                            <p id="profile-menu-name" class="text-sm font-semibold text-textmain"></p>
+                            <p id="profile-menu-email" class="mt-1 text-xs text-textmuted break-all"></p>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     </header>
@@ -212,7 +351,7 @@
 
         <!-- Discovery Sidebar -->
         <aside id="sidebar"
-            class="relative z-[1000] m-4 mt-5 glass-panel rounded-2xl p-5 shadow-sm border border-border/20 md:absolute md:top-24 md:right-4 md:m-0 md:mt-0 md:w-72 md:max-h-[calc(100vh-200px)] md:overflow-y-auto">
+            class="relative z-[1000] m-4 mt-5 glass-panel rounded-2xl p-5 shadow-sm border border-border/20 md:absolute md:top-48 md:right-4 md:m-0 md:mt-0 md:w-72 md:max-h-[calc(100vh-296px)] md:overflow-y-auto">
             <div class="flex items-center justify-between mb-5">
                 <h2 class="font-headline font-bold text-lg">Recent Stories</h2>
                 <button id="btn-close-sidebar" class="hidden text-textmuted hover:text-textmain transition-colors md:inline-flex">
@@ -225,10 +364,21 @@
         </aside>
     </main>
 
+    <script src="config.js"></script>
+    <script src="auth.js"></script>
     <!-- Leaflet JS -->
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 
     <script>
+        profileButton = document.getElementById("btn-profile");
+        profileButtonIcon = document.getElementById("profile-button-icon");
+        profileButtonInitials = document.getElementById("profile-button-initials");
+        profileMenu = document.getElementById("profile-menu");
+        profileMenuState = document.getElementById("profile-menu-state");
+        profileMenuActions = document.getElementById("profile-menu-actions");
+        profileMenuUser = document.getElementById("profile-menu-user");
+        profileMenuName = document.getElementById("profile-menu-name");
+        profileMenuEmail = document.getElementById("profile-menu-email");
         // ─── Mock story data (will be replaced by API calls) ───
         const MOCK_STORIES = [
             {
@@ -541,12 +691,27 @@
             if (!document.getElementById("search-container").contains(e.target)) {
                 searchResults.classList.add("hidden");
             }
+
+            if (!profileMenu.hidden && !profileMenu.contains(e.target) && !profileButton.contains(e.target)) {
+                closeProfileMenu();
+            }
+        });
+
+        profileButton.addEventListener("click", function () {
+            toggleProfileMenu();
+        });
+
+        document.addEventListener("keydown", function (e) {
+            if (e.key === "Escape") {
+                closeProfileMenu();
+            }
         });
 
         // ─── Initialize ───
         // In production, this would be: fetch("/api/stories").then(r => r.json()).then(loadStories)
         loadStories(MOCK_STORIES);
         populateSidebar(MOCK_STORIES);
+        loadCurrentUser();
         syncMapSize();
         window.addEventListener("resize", syncMapSize);
     </script>

--- a/frontend/map.html
+++ b/frontend/map.html
@@ -386,22 +386,29 @@
         profileMenuUser = document.getElementById("profile-menu-user");
         profileMenuName = document.getElementById("profile-menu-name");
         profileMenuEmail = document.getElementById("profile-menu-email");
-        // ─── Story cache & fetching ───
-        var cachedStories = null;
+        // ─── Story fetching ───
+        var cachedStories = [];
+        var fetchTimeout = null;
 
-        async function fetchStories() {
-            if (cachedStories) return cachedStories;
+        async function fetchStoriesInBounds() {
+            var bounds = map.getBounds();
+            var params = new URLSearchParams({
+                min_lat: bounds.getSouthWest().lat,
+                max_lat: bounds.getNorthEast().lat,
+                min_lng: bounds.getSouthWest().lng,
+                max_lng: bounds.getNorthEast().lng
+            });
 
             try {
-                var response = await fetch(API_BASE + "/stories");
+                var response = await fetch(API_BASE + "/stories?" + params.toString());
                 if (!response.ok) throw new Error("Failed to fetch stories");
                 var data = await response.json();
                 cachedStories = data.stories || [];
-                return cachedStories;
+                loadStories(cachedStories);
+                populateSidebar(cachedStories);
             } catch (err) {
                 console.error("Error fetching stories:", err);
                 document.getElementById("story-count").textContent = "Failed to load stories";
-                return [];
             }
         }
 
@@ -654,10 +661,11 @@
         });
 
         // ─── Initialize ───
-        fetchStories().then(function (stories) {
-            loadStories(stories);
-            populateSidebar(stories);
+        map.on("moveend", function () {
+            clearTimeout(fetchTimeout);
+            fetchTimeout = setTimeout(fetchStoriesInBounds, 300);
         });
+        fetchStoriesInBounds();
         loadCurrentUser();
         syncMapSize();
         window.addEventListener("resize", syncMapSize);

--- a/frontend/map.html
+++ b/frontend/map.html
@@ -151,7 +151,7 @@
                         href="index.html">Login</a>
                 </nav>
             </div>
-            <div class="flex items-center gap-4">
+            <div class="flex items-center gap-3 sm:gap-4">
                 <!-- Search -->
                 <div class="relative hidden sm:block" id="search-container">
                     <span
@@ -163,6 +163,11 @@
                         class="absolute top-full left-0 right-0 mt-1 bg-white border border-border rounded-xl shadow-soft overflow-hidden hidden z-50">
                     </div>
                 </div>
+                <button id="btn-profile" type="button"
+                    class="inline-flex h-11 w-11 items-center justify-center rounded-full border border-border bg-white text-textmain shadow-sm transition hover:bg-stone-50"
+                    aria-label="Open profile">
+                    <span class="material-symbols-outlined text-[20px] leading-none">account_circle</span>
+                </button>
             </div>
         </div>
     </header>

--- a/frontend/map.html
+++ b/frontend/map.html
@@ -293,17 +293,15 @@
                 <div class="relative">
                     <button id="btn-profile" type="button"
                         class="inline-flex h-11 min-w-11 items-center justify-center rounded-full border border-border bg-white px-2 text-textmain shadow-sm transition hover:bg-stone-50"
-                        aria-label="Open account menu"
-                        aria-haspopup="menu"
-                        aria-expanded="false">
-                        <span id="profile-button-icon" class="material-symbols-outlined text-[20px] leading-none">account_circle</span>
+                        aria-label="Open account menu" aria-haspopup="menu" aria-expanded="false">
+                        <span id="profile-button-icon"
+                            class="material-symbols-outlined text-[20px] leading-none">account_circle</span>
                         <span id="profile-button-initials"
                             class="hidden h-7 min-w-7 items-center justify-center rounded-full bg-primary text-xs font-bold uppercase text-white"></span>
                     </button>
                     <div id="profile-menu" hidden
                         class="absolute right-0 top-[calc(100%+0.75rem)] w-72 rounded-2xl border border-border bg-white p-2 shadow-soft"
-                        role="menu"
-                        aria-labelledby="btn-profile">
+                        role="menu" aria-labelledby="btn-profile">
                         <div id="profile-menu-state" class="px-4 py-3 text-sm text-textmuted">
                             Checking account status...
                         </div>
@@ -350,7 +348,8 @@
             <div class="absolute bottom-6 right-4 z-[1000] md:bottom-8 md:right-8">
                 <a href="story-create.html"
                     class="flex items-center gap-3 bg-primary text-white px-4 py-3 rounded-xl text-sm font-semibold shadow-xl hover:scale-105 active:scale-95 transition-all border border-primary-light/20 md:px-6 md:py-4 md:text-base">
-                    <span class="material-symbols-outlined" style="font-variation-settings: 'FILL' 1;">edit_square</span>
+                    <span class="material-symbols-outlined"
+                        style="font-variation-settings: 'FILL' 1;">edit_square</span>
                     Share a Story
                 </a>
             </div>
@@ -361,7 +360,8 @@
             class="relative z-[1000] m-4 mt-5 glass-panel rounded-2xl p-5 shadow-sm border border-border/20 md:absolute md:top-48 md:right-4 md:m-0 md:mt-0 md:w-72 md:max-h-[calc(100vh-296px)] md:overflow-y-auto">
             <div class="flex items-center justify-between mb-5">
                 <h2 class="font-headline font-bold text-lg">Recent Stories</h2>
-                <button id="btn-close-sidebar" class="hidden text-textmuted hover:text-textmain transition-colors md:inline-flex">
+                <button id="btn-close-sidebar"
+                    class="hidden text-textmuted hover:text-textmain transition-colors md:inline-flex">
                     <span class="material-symbols-outlined text-xl">close</span>
                 </button>
             </div>
@@ -661,11 +661,15 @@
         });
 
         // ─── Initialize ───
-        map.on("moveend", function () {
-            clearTimeout(fetchTimeout);
-            fetchTimeout = setTimeout(fetchStoriesInBounds, 300);
-        });
-        fetchStoriesInBounds();
+        fetch(API_BASE + "/stories")
+            .then(res => res.json())
+            .then(data => {
+                var realStories = data.stories || [];
+                loadStories(realStories);
+                populateSidebar(realStories);
+            })
+            .catch(err => console.error("Error loading stories:", err));
+
         loadCurrentUser();
         syncMapSize();
         window.addEventListener("resize", syncMapSize);

--- a/frontend/map.html
+++ b/frontend/map.html
@@ -104,10 +104,10 @@
 <div class="flex items-center gap-8">
 <h1 class="text-2xl font-bold font-headline text-[#1d1c16] dark:text-[#f2ede4] tracking-tight">Local History Map</h1>
 <nav class="hidden md:flex items-center gap-6">
-<a class="text-[#775a19] dark:text-[#c5a059] font-bold border-b-2 border-[#775a19] pb-1 font-body" href="#">Map</a>
-<a class="text-[#1d1c16] dark:text-[#f2ede4] font-medium hover:text-[#35618f] transition-colors duration-300 font-body" href="#">Archive</a>
-<a class="text-[#1d1c16] dark:text-[#f2ede4] font-medium hover:text-[#35618f] transition-colors duration-300 font-body" href="#">Chronicles</a>
-<a class="text-[#1d1c16] dark:text-[#f2ede4] font-medium hover:text-[#35618f] transition-colors duration-300 font-body" href="#">About</a>
+<a class="text-[#775a19] dark:text-[#c5a059] font-bold border-b-2 border-[#775a19] pb-1 font-body" href="map.html">Map</a>
+<a class="text-[#1d1c16] dark:text-[#f2ede4] font-medium hover:text-[#35618f] transition-colors duration-300 font-body" href="story-detail.html">Archive</a>
+<a class="text-[#1d1c16] dark:text-[#f2ede4] font-medium hover:text-[#35618f] transition-colors duration-300 font-body" href="story-create.html">Create Story</a>
+<a class="text-[#1d1c16] dark:text-[#f2ede4] font-medium hover:text-[#35618f] transition-colors duration-300 font-body" href="index.html">Login</a>
 </nav>
 </div>
 <div class="flex items-center gap-4">
@@ -163,7 +163,7 @@
 <span class="material-symbols-outlined text-sm">history_edu</span>
               MEMOIR #442
             </span>
-<button class="text-primary font-bold text-xs hover:underline">Read Archive →</button>
+<a class="text-primary font-bold text-xs hover:underline" href="story-detail.html">Read Archive →</a>
 </div>
 </div>
 </div>
@@ -187,10 +187,10 @@
 <span class="w-2 h-2 rounded-full bg-emerald-500"></span>
         12 new stories shared today near Galata
       </div>
-<button class="bg-gradient-to-br from-primary to-primary-container text-surface px-8 py-4 rounded-xl font-bold flex items-center gap-3 shadow-xl hover:scale-105 active:scale-95 transition-all">
-<span class="material-symbols-outlined" style="font-variation-settings: 'FILL' 1;">my_location</span>
+<a class="bg-gradient-to-br from-primary to-primary-container text-surface px-8 py-4 rounded-xl font-bold flex items-center gap-3 shadow-xl hover:scale-105 active:scale-95 transition-all" href="story-create.html">
+<span class="material-symbols-outlined" style="font-variation-settings: 'FILL' 1;">edit_square</span>
         Stories Near Me
-      </button>
+      </a>
 </div>
 <!-- Discovery Panel (Asymmetric Sidebar) -->
 <aside class="absolute top-24 right-8 w-72 glass-panel rounded-2xl p-6 shadow-sm pointer-events-auto border border-outline-variant/5">
@@ -199,11 +199,11 @@
 <span class="material-symbols-outlined text-outline">tune</span>
 </div>
 <div class="space-y-6">
-<div class="group cursor-pointer">
+<a class="group cursor-pointer block" href="story-detail.html">
 <div class="text-[10px] font-bold text-tertiary tracking-widest uppercase mb-1">Current Narrative</div>
 <h4 class="font-bold text-sm mb-1 group-hover:text-primary transition-colors">The Levantines of Beyoğlu</h4>
 <p class="text-xs text-on-surface-variant line-clamp-2 leading-relaxed">Tracing the architectural footprint of 19th-century trade families...</p>
-</div>
+</a>
 <div class="h-px bg-outline-variant/10"></div>
 <div>
 <div class="text-[10px] font-bold text-tertiary tracking-widest uppercase mb-3">Time Filter</div>

--- a/frontend/map.html
+++ b/frontend/map.html
@@ -1,0 +1,220 @@
+<!DOCTYPE html>
+
+<html class="light" lang="en"><head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<title>Local History Map - Istanbul Chronicles</title>
+<script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=Noto+Serif:wght@400;700;800&amp;display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
+<script id="tailwind-config">
+    tailwind.config = {
+      darkMode: "class",
+      theme: {
+        extend: {
+          colors: {
+            "on-surface": "#1d1c16",
+            "surface": "#fef9f0",
+            "on-tertiary-container": "#043d69",
+            "on-primary-container": "#4e3700",
+            "inverse-primary": "#e9c176",
+            "surface-container-lowest": "#ffffff",
+            "on-primary-fixed-variant": "#5d4201",
+            "background": "#fef9f0",
+            "surface-container-high": "#ece8df",
+            "on-tertiary-fixed-variant": "#194976",
+            "secondary": "#506169",
+            "on-tertiary": "#ffffff",
+            "on-surface-variant": "#4e4639",
+            "on-error": "#ffffff",
+            "surface-bright": "#fef9f0",
+            "on-secondary-fixed": "#0d1e25",
+            "error-container": "#ffdad6",
+            "tertiary": "#35618f",
+            "primary-fixed-dim": "#e9c176",
+            "primary-fixed": "#ffdea5",
+            "surface-variant": "#e7e2d9",
+            "on-primary-fixed": "#261900",
+            "on-primary": "#ffffff",
+            "surface-tint": "#775a19",
+            "on-secondary-fixed-variant": "#394951",
+            "primary-container": "#c5a059",
+            "primary": "#775a19",
+            "outline-variant": "#d1c5b4",
+            "on-secondary-container": "#55656d",
+            "on-error-container": "#93000a",
+            "inverse-surface": "#32302a",
+            "tertiary-container": "#7fa8db",
+            "on-tertiary-fixed": "#001d36",
+            "on-secondary": "#ffffff",
+            "on-background": "#1d1c16",
+            "inverse-on-surface": "#f5f0e7",
+            "surface-dim": "#ded9d1",
+            "outline": "#7f7667",
+            "tertiary-fixed": "#d2e4ff",
+            "secondary-container": "#d1e2ec",
+            "secondary-fixed-dim": "#b8c9d3",
+            "tertiary-fixed-dim": "#a0cafe",
+            "surface-container-highest": "#e7e2d9",
+            "error": "#ba1a1a",
+            "surface-container-low": "#f8f3ea",
+            "secondary-fixed": "#d4e5ef",
+            "surface-container": "#f2ede4"
+          },
+          fontFamily: {
+            "headline": ["Noto Serif"],
+            "body": ["Inter"],
+            "label": ["Inter"]
+          },
+          borderRadius: {"DEFAULT": "0.25rem", "lg": "0.5rem", "xl": "0.75rem", "full": "9999px"},
+        },
+      },
+    }
+  </script>
+<style>.material-symbols-outlined {
+    font-variation-settings: "FILL" 0, "wght" 400, "GRAD" 0, "opsz" 24
+    }
+.map-texture {
+    background-image: url(https://lh3.googleusercontent.com/aida-public/AB6AXuBsvyBsfVlP98qqniSVy9IC69yFiegWc9BydNf_UR9ZqfKaVPL8Vmqg5_yTOImOOSZFGf2L27ovIqxWMYcGn_CSvRc_56j5U1YxCmPN84L8yj7AjvXA-m63hZj7asWzQfuhwr2YaJ4tu-EXlBJnv3oFzShGmyKDhOm_U9oaudW41mt_M4VJRVBuOsqD2eZYddamP9gizUuRl9dx-f_KqPnDMfQ6ejdDyrvQQMPSf7e_vY1nmg_urRrAlpSIB_SqrH2EIVQXFyPmp5Ic);
+    background-size: cover;
+    background-position: center;
+    filter: sepia(20%) contrast(90%) brightness(105%)
+    }
+.glass-panel {
+    background: rgba(254, 249, 240, 0.85);
+    backdrop-filter: blur(12px)
+    }
+.noise-overlay {
+    position: fixed;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    opacity: 0.03;
+    z-index: 50;
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E")
+    }</style>
+</head>
+<body class="bg-surface text-on-surface font-body overflow-hidden">
+<div class="noise-overlay"></div>
+<!-- Shared Component: TopNavBar -->
+<header class="fixed top-0 left-0 right-0 z-40 bg-[#f8f3ea] dark:bg-stone-900">
+<div class="flex justify-between items-center w-full px-8 py-4 max-w-screen-2xl mx-auto">
+<div class="flex items-center gap-8">
+<h1 class="text-2xl font-bold font-headline text-[#1d1c16] dark:text-[#f2ede4] tracking-tight">Local History Map</h1>
+<nav class="hidden md:flex items-center gap-6">
+<a class="text-[#775a19] dark:text-[#c5a059] font-bold border-b-2 border-[#775a19] pb-1 font-body" href="#">Map</a>
+<a class="text-[#1d1c16] dark:text-[#f2ede4] font-medium hover:text-[#35618f] transition-colors duration-300 font-body" href="#">Archive</a>
+<a class="text-[#1d1c16] dark:text-[#f2ede4] font-medium hover:text-[#35618f] transition-colors duration-300 font-body" href="#">Chronicles</a>
+<a class="text-[#1d1c16] dark:text-[#f2ede4] font-medium hover:text-[#35618f] transition-colors duration-300 font-body" href="#">About</a>
+</nav>
+</div>
+<div class="flex items-center gap-4">
+<div class="relative group">
+<span class="absolute left-3 top-1/2 -translate-y-1/2 material-symbols-outlined text-outline">search</span>
+<input class="pl-10 pr-4 py-2 bg-surface-container-lowest border-none ring-1 ring-outline-variant/15 focus:ring-2 focus:ring-primary rounded-lg w-64 text-sm transition-all duration-300" placeholder="Explore Istanbul's past..." type="text"/>
+</div>
+<img alt="Curator Profile" class="w-10 h-10 rounded-full object-cover ring-2 ring-primary/20" data-alt="professional portrait of a middle-aged academic curator in a library setting with warm lighting" src="https://lh3.googleusercontent.com/aida-public/AB6AXuDTcsEM3IuePdpPNdjxvKMZTsyJB4h9YpTE9lTNKUyQiRd5IACaoSZBeJH3M--ijNxE2TsO5cVA-J-kXzU_sqY3ZC3FpZmO0vcuHokRpXNap_sC9e5A3Q0J4QOqvf6x5wdpOX1UI2zmXvOmyJCaqQaNWOuVuwi7aYkVz9NLkLG62S80wbSpZHy2rbLi-74YQYHNDEYNBAWZmWITcmAxlpI3KfC06Gcy5MPrbR5gsv5chllEfB1K_6Q27J_mp2hP4nuGM9IVAY39vDvp"/>
+</div>
+</div>
+</header>
+<!-- Main Content: Map Canvas -->
+<main class="relative w-full h-screen pt-16">
+<!-- Map Interface -->
+<div class="absolute inset-0 map-texture" data-location="Istanbul, Turkey" style=""></div>
+<!-- Map UI Controls -->
+<div class="absolute left-8 top-24 flex flex-col gap-3">
+<button class="glass-panel w-12 h-12 flex items-center justify-center rounded-lg text-primary shadow-sm hover:bg-surface transition-colors">
+<span class="material-symbols-outlined">add</span>
+</button>
+<button class="glass-panel w-12 h-12 flex items-center justify-center rounded-lg text-primary shadow-sm hover:bg-surface transition-colors">
+<span class="material-symbols-outlined">remove</span>
+</button>
+<button class="glass-panel w-12 h-12 flex items-center justify-center rounded-lg text-tertiary shadow-sm hover:bg-surface transition-colors">
+<span class="material-symbols-outlined">layers</span>
+</button>
+</div>
+<!-- Map Markers (Story-Specific) -->
+<!-- Marker 1: Passive -->
+<div class="absolute top-1/3 left-1/4 group cursor-pointer">
+<div class="relative">
+<div class="w-10 h-10 rounded-full border-2 border-surface bg-primary shadow-lg overflow-hidden transition-transform group-hover:scale-110">
+<img class="w-full h-full object-cover" data-alt="vintage black and white photo of an old coffee house in istanbul" src="https://lh3.googleusercontent.com/aida-public/AB6AXuDh3_e3fHr3WBJxj6aSSaO_sSsmKynht2RmFPGwP5uTU7DanYj75NJ4BdDKHrYEgFrC9Fb2WbEDm8_gFjn-8xsBTwyysyxhm8hNewkjzTilO641d8B8M46FQJKWOuJx8K0ljfmXbRdfu-30-luzQaRVv91Rfpx3B_DYX4vuqhGdX6R7D3U9c32bHzDuCbWXK2MeMAQ0kgz9h8gdUsfx-H6NqV_fDb8mXqPEpnIq2v6Ye13_cWD9rc7PuuPRe1U_yieeTo3COHM9Mdjx"/>
+</div>
+<div class="absolute -bottom-1 -right-1 w-4 h-4 bg-tertiary rounded-full border-2 border-surface"></div>
+</div>
+</div>
+<!-- Marker 2: Highlighted/Active -->
+<div class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-20">
+<!-- Story Card Preview -->
+<div class="mb-4 bg-surface-container-lowest rounded-xl shadow-2xl w-80 overflow-hidden transform scale-100 animate-in fade-in zoom-in duration-300">
+<div class="relative h-40">
+<img class="w-full h-full object-cover" data-alt="sepia toned 1970s photograph of a small humble storefront in a narrow galata street istanbul" src="https://lh3.googleusercontent.com/aida-public/AB6AXuC1VSYzV0rWnrp7TM_Ar-J9G-rOSMKA-CI9R5aLPGajntO2zYQII7bw3pSp2YkMat0UyA4xXOPsgB7oG7y3PMNOkGQiL3HO574YJqKKRa4WyZkFLoXiX_lCODH6j2VDRcg1l6qkUdZAZ4wSnAcw1kwaTXn12853JyNMky30rnYAo-M6aLt1LSTNyjlrfYxiw030MwzhaLeqHxvcALFQEzClzia_IsTuYVW3SSiudZoqD8I19TwzYKcregHohmSLh2Qy_3eDl-rTQhj6"/>
+<div class="absolute top-3 left-3 px-2 py-1 bg-primary text-surface text-[10px] font-bold uppercase tracking-widest rounded">1970s Era</div>
+</div>
+<div class="p-5">
+<h3 class="font-headline text-xl font-bold text-on-surface mb-2 leading-tight">My Father's First Shop in Galata</h3>
+<p class="text-sm text-on-surface-variant leading-relaxed mb-4 italic">
+            "The smell of fresh timber and roasted coffee always brings me back to that narrow cobblestone alley..."
+          </p>
+<div class="flex items-center justify-between">
+<span class="text-[11px] font-bold text-tertiary flex items-center gap-1">
+<span class="material-symbols-outlined text-sm">history_edu</span>
+              MEMOIR #442
+            </span>
+<button class="text-primary font-bold text-xs hover:underline">Read Archive →</button>
+</div>
+</div>
+</div>
+<!-- Active Marker -->
+<div class="mx-auto w-14 h-14 rounded-full border-4 border-tertiary bg-primary shadow-2xl overflow-hidden scale-110 ring-4 ring-tertiary/20">
+<img class="w-full h-full object-cover" data-alt="close up archive photo snippet of 1970s shop" src="https://lh3.googleusercontent.com/aida-public/AB6AXuBSmcp0kWGb-ABo3SBDsJHe0mKqHWle8Rt04XrK6Or3aJp4a7CGP0fv2kMVA3g0s67cIcrm6K1OGdgD1ueFJumoclE8JSvTk6kZvskaz167dwxe9e70vdxeTocbPpDFkXpkdYdCDkep6s5l8EhPKq9_YhZhwDFvqBZwIJAaxUHOCWtoI9v96Hn-r9H-bPNt_u1b7kfDwBEWgQ1iYUz54wmT8pTrUmT00C7zUQTys3fmcPjk4L_ZPHtyLtQf1TeoDF7Ck962Zxxmeviy"/>
+</div>
+</div>
+<!-- Marker 3: Passive -->
+<div class="absolute bottom-1/4 right-1/3 group cursor-pointer">
+<div class="relative">
+<div class="w-10 h-10 rounded-full border-2 border-surface bg-primary shadow-lg overflow-hidden transition-transform group-hover:scale-110">
+<img class="w-full h-full object-cover" data-alt="old wooden ferry on the bosphorus in grainy vintage style" src="https://lh3.googleusercontent.com/aida-public/AB6AXuANXRIoe6Ih8yrUVmhBh9ThvktRI-2WzkQjb2DfGHBXbI0hNvc6ze4aHewx-OOWaXAqOfxGUPi5htYpG6eiOkrmSGlnq7KzU_7fcbZ4Cqvh_EPFeEbCePOBRvUTx9IKb2xcb_vRigCIQbfxy-N_yGpYnbo5WiojLklJuSUFYGJ_was9Sp5FuHjANZErYpXppvQ9Ca-JOdpI5NzVFy43FLdSVNS47W0BbsK68GJAd6-uzWjkeC7OZ5Bog6Fgv8BmTqb3LmU6m817pKx0"/>
+</div>
+<div class="absolute -bottom-1 -right-1 w-4 h-4 bg-tertiary rounded-full border-2 border-surface"></div>
+</div>
+</div>
+<!-- Contextual FAB -->
+<div class="absolute bottom-8 right-8 flex flex-col items-end gap-4">
+<div class="glass-panel px-4 py-2 rounded-full border border-outline-variant/10 text-xs font-medium text-on-surface-variant flex items-center gap-2 mb-2">
+<span class="w-2 h-2 rounded-full bg-emerald-500"></span>
+        12 new stories shared today near Galata
+      </div>
+<button class="bg-gradient-to-br from-primary to-primary-container text-surface px-8 py-4 rounded-xl font-bold flex items-center gap-3 shadow-xl hover:scale-105 active:scale-95 transition-all">
+<span class="material-symbols-outlined" style="font-variation-settings: 'FILL' 1;">my_location</span>
+        Stories Near Me
+      </button>
+</div>
+<!-- Discovery Panel (Asymmetric Sidebar) -->
+<aside class="absolute top-24 right-8 w-72 glass-panel rounded-2xl p-6 shadow-sm pointer-events-auto border border-outline-variant/5">
+<div class="flex items-center justify-between mb-6">
+<h2 class="font-headline font-bold text-lg">Curated Focus</h2>
+<span class="material-symbols-outlined text-outline">tune</span>
+</div>
+<div class="space-y-6">
+<div class="group cursor-pointer">
+<div class="text-[10px] font-bold text-tertiary tracking-widest uppercase mb-1">Current Narrative</div>
+<h4 class="font-bold text-sm mb-1 group-hover:text-primary transition-colors">The Levantines of Beyoğlu</h4>
+<p class="text-xs text-on-surface-variant line-clamp-2 leading-relaxed">Tracing the architectural footprint of 19th-century trade families...</p>
+</div>
+<div class="h-px bg-outline-variant/10"></div>
+<div>
+<div class="text-[10px] font-bold text-tertiary tracking-widest uppercase mb-3">Time Filter</div>
+<div class="grid grid-cols-2 gap-2">
+<button class="px-3 py-2 rounded-lg bg-surface-container-high text-xs font-medium text-center hover:bg-primary hover:text-surface transition-all">Modernist</button>
+<button class="px-3 py-2 rounded-lg bg-surface-container-high text-xs font-medium text-center hover:bg-primary hover:text-surface transition-all">Digital Age</button>
+</div>
+</div>
+</div>
+</aside>
+</main>
+<!-- Shared Component: Footer (Suppressed for focused map view, normally would go here) -->
+<!-- Following the Shell Visibility & Relevance rule: Navigation suppressed to prioritize map canvas -->
+</body></html>

--- a/frontend/map.html
+++ b/frontend/map.html
@@ -661,6 +661,10 @@
         });
 
         // ─── Initialize ───
+        map.on("moveend", function () {
+            clearTimeout(fetchTimeout);
+            fetchTimeout = setTimeout(fetchStoriesInBounds, 300);
+        });
         fetchStoriesInBounds();
 
         loadCurrentUser();

--- a/frontend/map.html
+++ b/frontend/map.html
@@ -386,97 +386,24 @@
         profileMenuUser = document.getElementById("profile-menu-user");
         profileMenuName = document.getElementById("profile-menu-name");
         profileMenuEmail = document.getElementById("profile-menu-email");
-        // ─── Mock story data (will be replaced by API calls) ───
-        const MOCK_STORIES = [
-            {
-                id: "1",
-                title: "My Father's First Shop in Galata",
-                summary: "The smell of fresh timber and roasted coffee always brings me back to that narrow cobblestone alley...",
-                author: "mehmet_arif",
-                date_label: "1970s Era",
-                latitude: 41.0256,
-                longitude: 28.9744,
-                location_name: "Galata, Istanbul",
-                thumbnail: null
-            },
-            {
-                id: "2",
-                title: "The Old Fisherman's Quarter of Kadikoy",
-                summary: "In the narrow streets behind the market, a row of wooden houses once stood where fishermen repaired their nets.",
-                author: "ayse_k",
-                date_label: "1965 - 1985",
-                latitude: 40.9903,
-                longitude: 29.0230,
-                location_name: "Kadikoy, Istanbul",
-                thumbnail: null
-            },
-            {
-                id: "3",
-                title: "Bosphorus Ferry Memories",
-                summary: "Every morning my grandmother took the ferry from Üsküdar to Eminönü, carrying fresh bread and stories.",
-                author: "can_photo",
-                date_label: "1950s - 1960s",
-                latitude: 41.0232,
-                longitude: 29.0154,
-                location_name: "Üsküdar, Istanbul",
-                thumbnail: null
-            },
-            {
-                id: "4",
-                title: "The Grand Bazaar Before Tourism",
-                summary: "My uncle ran a copper workshop in the inner passages. The sound of hammering echoed through every corridor.",
-                author: "deniz_y",
-                date_label: "1980s",
-                latitude: 41.0106,
-                longitude: 28.9680,
-                location_name: "Grand Bazaar, Istanbul",
-                thumbnail: null
-            },
-            {
-                id: "5",
-                title: "Boğaziçi Campus in the 90s",
-                summary: "The library was our second home during finals. We pulled all-nighters fueled by tea from the canteen.",
-                author: "ali_c",
-                date_label: "1994 - 1998",
-                latitude: 41.0839,
-                longitude: 29.0510,
-                location_name: "Boğaziçi University, Istanbul",
-                thumbnail: null
-            },
-            {
-                id: "6",
-                title: "Sultanahmet's Hidden Gardens",
-                summary: "Behind the Blue Mosque there was a tea garden where locals gathered every Friday after prayers.",
-                author: "fatma_h",
-                date_label: "1960s - 1970s",
-                latitude: 41.0054,
-                longitude: 28.9768,
-                location_name: "Sultanahmet, Istanbul",
-                thumbnail: null
-            },
-            {
-                id: "7",
-                title: "The Tram Line on İstiklal Avenue",
-                summary: "Before the nostalgic tram returned, İstiklal was a vibrant pedestrian boulevard with street musicians and bookshops.",
-                author: "ozan_m",
-                date_label: "1990s",
-                latitude: 41.0340,
-                longitude: 28.9784,
-                location_name: "İstiklal Avenue, Istanbul",
-                thumbnail: null
-            },
-            {
-                id: "8",
-                title: "Haydarpaşa Train Station Arrivals",
-                summary: "Families from Anatolia arrived here with suitcases and dreams. The station felt like the gateway to a new world.",
-                author: "yusuf_b",
-                date_label: "1950s - 1970s",
-                latitude: 40.9977,
-                longitude: 29.0183,
-                location_name: "Haydarpaşa, Istanbul",
-                thumbnail: null
+        // ─── Story cache & fetching ───
+        var cachedStories = null;
+
+        async function fetchStories() {
+            if (cachedStories) return cachedStories;
+
+            try {
+                var response = await fetch(API_BASE + "/stories");
+                if (!response.ok) throw new Error("Failed to fetch stories");
+                var data = await response.json();
+                cachedStories = data.stories || [];
+                return cachedStories;
+            } catch (err) {
+                console.error("Error fetching stories:", err);
+                document.getElementById("story-count").textContent = "Failed to load stories";
+                return [];
             }
-        ];
+        }
 
         // ─── Initialize Map ───
         const map = L.map("map", {
@@ -547,22 +474,24 @@
         }
 
         function createPopupContent(story) {
-            return `
-      <div style="width:300px;">
-        <div style="background:linear-gradient(135deg,#e9dfcd,#f7f3eb);height:100px;display:flex;align-items:center;justify-content:center;position:relative;">
-          <span class="material-symbols-outlined" style="font-size:36px;color:#775a19;opacity:0.4;">photo_library</span>
-          <div style="position:absolute;top:8px;left:8px;padding:2px 8px;background:#775a19;color:white;font-size:10px;font-weight:700;letter-spacing:0.1em;text-transform:uppercase;border-radius:6px;">${story.date_label}</div>
-        </div>
-        <div style="padding:16px;">
-          <h3 style="font-family:'Noto Serif',serif;font-size:16px;font-weight:700;color:#1d1c16;margin:0 0 6px 0;line-height:1.3;">${story.title}</h3>
-          <p style="font-size:13px;color:#5f584c;line-height:1.5;margin:0 0 12px 0;font-style:italic;">"${story.summary}"</p>
-          <div style="display:flex;align-items:center;justify-content:space-between;">
-            <span style="font-size:11px;color:#35618f;font-weight:600;">${story.location_name}</span>
-            <a href="story-detail.html?id=${story.id}" style="font-size:12px;color:#775a19;font-weight:700;text-decoration:none;">Read Story →</a>
-          </div>
-        </div>
-      </div>
-    `;
+            var preview = (story.content || "").length > 200
+                ? story.content.substring(0, 200) + "..."
+                : (story.content || "");
+            var placeName = story.place_name || "";
+            var dateLabel = story.date_label || "";
+
+            return '<div style="width:300px;">' +
+                '<div style="background:linear-gradient(135deg,#e9dfcd,#f7f3eb);height:100px;display:flex;align-items:center;justify-content:center;position:relative;">' +
+                '<span class="material-symbols-outlined" style="font-size:36px;color:#775a19;opacity:0.4;">photo_library</span>' +
+                (dateLabel ? '<div style="position:absolute;top:8px;left:8px;padding:2px 8px;background:#775a19;color:white;font-size:10px;font-weight:700;letter-spacing:0.1em;text-transform:uppercase;border-radius:6px;">' + dateLabel + '</div>' : '') +
+                '</div>' +
+                '<div style="padding:16px;">' +
+                '<h3 style="font-family:\'Noto Serif\',serif;font-size:16px;font-weight:700;color:#1d1c16;margin:0 0 6px 0;line-height:1.3;">' + story.title + '</h3>' +
+                '<p style="font-size:13px;color:#5f584c;line-height:1.5;margin:0 0 12px 0;font-style:italic;">"' + preview + '"</p>' +
+                '<div style="display:flex;align-items:center;justify-content:space-between;">' +
+                (placeName ? '<span style="font-size:11px;color:#35618f;font-weight:600;">' + placeName + '</span>' : '<span></span>') +
+                '<a href="story-detail.html?id=' + story.id + '" style="font-size:12px;color:#775a19;font-weight:700;text-decoration:none;">Read Story →</a>' +
+                '</div></div></div>';
         }
 
         const markers = [];
@@ -609,14 +538,20 @@
             container.innerHTML = "";
 
             stories.forEach(function (story) {
+                var preview = (story.content || "").length > 200
+                    ? story.content.substring(0, 200) + "..."
+                    : (story.content || "");
+                var placeName = story.place_name || "";
+                var dateLabel = story.date_label || "";
+
                 var div = document.createElement("div");
                 div.className = "rounded-xl bg-white/80 p-3.5 border border-border/50 cursor-pointer hover:bg-white transition-colors";
                 div.innerHTML =
-                    '<div class="text-[10px] font-bold text-tertiary tracking-widest uppercase mb-1">' + story.date_label + '</div>' +
+                    (dateLabel ? '<div class="text-[10px] font-bold text-tertiary tracking-widest uppercase mb-1">' + dateLabel + '</div>' : '') +
                     '<h4 class="font-semibold text-sm text-textmain leading-snug mb-1">' + story.title + '</h4>' +
-                    '<p class="text-xs text-textmuted line-clamp-2 leading-relaxed">' + story.summary + '</p>' +
+                    '<p class="text-xs text-textmuted line-clamp-2 leading-relaxed">' + preview + '</p>' +
                     '<div class="mt-2 flex items-center justify-between">' +
-                    '<span class="text-[10px] text-textmuted">' + story.location_name + '</span>' +
+                    '<span class="text-[10px] text-textmuted">' + placeName + '</span>' +
                     '<a href="story-detail.html?id=' + story.id + '" class="text-[11px] font-bold text-primary hover:underline">View →</a>' +
                     '</div>';
 
@@ -657,11 +592,12 @@
             }
 
             searchTimeout = setTimeout(function () {
-                var filtered = MOCK_STORIES.filter(function (s) {
-                    return s.title.toLowerCase().includes(query) ||
-                        s.location_name.toLowerCase().includes(query) ||
-                        s.summary.toLowerCase().includes(query) ||
-                        s.author.toLowerCase().includes(query);
+                var stories = cachedStories || [];
+                var filtered = stories.filter(function (s) {
+                    return (s.title || "").toLowerCase().includes(query) ||
+                        (s.place_name || "").toLowerCase().includes(query) ||
+                        (s.content || "").toLowerCase().includes(query) ||
+                        (s.author || "").toLowerCase().includes(query);
                 });
 
                 if (filtered.length === 0) {
@@ -674,9 +610,12 @@
                 filtered.forEach(function (story) {
                     var item = document.createElement("div");
                     item.className = "px-4 py-3 hover:bg-background cursor-pointer border-b border-border/30 last:border-0";
+                    var placeName = story.place_name || "";
+                    var dateLabel = story.date_label || "";
+                    var subtitle = [placeName, dateLabel].filter(Boolean).join(" · ");
                     item.innerHTML =
                         '<div class="font-semibold text-sm text-textmain">' + story.title + '</div>' +
-                        '<div class="text-xs text-textmuted mt-0.5">' + story.location_name + ' · ' + story.date_label + '</div>';
+                        (subtitle ? '<div class="text-xs text-textmuted mt-0.5">' + subtitle + '</div>' : '');
                     item.addEventListener("click", function () {
                         map.setView([story.latitude, story.longitude], 16);
                         markers.forEach(function (m) {
@@ -715,9 +654,10 @@
         });
 
         // ─── Initialize ───
-        // In production, this would be: fetch("/api/stories").then(r => r.json()).then(loadStories)
-        loadStories(MOCK_STORIES);
-        populateSidebar(MOCK_STORIES);
+        fetchStories().then(function (stories) {
+            loadStories(stories);
+            populateSidebar(stories);
+        });
         loadCurrentUser();
         syncMapSize();
         window.addEventListener("resize", syncMapSize);

--- a/frontend/map.html
+++ b/frontend/map.html
@@ -1,220 +1,510 @@
 <!DOCTYPE html>
-
-<html class="light" lang="en"><head>
-<meta charset="utf-8"/>
-<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>Local History Map - Istanbul Chronicles</title>
-<script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=Noto+Serif:wght@400;700;800&amp;display=swap" rel="stylesheet"/>
-<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
-<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
-<script id="tailwind-config">
-    tailwind.config = {
-      darkMode: "class",
-      theme: {
-        extend: {
-          colors: {
-            "on-surface": "#1d1c16",
-            "surface": "#fef9f0",
-            "on-tertiary-container": "#043d69",
-            "on-primary-container": "#4e3700",
-            "inverse-primary": "#e9c176",
-            "surface-container-lowest": "#ffffff",
-            "on-primary-fixed-variant": "#5d4201",
-            "background": "#fef9f0",
-            "surface-container-high": "#ece8df",
-            "on-tertiary-fixed-variant": "#194976",
-            "secondary": "#506169",
-            "on-tertiary": "#ffffff",
-            "on-surface-variant": "#4e4639",
-            "on-error": "#ffffff",
-            "surface-bright": "#fef9f0",
-            "on-secondary-fixed": "#0d1e25",
-            "error-container": "#ffdad6",
-            "tertiary": "#35618f",
-            "primary-fixed-dim": "#e9c176",
-            "primary-fixed": "#ffdea5",
-            "surface-variant": "#e7e2d9",
-            "on-primary-fixed": "#261900",
-            "on-primary": "#ffffff",
-            "surface-tint": "#775a19",
-            "on-secondary-fixed-variant": "#394951",
-            "primary-container": "#c5a059",
-            "primary": "#775a19",
-            "outline-variant": "#d1c5b4",
-            "on-secondary-container": "#55656d",
-            "on-error-container": "#93000a",
-            "inverse-surface": "#32302a",
-            "tertiary-container": "#7fa8db",
-            "on-tertiary-fixed": "#001d36",
-            "on-secondary": "#ffffff",
-            "on-background": "#1d1c16",
-            "inverse-on-surface": "#f5f0e7",
-            "surface-dim": "#ded9d1",
-            "outline": "#7f7667",
-            "tertiary-fixed": "#d2e4ff",
-            "secondary-container": "#d1e2ec",
-            "secondary-fixed-dim": "#b8c9d3",
-            "tertiary-fixed-dim": "#a0cafe",
-            "surface-container-highest": "#e7e2d9",
-            "error": "#ba1a1a",
-            "surface-container-low": "#f8f3ea",
-            "secondary-fixed": "#d4e5ef",
-            "surface-container": "#f2ede4"
-          },
-          fontFamily: {
-            "headline": ["Noto Serif"],
-            "body": ["Inter"],
-            "label": ["Inter"]
-          },
-          borderRadius: {"DEFAULT": "0.25rem", "lg": "0.5rem", "xl": "0.75rem", "full": "9999px"},
-        },
-      },
-    }
-  </script>
-<style>.material-symbols-outlined {
-    font-variation-settings: "FILL" 0, "wght" 400, "GRAD" 0, "opsz" 24
-    }
-.map-texture {
-    background-image: url(https://lh3.googleusercontent.com/aida-public/AB6AXuBsvyBsfVlP98qqniSVy9IC69yFiegWc9BydNf_UR9ZqfKaVPL8Vmqg5_yTOImOOSZFGf2L27ovIqxWMYcGn_CSvRc_56j5U1YxCmPN84L8yj7AjvXA-m63hZj7asWzQfuhwr2YaJ4tu-EXlBJnv3oFzShGmyKDhOm_U9oaudW41mt_M4VJRVBuOsqD2eZYddamP9gizUuRl9dx-f_KqPnDMfQ6ejdDyrvQQMPSf7e_vY1nmg_urRrAlpSIB_SqrH2EIVQXFyPmp5Ic);
-    background-size: cover;
-    background-position: center;
-    filter: sepia(20%) contrast(90%) brightness(105%)
-    }
-.glass-panel {
-    background: rgba(254, 249, 240, 0.85);
-    backdrop-filter: blur(12px)
-    }
-.noise-overlay {
-    position: fixed;
-    inset: 0;
-    width: 100%;
-    height: 100%;
-    pointer-events: none;
-    opacity: 0.03;
-    z-index: 50;
-    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E")
-    }</style>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Local History Map - Istanbul Chronicles</title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Serif:wght@700;800&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet">
+    <!-- Leaflet CSS -->
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: {
+                        background: "#fef9f0",
+                        surface: "#ffffff",
+                        primary: "#775a19",
+                        "primary-light": "#c5a059",
+                        secondary: "#506169",
+                        tertiary: "#35618f",
+                        border: "#e7e2d9",
+                        textmain: "#1d1c16",
+                        textmuted: "#5f584c"
+                    },
+                    fontFamily: {
+                        body: ["Inter", "sans-serif"],
+                        headline: ["Noto Serif", "serif"]
+                    },
+                    boxShadow: {
+                        soft: "0 20px 50px rgba(0,0,0,0.08)"
+                    }
+                }
+            }
+        };
+    </script>
+    <style>
+        .material-symbols-outlined {
+            font-variation-settings: "FILL" 0, "wght" 400, "GRAD" 0, "opsz" 24;
+        }
+        /* Override Leaflet defaults to match project style */
+        .leaflet-container {
+            font-family: "Inter", sans-serif;
+        }
+        .leaflet-control-zoom a {
+            background: rgba(254, 249, 240, 0.9) !important;
+            backdrop-filter: blur(12px);
+            color: #775a19 !important;
+            border: 1px solid #e7e2d9 !important;
+            font-weight: 600;
+        }
+        .leaflet-control-zoom a:hover {
+            background: #ffffff !important;
+        }
+        .leaflet-control-attribution {
+            background: rgba(254, 249, 240, 0.75) !important;
+            font-size: 10px;
+        }
+        /* Custom marker style */
+        .story-marker {
+            width: 40px;
+            height: 40px;
+            border-radius: 50%;
+            border: 3px solid #ffffff;
+            background: #775a19;
+            box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+            cursor: pointer;
+            transition: transform 0.2s ease;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: white;
+            font-size: 16px;
+        }
+        .story-marker:hover {
+            transform: scale(1.15);
+        }
+        .story-marker.active {
+            border-color: #35618f;
+            box-shadow: 0 0 0 4px rgba(53,97,143,0.2), 0 4px 12px rgba(0,0,0,0.2);
+            transform: scale(1.1);
+        }
+        /* Story popup card */
+        .leaflet-popup-content-wrapper {
+            border-radius: 16px !important;
+            padding: 0 !important;
+            box-shadow: 0 20px 50px rgba(0,0,0,0.12) !important;
+            overflow: hidden;
+        }
+        .leaflet-popup-content {
+            margin: 0 !important;
+            width: 300px !important;
+        }
+        .leaflet-popup-tip {
+            box-shadow: none !important;
+        }
+        .glass-panel {
+            background: rgba(254, 249, 240, 0.9);
+            backdrop-filter: blur(12px);
+        }
+        /* Search results dropdown */
+        #search-results {
+            max-height: 240px;
+            overflow-y: auto;
+        }
+        #search-results::-webkit-scrollbar {
+            width: 4px;
+        }
+        #search-results::-webkit-scrollbar-thumb {
+            background: #c5a059;
+            border-radius: 4px;
+        }
+    </style>
 </head>
-<body class="bg-surface text-on-surface font-body overflow-hidden">
-<div class="noise-overlay"></div>
-<!-- Shared Component: TopNavBar -->
-<header class="fixed top-0 left-0 right-0 z-40 bg-[#f8f3ea] dark:bg-stone-900">
-<div class="flex justify-between items-center w-full px-8 py-4 max-w-screen-2xl mx-auto">
-<div class="flex items-center gap-8">
-<h1 class="text-2xl font-bold font-headline text-[#1d1c16] dark:text-[#f2ede4] tracking-tight">Local History Map</h1>
-<nav class="hidden md:flex items-center gap-6">
-<a class="text-[#775a19] dark:text-[#c5a059] font-bold border-b-2 border-[#775a19] pb-1 font-body" href="map.html">Map</a>
-<a class="text-[#1d1c16] dark:text-[#f2ede4] font-medium hover:text-[#35618f] transition-colors duration-300 font-body" href="story-detail.html">Archive</a>
-<a class="text-[#1d1c16] dark:text-[#f2ede4] font-medium hover:text-[#35618f] transition-colors duration-300 font-body" href="story-create.html">Create Story</a>
-<a class="text-[#1d1c16] dark:text-[#f2ede4] font-medium hover:text-[#35618f] transition-colors duration-300 font-body" href="index.html">Login</a>
-</nav>
-</div>
-<div class="flex items-center gap-4">
-<div class="relative group">
-<span class="absolute left-3 top-1/2 -translate-y-1/2 material-symbols-outlined text-outline">search</span>
-<input class="pl-10 pr-4 py-2 bg-surface-container-lowest border-none ring-1 ring-outline-variant/15 focus:ring-2 focus:ring-primary rounded-lg w-64 text-sm transition-all duration-300" placeholder="Explore Istanbul's past..." type="text"/>
-</div>
-<img alt="Curator Profile" class="w-10 h-10 rounded-full object-cover ring-2 ring-primary/20" data-alt="professional portrait of a middle-aged academic curator in a library setting with warm lighting" src="https://lh3.googleusercontent.com/aida-public/AB6AXuDTcsEM3IuePdpPNdjxvKMZTsyJB4h9YpTE9lTNKUyQiRd5IACaoSZBeJH3M--ijNxE2TsO5cVA-J-kXzU_sqY3ZC3FpZmO0vcuHokRpXNap_sC9e5A3Q0J4QOqvf6x5wdpOX1UI2zmXvOmyJCaqQaNWOuVuwi7aYkVz9NLkLG62S80wbSpZHy2rbLi-74YQYHNDEYNBAWZmWITcmAxlpI3KfC06Gcy5MPrbR5gsv5chllEfB1K_6Q27J_mp2hP4nuGM9IVAY39vDvp"/>
-</div>
-</div>
+<body class="bg-background text-textmain font-body overflow-hidden">
+
+<!-- Top Navigation Bar -->
+<header class="fixed top-0 left-0 right-0 z-[1000] bg-[#f8f3ea]/95 backdrop-blur-sm border-b border-border/30">
+    <div class="flex justify-between items-center w-full px-8 py-4 max-w-screen-2xl mx-auto">
+        <div class="flex items-center gap-8">
+            <h1 class="text-2xl font-bold font-headline text-textmain tracking-tight">Local History Map</h1>
+            <nav class="hidden md:flex items-center gap-6">
+                <a class="text-primary font-bold border-b-2 border-primary pb-1" href="map.html">Map</a>
+                <a class="text-textmain font-medium hover:text-tertiary transition-colors" href="story-detail.html">Archive</a>
+                <a class="text-textmain font-medium hover:text-tertiary transition-colors" href="story-create.html">Create Story</a>
+                <a class="text-textmain font-medium hover:text-tertiary transition-colors" href="index.html">Login</a>
+            </nav>
+        </div>
+        <div class="flex items-center gap-4">
+            <!-- Search -->
+            <div class="relative" id="search-container">
+                <span class="absolute left-3 top-1/2 -translate-y-1/2 material-symbols-outlined text-textmuted text-xl">search</span>
+                <input
+                        id="search-input"
+                        class="pl-10 pr-4 py-2 bg-white border border-border rounded-xl w-72 text-sm focus:border-primary focus:ring-primary transition-all"
+                        placeholder="Search stories by location..."
+                        type="text"
+                        autocomplete="off"
+                />
+                <div id="search-results" class="absolute top-full left-0 right-0 mt-1 bg-white border border-border rounded-xl shadow-soft overflow-hidden hidden z-50"></div>
+            </div>
+        </div>
+    </div>
 </header>
-<!-- Main Content: Map Canvas -->
-<main class="relative w-full h-screen pt-16">
-<!-- Map Interface -->
-<div class="absolute inset-0 map-texture" data-location="Istanbul, Turkey" style=""></div>
-<!-- Map UI Controls -->
-<div class="absolute left-8 top-24 flex flex-col gap-3">
-<button class="glass-panel w-12 h-12 flex items-center justify-center rounded-lg text-primary shadow-sm hover:bg-surface transition-colors">
-<span class="material-symbols-outlined">add</span>
-</button>
-<button class="glass-panel w-12 h-12 flex items-center justify-center rounded-lg text-primary shadow-sm hover:bg-surface transition-colors">
-<span class="material-symbols-outlined">remove</span>
-</button>
-<button class="glass-panel w-12 h-12 flex items-center justify-center rounded-lg text-tertiary shadow-sm hover:bg-surface transition-colors">
-<span class="material-symbols-outlined">layers</span>
-</button>
-</div>
-<!-- Map Markers (Story-Specific) -->
-<!-- Marker 1: Passive -->
-<div class="absolute top-1/3 left-1/4 group cursor-pointer">
-<div class="relative">
-<div class="w-10 h-10 rounded-full border-2 border-surface bg-primary shadow-lg overflow-hidden transition-transform group-hover:scale-110">
-<img class="w-full h-full object-cover" data-alt="vintage black and white photo of an old coffee house in istanbul" src="https://lh3.googleusercontent.com/aida-public/AB6AXuDh3_e3fHr3WBJxj6aSSaO_sSsmKynht2RmFPGwP5uTU7DanYj75NJ4BdDKHrYEgFrC9Fb2WbEDm8_gFjn-8xsBTwyysyxhm8hNewkjzTilO641d8B8M46FQJKWOuJx8K0ljfmXbRdfu-30-luzQaRVv91Rfpx3B_DYX4vuqhGdX6R7D3U9c32bHzDuCbWXK2MeMAQ0kgz9h8gdUsfx-H6NqV_fDb8mXqPEpnIq2v6Ye13_cWD9rc7PuuPRe1U_yieeTo3COHM9Mdjx"/>
-</div>
-<div class="absolute -bottom-1 -right-1 w-4 h-4 bg-tertiary rounded-full border-2 border-surface"></div>
-</div>
-</div>
-<!-- Marker 2: Highlighted/Active -->
-<div class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-20">
-<!-- Story Card Preview -->
-<div class="mb-4 bg-surface-container-lowest rounded-xl shadow-2xl w-80 overflow-hidden transform scale-100 animate-in fade-in zoom-in duration-300">
-<div class="relative h-40">
-<img class="w-full h-full object-cover" data-alt="sepia toned 1970s photograph of a small humble storefront in a narrow galata street istanbul" src="https://lh3.googleusercontent.com/aida-public/AB6AXuC1VSYzV0rWnrp7TM_Ar-J9G-rOSMKA-CI9R5aLPGajntO2zYQII7bw3pSp2YkMat0UyA4xXOPsgB7oG7y3PMNOkGQiL3HO574YJqKKRa4WyZkFLoXiX_lCODH6j2VDRcg1l6qkUdZAZ4wSnAcw1kwaTXn12853JyNMky30rnYAo-M6aLt1LSTNyjlrfYxiw030MwzhaLeqHxvcALFQEzClzia_IsTuYVW3SSiudZoqD8I19TwzYKcregHohmSLh2Qy_3eDl-rTQhj6"/>
-<div class="absolute top-3 left-3 px-2 py-1 bg-primary text-surface text-[10px] font-bold uppercase tracking-widest rounded">1970s Era</div>
-</div>
-<div class="p-5">
-<h3 class="font-headline text-xl font-bold text-on-surface mb-2 leading-tight">My Father's First Shop in Galata</h3>
-<p class="text-sm text-on-surface-variant leading-relaxed mb-4 italic">
-            "The smell of fresh timber and roasted coffee always brings me back to that narrow cobblestone alley..."
-          </p>
-<div class="flex items-center justify-between">
-<span class="text-[11px] font-bold text-tertiary flex items-center gap-1">
-<span class="material-symbols-outlined text-sm">history_edu</span>
-              MEMOIR #442
-            </span>
-<a class="text-primary font-bold text-xs hover:underline" href="story-detail.html">Read Archive →</a>
-</div>
-</div>
-</div>
-<!-- Active Marker -->
-<div class="mx-auto w-14 h-14 rounded-full border-4 border-tertiary bg-primary shadow-2xl overflow-hidden scale-110 ring-4 ring-tertiary/20">
-<img class="w-full h-full object-cover" data-alt="close up archive photo snippet of 1970s shop" src="https://lh3.googleusercontent.com/aida-public/AB6AXuBSmcp0kWGb-ABo3SBDsJHe0mKqHWle8Rt04XrK6Or3aJp4a7CGP0fv2kMVA3g0s67cIcrm6K1OGdgD1ueFJumoclE8JSvTk6kZvskaz167dwxe9e70vdxeTocbPpDFkXpkdYdCDkep6s5l8EhPKq9_YhZhwDFvqBZwIJAaxUHOCWtoI9v96Hn-r9H-bPNt_u1b7kfDwBEWgQ1iYUz54wmT8pTrUmT00C7zUQTys3fmcPjk4L_ZPHtyLtQf1TeoDF7Ck962Zxxmeviy"/>
-</div>
-</div>
-<!-- Marker 3: Passive -->
-<div class="absolute bottom-1/4 right-1/3 group cursor-pointer">
-<div class="relative">
-<div class="w-10 h-10 rounded-full border-2 border-surface bg-primary shadow-lg overflow-hidden transition-transform group-hover:scale-110">
-<img class="w-full h-full object-cover" data-alt="old wooden ferry on the bosphorus in grainy vintage style" src="https://lh3.googleusercontent.com/aida-public/AB6AXuANXRIoe6Ih8yrUVmhBh9ThvktRI-2WzkQjb2DfGHBXbI0hNvc6ze4aHewx-OOWaXAqOfxGUPi5htYpG6eiOkrmSGlnq7KzU_7fcbZ4Cqvh_EPFeEbCePOBRvUTx9IKb2xcb_vRigCIQbfxy-N_yGpYnbo5WiojLklJuSUFYGJ_was9Sp5FuHjANZErYpXppvQ9Ca-JOdpI5NzVFy43FLdSVNS47W0BbsK68GJAd6-uzWjkeC7OZ5Bog6Fgv8BmTqb3LmU6m817pKx0"/>
-</div>
-<div class="absolute -bottom-1 -right-1 w-4 h-4 bg-tertiary rounded-full border-2 border-surface"></div>
-</div>
-</div>
-<!-- Contextual FAB -->
-<div class="absolute bottom-8 right-8 flex flex-col items-end gap-4">
-<div class="glass-panel px-4 py-2 rounded-full border border-outline-variant/10 text-xs font-medium text-on-surface-variant flex items-center gap-2 mb-2">
-<span class="w-2 h-2 rounded-full bg-emerald-500"></span>
-        12 new stories shared today near Galata
-      </div>
-<a class="bg-gradient-to-br from-primary to-primary-container text-surface px-8 py-4 rounded-xl font-bold flex items-center gap-3 shadow-xl hover:scale-105 active:scale-95 transition-all" href="story-create.html">
-<span class="material-symbols-outlined" style="font-variation-settings: 'FILL' 1;">edit_square</span>
-        Stories Near Me
-      </a>
-</div>
-<!-- Discovery Panel (Asymmetric Sidebar) -->
-<aside class="absolute top-24 right-8 w-72 glass-panel rounded-2xl p-6 shadow-sm pointer-events-auto border border-outline-variant/5">
-<div class="flex items-center justify-between mb-6">
-<h2 class="font-headline font-bold text-lg">Curated Focus</h2>
-<span class="material-symbols-outlined text-outline">tune</span>
-</div>
-<div class="space-y-6">
-<a class="group cursor-pointer block" href="story-detail.html">
-<div class="text-[10px] font-bold text-tertiary tracking-widest uppercase mb-1">Current Narrative</div>
-<h4 class="font-bold text-sm mb-1 group-hover:text-primary transition-colors">The Levantines of Beyoğlu</h4>
-<p class="text-xs text-on-surface-variant line-clamp-2 leading-relaxed">Tracing the architectural footprint of 19th-century trade families...</p>
-</a>
-<div class="h-px bg-outline-variant/10"></div>
-<div>
-<div class="text-[10px] font-bold text-tertiary tracking-widest uppercase mb-3">Time Filter</div>
-<div class="grid grid-cols-2 gap-2">
-<button class="px-3 py-2 rounded-lg bg-surface-container-high text-xs font-medium text-center hover:bg-primary hover:text-surface transition-all">Modernist</button>
-<button class="px-3 py-2 rounded-lg bg-surface-container-high text-xs font-medium text-center hover:bg-primary hover:text-surface transition-all">Digital Age</button>
-</div>
-</div>
-</div>
-</aside>
+
+<!-- Map Container -->
+<main class="relative w-full h-screen pt-[68px]">
+    <div id="map" class="absolute inset-0 top-[68px]"></div>
+
+    <!-- Map Layer Toggle -->
+    <div class="absolute left-4 top-28 z-[1000] flex flex-col gap-2">
+        <button id="btn-layers" class="glass-panel w-11 h-11 flex items-center justify-center rounded-xl text-primary shadow-sm hover:bg-white transition-colors border border-border/30" title="Toggle map layers">
+            <span class="material-symbols-outlined text-xl">layers</span>
+        </button>
+        <button id="btn-locate" class="glass-panel w-11 h-11 flex items-center justify-center rounded-xl text-tertiary shadow-sm hover:bg-white transition-colors border border-border/30" title="Go to my location">
+            <span class="material-symbols-outlined text-xl">my_location</span>
+        </button>
+    </div>
+
+    <!-- Story Count Badge -->
+    <div class="absolute bottom-8 left-8 z-[1000]">
+        <div class="glass-panel px-4 py-2.5 rounded-full border border-border/30 text-xs font-medium text-textmuted flex items-center gap-2 shadow-sm">
+            <span class="w-2 h-2 rounded-full bg-emerald-500 animate-pulse"></span>
+            <span id="story-count">Loading stories...</span>
+        </div>
+    </div>
+
+    <!-- Floating Action Button -->
+    <div class="absolute bottom-8 right-8 z-[1000]">
+        <a href="story-create.html" class="flex items-center gap-3 bg-primary text-white px-6 py-4 rounded-xl font-semibold shadow-xl hover:scale-105 active:scale-95 transition-all border border-primary-light/20">
+            <span class="material-symbols-outlined" style="font-variation-settings: 'FILL' 1;">edit_square</span>
+            Share a Story
+        </a>
+    </div>
+
+    <!-- Discovery Sidebar -->
+    <aside id="sidebar" class="absolute top-24 right-4 w-72 glass-panel rounded-2xl p-5 shadow-sm border border-border/20 z-[1000] max-h-[calc(100vh-160px)] overflow-y-auto">
+        <div class="flex items-center justify-between mb-5">
+            <h2 class="font-headline font-bold text-lg">Recent Stories</h2>
+            <button id="btn-close-sidebar" class="text-textmuted hover:text-textmain transition-colors">
+                <span class="material-symbols-outlined text-xl">close</span>
+            </button>
+        </div>
+        <div id="sidebar-stories" class="space-y-3">
+            <!-- Populated by JS -->
+        </div>
+    </aside>
 </main>
-<!-- Shared Component: Footer (Suppressed for focused map view, normally would go here) -->
-<!-- Following the Shell Visibility & Relevance rule: Navigation suppressed to prioritize map canvas -->
-</body></html>
+
+<!-- Leaflet JS -->
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+
+<script>
+    // ─── Mock story data (will be replaced by API calls) ───
+    const MOCK_STORIES = [
+        {
+            id: "1",
+            title: "My Father's First Shop in Galata",
+            summary: "The smell of fresh timber and roasted coffee always brings me back to that narrow cobblestone alley...",
+            author: "mehmet_arif",
+            date_label: "1970s Era",
+            latitude: 41.0256,
+            longitude: 28.9744,
+            location_name: "Galata, Istanbul",
+            thumbnail: null
+        },
+        {
+            id: "2",
+            title: "The Old Fisherman's Quarter of Kadikoy",
+            summary: "In the narrow streets behind the market, a row of wooden houses once stood where fishermen repaired their nets.",
+            author: "ayse_k",
+            date_label: "1965 - 1985",
+            latitude: 40.9903,
+            longitude: 29.0230,
+            location_name: "Kadikoy, Istanbul",
+            thumbnail: null
+        },
+        {
+            id: "3",
+            title: "Bosphorus Ferry Memories",
+            summary: "Every morning my grandmother took the ferry from Üsküdar to Eminönü, carrying fresh bread and stories.",
+            author: "can_photo",
+            date_label: "1950s - 1960s",
+            latitude: 41.0232,
+            longitude: 29.0154,
+            location_name: "Üsküdar, Istanbul",
+            thumbnail: null
+        },
+        {
+            id: "4",
+            title: "The Grand Bazaar Before Tourism",
+            summary: "My uncle ran a copper workshop in the inner passages. The sound of hammering echoed through every corridor.",
+            author: "deniz_y",
+            date_label: "1980s",
+            latitude: 41.0106,
+            longitude: 28.9680,
+            location_name: "Grand Bazaar, Istanbul",
+            thumbnail: null
+        },
+        {
+            id: "5",
+            title: "Boğaziçi Campus in the 90s",
+            summary: "The library was our second home during finals. We pulled all-nighters fueled by tea from the canteen.",
+            author: "ali_c",
+            date_label: "1994 - 1998",
+            latitude: 41.0839,
+            longitude: 29.0510,
+            location_name: "Boğaziçi University, Istanbul",
+            thumbnail: null
+        },
+        {
+            id: "6",
+            title: "Sultanahmet's Hidden Gardens",
+            summary: "Behind the Blue Mosque there was a tea garden where locals gathered every Friday after prayers.",
+            author: "fatma_h",
+            date_label: "1960s - 1970s",
+            latitude: 41.0054,
+            longitude: 28.9768,
+            location_name: "Sultanahmet, Istanbul",
+            thumbnail: null
+        },
+        {
+            id: "7",
+            title: "The Tram Line on İstiklal Avenue",
+            summary: "Before the nostalgic tram returned, İstiklal was a vibrant pedestrian boulevard with street musicians and bookshops.",
+            author: "ozan_m",
+            date_label: "1990s",
+            latitude: 41.0340,
+            longitude: 28.9784,
+            location_name: "İstiklal Avenue, Istanbul",
+            thumbnail: null
+        },
+        {
+            id: "8",
+            title: "Haydarpaşa Train Station Arrivals",
+            summary: "Families from Anatolia arrived here with suitcases and dreams. The station felt like the gateway to a new world.",
+            author: "yusuf_b",
+            date_label: "1950s - 1970s",
+            latitude: 40.9977,
+            longitude: 29.0183,
+            location_name: "Haydarpaşa, Istanbul",
+            thumbnail: null
+        }
+    ];
+
+    // ─── Initialize Map ───
+    const map = L.map("map", {
+        center: [41.015, 28.979],
+        zoom: 13,
+        zoomControl: false
+    });
+
+    // Tile layers
+    const osmLayer = L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+        maxZoom: 19
+    });
+
+    const topoLayer = L.tileLayer("https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png", {
+        attribution: '&copy; <a href="https://opentopomap.org">OpenTopoMap</a>',
+        maxZoom: 17
+    });
+
+    // Default layer
+    osmLayer.addTo(map);
+    let currentLayer = "osm";
+
+    // Zoom controls (Leaflet default position overridden by CSS, but we add custom)
+    L.control.zoom({ position: "topleft" }).addTo(map);
+
+    // ─── Layer Toggle ───
+    document.getElementById("btn-layers").addEventListener("click", function () {
+        if (currentLayer === "osm") {
+            map.removeLayer(osmLayer);
+            topoLayer.addTo(map);
+            currentLayer = "topo";
+        } else {
+            map.removeLayer(topoLayer);
+            osmLayer.addTo(map);
+            currentLayer = "osm";
+        }
+    });
+
+    // ─── Geolocation ───
+    document.getElementById("btn-locate").addEventListener("click", function () {
+        if (!navigator.geolocation) return;
+        navigator.geolocation.getCurrentPosition(
+            function (pos) {
+                map.setView([pos.coords.latitude, pos.coords.longitude], 15);
+            },
+            function () {
+                alert("Unable to access your location.");
+            }
+        );
+    });
+
+    // ─── Create Markers ───
+    function createMarkerIcon() {
+        return L.divIcon({
+            className: "",
+            html: '<div class="story-marker"><span class="material-symbols-outlined" style="font-size:18px;">auto_stories</span></div>',
+            iconSize: [40, 40],
+            iconAnchor: [20, 20],
+            popupAnchor: [0, -24]
+        });
+    }
+
+    function createPopupContent(story) {
+        return `
+      <div style="width:300px;">
+        <div style="background:linear-gradient(135deg,#e9dfcd,#f7f3eb);height:100px;display:flex;align-items:center;justify-content:center;position:relative;">
+          <span class="material-symbols-outlined" style="font-size:36px;color:#775a19;opacity:0.4;">photo_library</span>
+          <div style="position:absolute;top:8px;left:8px;padding:2px 8px;background:#775a19;color:white;font-size:10px;font-weight:700;letter-spacing:0.1em;text-transform:uppercase;border-radius:6px;">${story.date_label}</div>
+        </div>
+        <div style="padding:16px;">
+          <h3 style="font-family:'Noto Serif',serif;font-size:16px;font-weight:700;color:#1d1c16;margin:0 0 6px 0;line-height:1.3;">${story.title}</h3>
+          <p style="font-size:13px;color:#5f584c;line-height:1.5;margin:0 0 12px 0;font-style:italic;">"${story.summary}"</p>
+          <div style="display:flex;align-items:center;justify-content:space-between;">
+            <span style="font-size:11px;color:#35618f;font-weight:600;">${story.location_name}</span>
+            <a href="story-detail.html?id=${story.id}" style="font-size:12px;color:#775a19;font-weight:700;text-decoration:none;">Read Story →</a>
+          </div>
+        </div>
+      </div>
+    `;
+    }
+
+    const markers = [];
+
+    function loadStories(stories) {
+        // Clear existing markers
+        markers.forEach(function (m) { map.removeLayer(m); });
+        markers.length = 0;
+
+        stories.forEach(function (story) {
+            const marker = L.marker([story.latitude, story.longitude], {
+                icon: createMarkerIcon()
+            });
+
+            marker.bindPopup(createPopupContent(story), {
+                maxWidth: 300,
+                minWidth: 300,
+                closeButton: true
+            });
+
+            marker.on("click", function () {
+                // Highlight active marker
+                document.querySelectorAll(".story-marker").forEach(function (el) {
+                    el.classList.remove("active");
+                });
+                var el = marker.getElement();
+                if (el) {
+                    var markerDiv = el.querySelector(".story-marker");
+                    if (markerDiv) markerDiv.classList.add("active");
+                }
+            });
+
+            marker.addTo(map);
+            markers.push(marker);
+        });
+
+        // Update count
+        document.getElementById("story-count").textContent = stories.length + " stories on the map";
+    }
+
+    // ─── Sidebar ───
+    function populateSidebar(stories) {
+        var container = document.getElementById("sidebar-stories");
+        container.innerHTML = "";
+
+        stories.forEach(function (story) {
+            var div = document.createElement("div");
+            div.className = "rounded-xl bg-white/80 p-3.5 border border-border/50 cursor-pointer hover:bg-white transition-colors";
+            div.innerHTML =
+                '<div class="text-[10px] font-bold text-tertiary tracking-widest uppercase mb-1">' + story.date_label + '</div>' +
+                '<h4 class="font-semibold text-sm text-textmain leading-snug mb-1">' + story.title + '</h4>' +
+                '<p class="text-xs text-textmuted line-clamp-2 leading-relaxed">' + story.summary + '</p>' +
+                '<div class="mt-2 flex items-center justify-between">' +
+                '<span class="text-[10px] text-textmuted">' + story.location_name + '</span>' +
+                '<a href="story-detail.html?id=' + story.id + '" class="text-[11px] font-bold text-primary hover:underline">View →</a>' +
+                '</div>';
+
+            div.addEventListener("click", function (e) {
+                if (e.target.tagName === "A") return;
+                map.setView([story.latitude, story.longitude], 16);
+                // Open the corresponding marker popup
+                markers.forEach(function (m) {
+                    if (m.getLatLng().lat === story.latitude && m.getLatLng().lng === story.longitude) {
+                        m.openPopup();
+                    }
+                });
+            });
+
+            container.appendChild(div);
+        });
+    }
+
+    // Close sidebar
+    document.getElementById("btn-close-sidebar").addEventListener("click", function () {
+        document.getElementById("sidebar").classList.add("hidden");
+    });
+
+    // ─── Search ───
+    var searchInput = document.getElementById("search-input");
+    var searchResults = document.getElementById("search-results");
+    var searchTimeout;
+
+    searchInput.addEventListener("input", function () {
+        clearTimeout(searchTimeout);
+        var query = searchInput.value.trim().toLowerCase();
+
+        if (query.length < 2) {
+            searchResults.classList.add("hidden");
+            searchResults.innerHTML = "";
+            return;
+        }
+
+        searchTimeout = setTimeout(function () {
+            var filtered = MOCK_STORIES.filter(function (s) {
+                return s.title.toLowerCase().includes(query) ||
+                    s.location_name.toLowerCase().includes(query) ||
+                    s.summary.toLowerCase().includes(query) ||
+                    s.author.toLowerCase().includes(query);
+            });
+
+            if (filtered.length === 0) {
+                searchResults.innerHTML = '<div class="px-4 py-3 text-sm text-textmuted">No stories found for "' + query + '"</div>';
+                searchResults.classList.remove("hidden");
+                return;
+            }
+
+            searchResults.innerHTML = "";
+            filtered.forEach(function (story) {
+                var item = document.createElement("div");
+                item.className = "px-4 py-3 hover:bg-background cursor-pointer border-b border-border/30 last:border-0";
+                item.innerHTML =
+                    '<div class="font-semibold text-sm text-textmain">' + story.title + '</div>' +
+                    '<div class="text-xs text-textmuted mt-0.5">' + story.location_name + ' · ' + story.date_label + '</div>';
+                item.addEventListener("click", function () {
+                    map.setView([story.latitude, story.longitude], 16);
+                    markers.forEach(function (m) {
+                        if (m.getLatLng().lat === story.latitude && m.getLatLng().lng === story.longitude) {
+                            m.openPopup();
+                        }
+                    });
+                    searchResults.classList.add("hidden");
+                    searchInput.value = story.title;
+                });
+                searchResults.appendChild(item);
+            });
+            searchResults.classList.remove("hidden");
+        }, 200);
+    });
+
+    // Close search results when clicking outside
+    document.addEventListener("click", function (e) {
+        if (!document.getElementById("search-container").contains(e.target)) {
+            searchResults.classList.add("hidden");
+        }
+    });
+
+    // ─── Initialize ───
+    // In production, this would be: fetch("/api/stories").then(r => r.json()).then(loadStories)
+    loadStories(MOCK_STORIES);
+    populateSidebar(MOCK_STORIES);
+</script>
+</body>
+</html>

--- a/frontend/map.html
+++ b/frontend/map.html
@@ -661,14 +661,7 @@
         });
 
         // ─── Initialize ───
-        fetch(API_BASE + "/stories")
-            .then(res => res.json())
-            .then(data => {
-                var realStories = data.stories || [];
-                loadStories(realStories);
-                populateSidebar(realStories);
-            })
-            .catch(err => console.error("Error loading stories:", err));
+        fetchStoriesInBounds();
 
         loadCurrentUser();
         syncMapSize();

--- a/frontend/map.html
+++ b/frontend/map.html
@@ -280,16 +280,15 @@
             </div>
             <div class="flex items-center gap-3 sm:gap-4">
                 <!-- Search -->
-                <div class="relative hidden sm:block" id="search-container">
-                    <span
-                        class="absolute left-3 top-1/2 -translate-y-1/2 material-symbols-outlined text-textmuted text-xl">search</span>
-                    <input id="search-input"
-                        class="pl-10 pr-4 py-2 bg-white border border-border rounded-xl w-72 text-sm focus:border-primary focus:ring-primary transition-all"
-                        placeholder="Search stories by location..." type="text" autocomplete="off" />
-                    <div id="search-results"
-                        class="absolute top-full left-0 right-0 mt-1 bg-white border border-border rounded-xl shadow-soft overflow-hidden hidden z-50">
+                <form id="search-form" class="relative hidden sm:flex items-center gap-2" action="search.html" method="get">
+                    <div class="relative">
+                        <span
+                            class="absolute left-3 top-1/2 -translate-y-1/2 material-symbols-outlined text-textmuted text-xl">search</span>
+                        <input id="search-input" name="q"
+                            class="pl-10 pr-4 py-2 bg-white border border-border rounded-xl w-72 text-sm focus:border-primary focus:ring-primary transition-all"
+                            placeholder="Search stories by location..." type="text" autocomplete="off" />
                     </div>
-                </div>
+                </form>
                 <div class="relative">
                     <button id="btn-profile" type="button"
                         class="inline-flex h-11 min-w-11 items-center justify-center rounded-full border border-border bg-white px-2 text-textmain shadow-sm transition hover:bg-stone-50"
@@ -583,68 +582,8 @@
             syncMapSize();
         });
 
-        // ─── Search ───
-        var searchInput = document.getElementById("search-input");
-        var searchResults = document.getElementById("search-results");
-        var searchTimeout;
-
-        searchInput.addEventListener("input", function () {
-            clearTimeout(searchTimeout);
-            var query = searchInput.value.trim().toLowerCase();
-
-            if (query.length < 2) {
-                searchResults.classList.add("hidden");
-                searchResults.innerHTML = "";
-                return;
-            }
-
-            searchTimeout = setTimeout(function () {
-                var stories = cachedStories || [];
-                var filtered = stories.filter(function (s) {
-                    return (s.title || "").toLowerCase().includes(query) ||
-                        (s.place_name || "").toLowerCase().includes(query) ||
-                        (s.content || "").toLowerCase().includes(query) ||
-                        (s.author || "").toLowerCase().includes(query);
-                });
-
-                if (filtered.length === 0) {
-                    searchResults.innerHTML = '<div class="px-4 py-3 text-sm text-textmuted">No stories found for "' + query + '"</div>';
-                    searchResults.classList.remove("hidden");
-                    return;
-                }
-
-                searchResults.innerHTML = "";
-                filtered.forEach(function (story) {
-                    var item = document.createElement("div");
-                    item.className = "px-4 py-3 hover:bg-background cursor-pointer border-b border-border/30 last:border-0";
-                    var placeName = story.place_name || "";
-                    var dateLabel = story.date_label || "";
-                    var subtitle = [placeName, dateLabel].filter(Boolean).join(" · ");
-                    item.innerHTML =
-                        '<div class="font-semibold text-sm text-textmain">' + story.title + '</div>' +
-                        (subtitle ? '<div class="text-xs text-textmuted mt-0.5">' + subtitle + '</div>' : '');
-                    item.addEventListener("click", function () {
-                        map.setView([story.latitude, story.longitude], 16);
-                        markers.forEach(function (m) {
-                            if (m.getLatLng().lat === story.latitude && m.getLatLng().lng === story.longitude) {
-                                m.openPopup();
-                            }
-                        });
-                        searchResults.classList.add("hidden");
-                        searchInput.value = story.title;
-                    });
-                    searchResults.appendChild(item);
-                });
-                searchResults.classList.remove("hidden");
-            }, 200);
-        });
-
-        // Close search results when clicking outside
+        // Close profile menu when clicking outside
         document.addEventListener("click", function (e) {
-            if (!document.getElementById("search-container").contains(e.target)) {
-                searchResults.classList.add("hidden");
-            }
-
             if (!profileMenu.hidden && !profileMenu.contains(e.target) && !profileButton.contains(e.target)) {
                 closeProfileMenu();
             }

--- a/frontend/map.html
+++ b/frontend/map.html
@@ -134,7 +134,7 @@
     </style>
 </head>
 
-<body class="bg-background text-textmain font-body overflow-hidden">
+<body class="bg-background text-textmain font-body md:overflow-hidden">
 
     <!-- Top Navigation Bar -->
     <header class="fixed top-0 left-0 right-0 z-[1000] bg-[#f8f3ea]/95 backdrop-blur-sm border-b border-border/30">
@@ -153,7 +153,7 @@
             </div>
             <div class="flex items-center gap-4">
                 <!-- Search -->
-                <div class="relative" id="search-container">
+                <div class="relative hidden sm:block" id="search-container">
                     <span
                         class="absolute left-3 top-1/2 -translate-y-1/2 material-symbols-outlined text-textmuted text-xl">search</span>
                     <input id="search-input"
@@ -168,51 +168,53 @@
     </header>
 
     <!-- Map Container -->
-    <main class="relative w-full h-screen pt-[68px]">
-        <div id="map" class="absolute inset-0 top-[68px]"></div>
+    <main class="relative w-full pt-[68px] md:h-screen">
+        <div class="relative h-[58vh] min-h-[360px] md:h-[calc(100vh-68px)]">
+            <div id="map" class="absolute inset-0 md:top-0"></div>
 
-        <!-- Map Layer Toggle -->
-        <div class="absolute left-4 top-40 z-[1000] flex flex-col gap-2">
-            <button id="btn-layers"
-                class="glass-panel w-11 h-11 flex items-center justify-center rounded-xl text-primary shadow-sm hover:bg-white transition-colors border border-border/30"
-                title="Toggle map layers">
-                <span class="material-symbols-outlined text-xl">layers</span>
-            </button>
-            <button id="btn-locate"
-                class="glass-panel w-11 h-11 flex items-center justify-center rounded-xl text-tertiary shadow-sm hover:bg-white transition-colors border border-border/30"
-                title="Go to my location">
-                <span class="material-symbols-outlined text-xl">my_location</span>
-            </button>
-        </div>
-
-        <!-- Story Count Badge -->
-        <div class="absolute bottom-8 left-8 z-[1000]">
-            <div
-                class="glass-panel px-4 py-2.5 rounded-full border border-border/30 text-xs font-medium text-textmuted flex items-center gap-2 shadow-sm">
-                <span class="w-2 h-2 rounded-full bg-emerald-500 animate-pulse"></span>
-                <span id="story-count">Loading stories...</span>
+            <!-- Map Layer Toggle -->
+            <div class="absolute left-4 top-20 z-[1000] flex flex-col gap-2 md:top-40">
+                <button id="btn-layers"
+                    class="glass-panel w-11 h-11 flex items-center justify-center rounded-xl text-primary shadow-sm hover:bg-white transition-colors border border-border/30"
+                    title="Toggle map layers">
+                    <span class="material-symbols-outlined text-xl">layers</span>
+                </button>
+                <button id="btn-locate"
+                    class="glass-panel w-11 h-11 flex items-center justify-center rounded-xl text-tertiary shadow-sm hover:bg-white transition-colors border border-border/30"
+                    title="Go to my location">
+                    <span class="material-symbols-outlined text-xl">my_location</span>
+                </button>
             </div>
-        </div>
 
-        <!-- Floating Action Button -->
-        <div class="absolute bottom-8 right-8 z-[1000]">
-            <a href="story-create.html"
-                class="flex items-center gap-3 bg-primary text-white px-6 py-4 rounded-xl font-semibold shadow-xl hover:scale-105 active:scale-95 transition-all border border-primary-light/20">
-                <span class="material-symbols-outlined" style="font-variation-settings: 'FILL' 1;">edit_square</span>
-                Share a Story
-            </a>
+            <!-- Story Count Badge -->
+            <div class="absolute bottom-6 left-4 z-[1000] md:bottom-8 md:left-8">
+                <div
+                    class="glass-panel px-4 py-2.5 rounded-full border border-border/30 text-xs font-medium text-textmuted flex items-center gap-2 shadow-sm">
+                    <span class="w-2 h-2 rounded-full bg-emerald-500 animate-pulse"></span>
+                    <span id="story-count">Loading stories...</span>
+                </div>
+            </div>
+
+            <!-- Floating Action Button -->
+            <div class="absolute bottom-6 right-4 z-[1000] md:bottom-8 md:right-8">
+                <a href="story-create.html"
+                    class="flex items-center gap-3 bg-primary text-white px-4 py-3 rounded-xl text-sm font-semibold shadow-xl hover:scale-105 active:scale-95 transition-all border border-primary-light/20 md:px-6 md:py-4 md:text-base">
+                    <span class="material-symbols-outlined" style="font-variation-settings: 'FILL' 1;">edit_square</span>
+                    Share a Story
+                </a>
+            </div>
         </div>
 
         <!-- Discovery Sidebar -->
         <aside id="sidebar"
-            class="absolute top-24 right-4 w-72 glass-panel rounded-2xl p-5 shadow-sm border border-border/20 z-[1000] max-h-[calc(100vh-200px)] overflow-y-auto">
+            class="relative z-[1000] m-4 mt-5 glass-panel rounded-2xl p-5 shadow-sm border border-border/20 md:absolute md:top-24 md:right-4 md:m-0 md:mt-0 md:w-72 md:max-h-[calc(100vh-200px)] md:overflow-y-auto">
             <div class="flex items-center justify-between mb-5">
                 <h2 class="font-headline font-bold text-lg">Recent Stories</h2>
-                <button id="btn-close-sidebar" class="text-textmuted hover:text-textmain transition-colors">
+                <button id="btn-close-sidebar" class="hidden text-textmuted hover:text-textmain transition-colors md:inline-flex">
                     <span class="material-symbols-outlined text-xl">close</span>
                 </button>
             </div>
-            <div id="sidebar-stories" class="space-y-3">
+            <div id="sidebar-stories" class="space-y-3 pb-1">
                 <!-- Populated by JS -->
             </div>
         </aside>
@@ -320,6 +322,12 @@
             zoom: 13,
             zoomControl: false
         });
+
+        function syncMapSize() {
+            window.requestAnimationFrame(function () {
+                map.invalidateSize();
+            });
+        }
 
         // Tile layers
         const osmLayer = L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
@@ -468,6 +476,7 @@
         // Close sidebar
         document.getElementById("btn-close-sidebar").addEventListener("click", function () {
             document.getElementById("sidebar").classList.add("hidden");
+            syncMapSize();
         });
 
         // ─── Search ───
@@ -533,6 +542,8 @@
         // In production, this would be: fetch("/api/stories").then(r => r.json()).then(loadStories)
         loadStories(MOCK_STORIES);
         populateSidebar(MOCK_STORIES);
+        syncMapSize();
+        window.addEventListener("resize", syncMapSize);
     </script>
 </body>
 

--- a/frontend/map.html
+++ b/frontend/map.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -7,8 +8,11 @@
     <script src="https://cdn.tailwindcss.com?plugins=forms"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Serif:wght@700;800&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet">
+    <link
+        href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Serif:wght@700;800&display=swap"
+        rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+        rel="stylesheet">
     <!-- Leaflet CSS -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
     <script>
@@ -41,10 +45,12 @@
         .material-symbols-outlined {
             font-variation-settings: "FILL" 0, "wght" 400, "GRAD" 0, "opsz" 24;
         }
+
         /* Override Leaflet defaults to match project style */
         .leaflet-container {
             font-family: "Inter", sans-serif;
         }
+
         .leaflet-control-zoom a {
             background: rgba(254, 249, 240, 0.9) !important;
             backdrop-filter: blur(12px);
@@ -52,13 +58,16 @@
             border: 1px solid #e7e2d9 !important;
             font-weight: 600;
         }
+
         .leaflet-control-zoom a:hover {
             background: #ffffff !important;
         }
+
         .leaflet-control-attribution {
             background: rgba(254, 249, 240, 0.75) !important;
             font-size: 10px;
         }
+
         /* Custom marker style */
         .story-marker {
             width: 40px;
@@ -66,7 +75,7 @@
             border-radius: 50%;
             border: 3px solid #ffffff;
             background: #775a19;
-            box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
             cursor: pointer;
             transition: transform 0.2s ease;
             display: flex;
@@ -75,281 +84,300 @@
             color: white;
             font-size: 16px;
         }
+
         .story-marker:hover {
             transform: scale(1.15);
         }
+
         .story-marker.active {
             border-color: #35618f;
-            box-shadow: 0 0 0 4px rgba(53,97,143,0.2), 0 4px 12px rgba(0,0,0,0.2);
+            box-shadow: 0 0 0 4px rgba(53, 97, 143, 0.2), 0 4px 12px rgba(0, 0, 0, 0.2);
             transform: scale(1.1);
         }
+
         /* Story popup card */
         .leaflet-popup-content-wrapper {
             border-radius: 16px !important;
             padding: 0 !important;
-            box-shadow: 0 20px 50px rgba(0,0,0,0.12) !important;
+            box-shadow: 0 20px 50px rgba(0, 0, 0, 0.12) !important;
             overflow: hidden;
         }
+
         .leaflet-popup-content {
             margin: 0 !important;
             width: 300px !important;
         }
+
         .leaflet-popup-tip {
             box-shadow: none !important;
         }
+
         .glass-panel {
             background: rgba(254, 249, 240, 0.9);
             backdrop-filter: blur(12px);
         }
+
         /* Search results dropdown */
         #search-results {
             max-height: 240px;
             overflow-y: auto;
         }
+
         #search-results::-webkit-scrollbar {
             width: 4px;
         }
+
         #search-results::-webkit-scrollbar-thumb {
             background: #c5a059;
             border-radius: 4px;
         }
     </style>
 </head>
+
 <body class="bg-background text-textmain font-body overflow-hidden">
 
-<!-- Top Navigation Bar -->
-<header class="fixed top-0 left-0 right-0 z-[1000] bg-[#f8f3ea]/95 backdrop-blur-sm border-b border-border/30">
-    <div class="flex justify-between items-center w-full px-8 py-4 max-w-screen-2xl mx-auto">
-        <div class="flex items-center gap-8">
-            <h1 class="text-2xl font-bold font-headline text-textmain tracking-tight">Local History Map</h1>
-            <nav class="hidden md:flex items-center gap-6">
-                <a class="text-primary font-bold border-b-2 border-primary pb-1" href="map.html">Map</a>
-                <a class="text-textmain font-medium hover:text-tertiary transition-colors" href="story-detail.html">Archive</a>
-                <a class="text-textmain font-medium hover:text-tertiary transition-colors" href="story-create.html">Create Story</a>
-                <a class="text-textmain font-medium hover:text-tertiary transition-colors" href="index.html">Login</a>
-            </nav>
-        </div>
-        <div class="flex items-center gap-4">
-            <!-- Search -->
-            <div class="relative" id="search-container">
-                <span class="absolute left-3 top-1/2 -translate-y-1/2 material-symbols-outlined text-textmuted text-xl">search</span>
-                <input
-                        id="search-input"
+    <!-- Top Navigation Bar -->
+    <header class="fixed top-0 left-0 right-0 z-[1000] bg-[#f8f3ea]/95 backdrop-blur-sm border-b border-border/30">
+        <div class="flex justify-between items-center w-full px-8 py-4 max-w-screen-2xl mx-auto">
+            <div class="flex items-center gap-8">
+                <h1 class="text-2xl font-bold font-headline text-textmain tracking-tight">Local History Map</h1>
+                <nav class="hidden md:flex items-center gap-6">
+                    <a class="text-primary font-bold border-b-2 border-primary pb-1" href="map.html">Map</a>
+                    <a class="text-textmain font-medium hover:text-tertiary transition-colors"
+                        href="story-detail.html">Archive</a>
+                    <a class="text-textmain font-medium hover:text-tertiary transition-colors"
+                        href="story-create.html">Create Story</a>
+                    <a class="text-textmain font-medium hover:text-tertiary transition-colors"
+                        href="index.html">Login</a>
+                </nav>
+            </div>
+            <div class="flex items-center gap-4">
+                <!-- Search -->
+                <div class="relative" id="search-container">
+                    <span
+                        class="absolute left-3 top-1/2 -translate-y-1/2 material-symbols-outlined text-textmuted text-xl">search</span>
+                    <input id="search-input"
                         class="pl-10 pr-4 py-2 bg-white border border-border rounded-xl w-72 text-sm focus:border-primary focus:ring-primary transition-all"
-                        placeholder="Search stories by location..."
-                        type="text"
-                        autocomplete="off"
-                />
-                <div id="search-results" class="absolute top-full left-0 right-0 mt-1 bg-white border border-border rounded-xl shadow-soft overflow-hidden hidden z-50"></div>
+                        placeholder="Search stories by location..." type="text" autocomplete="off" />
+                    <div id="search-results"
+                        class="absolute top-full left-0 right-0 mt-1 bg-white border border-border rounded-xl shadow-soft overflow-hidden hidden z-50">
+                    </div>
+                </div>
             </div>
         </div>
-    </div>
-</header>
+    </header>
 
-<!-- Map Container -->
-<main class="relative w-full h-screen pt-[68px]">
-    <div id="map" class="absolute inset-0 top-[68px]"></div>
+    <!-- Map Container -->
+    <main class="relative w-full h-screen pt-[68px]">
+        <div id="map" class="absolute inset-0 top-[68px]"></div>
 
-    <!-- Map Layer Toggle -->
-    <div class="absolute left-4 top-28 z-[1000] flex flex-col gap-2">
-        <button id="btn-layers" class="glass-panel w-11 h-11 flex items-center justify-center rounded-xl text-primary shadow-sm hover:bg-white transition-colors border border-border/30" title="Toggle map layers">
-            <span class="material-symbols-outlined text-xl">layers</span>
-        </button>
-        <button id="btn-locate" class="glass-panel w-11 h-11 flex items-center justify-center rounded-xl text-tertiary shadow-sm hover:bg-white transition-colors border border-border/30" title="Go to my location">
-            <span class="material-symbols-outlined text-xl">my_location</span>
-        </button>
-    </div>
-
-    <!-- Story Count Badge -->
-    <div class="absolute bottom-8 left-8 z-[1000]">
-        <div class="glass-panel px-4 py-2.5 rounded-full border border-border/30 text-xs font-medium text-textmuted flex items-center gap-2 shadow-sm">
-            <span class="w-2 h-2 rounded-full bg-emerald-500 animate-pulse"></span>
-            <span id="story-count">Loading stories...</span>
-        </div>
-    </div>
-
-    <!-- Floating Action Button -->
-    <div class="absolute bottom-8 right-8 z-[1000]">
-        <a href="story-create.html" class="flex items-center gap-3 bg-primary text-white px-6 py-4 rounded-xl font-semibold shadow-xl hover:scale-105 active:scale-95 transition-all border border-primary-light/20">
-            <span class="material-symbols-outlined" style="font-variation-settings: 'FILL' 1;">edit_square</span>
-            Share a Story
-        </a>
-    </div>
-
-    <!-- Discovery Sidebar -->
-    <aside id="sidebar" class="absolute top-24 right-4 w-72 glass-panel rounded-2xl p-5 shadow-sm border border-border/20 z-[1000] max-h-[calc(100vh-160px)] overflow-y-auto">
-        <div class="flex items-center justify-between mb-5">
-            <h2 class="font-headline font-bold text-lg">Recent Stories</h2>
-            <button id="btn-close-sidebar" class="text-textmuted hover:text-textmain transition-colors">
-                <span class="material-symbols-outlined text-xl">close</span>
+        <!-- Map Layer Toggle -->
+        <div class="absolute left-4 top-40 z-[1000] flex flex-col gap-2">
+            <button id="btn-layers"
+                class="glass-panel w-11 h-11 flex items-center justify-center rounded-xl text-primary shadow-sm hover:bg-white transition-colors border border-border/30"
+                title="Toggle map layers">
+                <span class="material-symbols-outlined text-xl">layers</span>
+            </button>
+            <button id="btn-locate"
+                class="glass-panel w-11 h-11 flex items-center justify-center rounded-xl text-tertiary shadow-sm hover:bg-white transition-colors border border-border/30"
+                title="Go to my location">
+                <span class="material-symbols-outlined text-xl">my_location</span>
             </button>
         </div>
-        <div id="sidebar-stories" class="space-y-3">
-            <!-- Populated by JS -->
+
+        <!-- Story Count Badge -->
+        <div class="absolute bottom-8 left-8 z-[1000]">
+            <div
+                class="glass-panel px-4 py-2.5 rounded-full border border-border/30 text-xs font-medium text-textmuted flex items-center gap-2 shadow-sm">
+                <span class="w-2 h-2 rounded-full bg-emerald-500 animate-pulse"></span>
+                <span id="story-count">Loading stories...</span>
+            </div>
         </div>
-    </aside>
-</main>
 
-<!-- Leaflet JS -->
-<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+        <!-- Floating Action Button -->
+        <div class="absolute bottom-8 right-8 z-[1000]">
+            <a href="story-create.html"
+                class="flex items-center gap-3 bg-primary text-white px-6 py-4 rounded-xl font-semibold shadow-xl hover:scale-105 active:scale-95 transition-all border border-primary-light/20">
+                <span class="material-symbols-outlined" style="font-variation-settings: 'FILL' 1;">edit_square</span>
+                Share a Story
+            </a>
+        </div>
 
-<script>
-    // ─── Mock story data (will be replaced by API calls) ───
-    const MOCK_STORIES = [
-        {
-            id: "1",
-            title: "My Father's First Shop in Galata",
-            summary: "The smell of fresh timber and roasted coffee always brings me back to that narrow cobblestone alley...",
-            author: "mehmet_arif",
-            date_label: "1970s Era",
-            latitude: 41.0256,
-            longitude: 28.9744,
-            location_name: "Galata, Istanbul",
-            thumbnail: null
-        },
-        {
-            id: "2",
-            title: "The Old Fisherman's Quarter of Kadikoy",
-            summary: "In the narrow streets behind the market, a row of wooden houses once stood where fishermen repaired their nets.",
-            author: "ayse_k",
-            date_label: "1965 - 1985",
-            latitude: 40.9903,
-            longitude: 29.0230,
-            location_name: "Kadikoy, Istanbul",
-            thumbnail: null
-        },
-        {
-            id: "3",
-            title: "Bosphorus Ferry Memories",
-            summary: "Every morning my grandmother took the ferry from Üsküdar to Eminönü, carrying fresh bread and stories.",
-            author: "can_photo",
-            date_label: "1950s - 1960s",
-            latitude: 41.0232,
-            longitude: 29.0154,
-            location_name: "Üsküdar, Istanbul",
-            thumbnail: null
-        },
-        {
-            id: "4",
-            title: "The Grand Bazaar Before Tourism",
-            summary: "My uncle ran a copper workshop in the inner passages. The sound of hammering echoed through every corridor.",
-            author: "deniz_y",
-            date_label: "1980s",
-            latitude: 41.0106,
-            longitude: 28.9680,
-            location_name: "Grand Bazaar, Istanbul",
-            thumbnail: null
-        },
-        {
-            id: "5",
-            title: "Boğaziçi Campus in the 90s",
-            summary: "The library was our second home during finals. We pulled all-nighters fueled by tea from the canteen.",
-            author: "ali_c",
-            date_label: "1994 - 1998",
-            latitude: 41.0839,
-            longitude: 29.0510,
-            location_name: "Boğaziçi University, Istanbul",
-            thumbnail: null
-        },
-        {
-            id: "6",
-            title: "Sultanahmet's Hidden Gardens",
-            summary: "Behind the Blue Mosque there was a tea garden where locals gathered every Friday after prayers.",
-            author: "fatma_h",
-            date_label: "1960s - 1970s",
-            latitude: 41.0054,
-            longitude: 28.9768,
-            location_name: "Sultanahmet, Istanbul",
-            thumbnail: null
-        },
-        {
-            id: "7",
-            title: "The Tram Line on İstiklal Avenue",
-            summary: "Before the nostalgic tram returned, İstiklal was a vibrant pedestrian boulevard with street musicians and bookshops.",
-            author: "ozan_m",
-            date_label: "1990s",
-            latitude: 41.0340,
-            longitude: 28.9784,
-            location_name: "İstiklal Avenue, Istanbul",
-            thumbnail: null
-        },
-        {
-            id: "8",
-            title: "Haydarpaşa Train Station Arrivals",
-            summary: "Families from Anatolia arrived here with suitcases and dreams. The station felt like the gateway to a new world.",
-            author: "yusuf_b",
-            date_label: "1950s - 1970s",
-            latitude: 40.9977,
-            longitude: 29.0183,
-            location_name: "Haydarpaşa, Istanbul",
-            thumbnail: null
-        }
-    ];
+        <!-- Discovery Sidebar -->
+        <aside id="sidebar"
+            class="absolute top-24 right-4 w-72 glass-panel rounded-2xl p-5 shadow-sm border border-border/20 z-[1000] max-h-[calc(100vh-200px)] overflow-y-auto">
+            <div class="flex items-center justify-between mb-5">
+                <h2 class="font-headline font-bold text-lg">Recent Stories</h2>
+                <button id="btn-close-sidebar" class="text-textmuted hover:text-textmain transition-colors">
+                    <span class="material-symbols-outlined text-xl">close</span>
+                </button>
+            </div>
+            <div id="sidebar-stories" class="space-y-3">
+                <!-- Populated by JS -->
+            </div>
+        </aside>
+    </main>
 
-    // ─── Initialize Map ───
-    const map = L.map("map", {
-        center: [41.015, 28.979],
-        zoom: 13,
-        zoomControl: false
-    });
+    <!-- Leaflet JS -->
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 
-    // Tile layers
-    const osmLayer = L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
-        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-        maxZoom: 19
-    });
-
-    const topoLayer = L.tileLayer("https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png", {
-        attribution: '&copy; <a href="https://opentopomap.org">OpenTopoMap</a>',
-        maxZoom: 17
-    });
-
-    // Default layer
-    osmLayer.addTo(map);
-    let currentLayer = "osm";
-
-    // Zoom controls (Leaflet default position overridden by CSS, but we add custom)
-    L.control.zoom({ position: "topleft" }).addTo(map);
-
-    // ─── Layer Toggle ───
-    document.getElementById("btn-layers").addEventListener("click", function () {
-        if (currentLayer === "osm") {
-            map.removeLayer(osmLayer);
-            topoLayer.addTo(map);
-            currentLayer = "topo";
-        } else {
-            map.removeLayer(topoLayer);
-            osmLayer.addTo(map);
-            currentLayer = "osm";
-        }
-    });
-
-    // ─── Geolocation ───
-    document.getElementById("btn-locate").addEventListener("click", function () {
-        if (!navigator.geolocation) return;
-        navigator.geolocation.getCurrentPosition(
-            function (pos) {
-                map.setView([pos.coords.latitude, pos.coords.longitude], 15);
+    <script>
+        // ─── Mock story data (will be replaced by API calls) ───
+        const MOCK_STORIES = [
+            {
+                id: "1",
+                title: "My Father's First Shop in Galata",
+                summary: "The smell of fresh timber and roasted coffee always brings me back to that narrow cobblestone alley...",
+                author: "mehmet_arif",
+                date_label: "1970s Era",
+                latitude: 41.0256,
+                longitude: 28.9744,
+                location_name: "Galata, Istanbul",
+                thumbnail: null
             },
-            function () {
-                alert("Unable to access your location.");
+            {
+                id: "2",
+                title: "The Old Fisherman's Quarter of Kadikoy",
+                summary: "In the narrow streets behind the market, a row of wooden houses once stood where fishermen repaired their nets.",
+                author: "ayse_k",
+                date_label: "1965 - 1985",
+                latitude: 40.9903,
+                longitude: 29.0230,
+                location_name: "Kadikoy, Istanbul",
+                thumbnail: null
+            },
+            {
+                id: "3",
+                title: "Bosphorus Ferry Memories",
+                summary: "Every morning my grandmother took the ferry from Üsküdar to Eminönü, carrying fresh bread and stories.",
+                author: "can_photo",
+                date_label: "1950s - 1960s",
+                latitude: 41.0232,
+                longitude: 29.0154,
+                location_name: "Üsküdar, Istanbul",
+                thumbnail: null
+            },
+            {
+                id: "4",
+                title: "The Grand Bazaar Before Tourism",
+                summary: "My uncle ran a copper workshop in the inner passages. The sound of hammering echoed through every corridor.",
+                author: "deniz_y",
+                date_label: "1980s",
+                latitude: 41.0106,
+                longitude: 28.9680,
+                location_name: "Grand Bazaar, Istanbul",
+                thumbnail: null
+            },
+            {
+                id: "5",
+                title: "Boğaziçi Campus in the 90s",
+                summary: "The library was our second home during finals. We pulled all-nighters fueled by tea from the canteen.",
+                author: "ali_c",
+                date_label: "1994 - 1998",
+                latitude: 41.0839,
+                longitude: 29.0510,
+                location_name: "Boğaziçi University, Istanbul",
+                thumbnail: null
+            },
+            {
+                id: "6",
+                title: "Sultanahmet's Hidden Gardens",
+                summary: "Behind the Blue Mosque there was a tea garden where locals gathered every Friday after prayers.",
+                author: "fatma_h",
+                date_label: "1960s - 1970s",
+                latitude: 41.0054,
+                longitude: 28.9768,
+                location_name: "Sultanahmet, Istanbul",
+                thumbnail: null
+            },
+            {
+                id: "7",
+                title: "The Tram Line on İstiklal Avenue",
+                summary: "Before the nostalgic tram returned, İstiklal was a vibrant pedestrian boulevard with street musicians and bookshops.",
+                author: "ozan_m",
+                date_label: "1990s",
+                latitude: 41.0340,
+                longitude: 28.9784,
+                location_name: "İstiklal Avenue, Istanbul",
+                thumbnail: null
+            },
+            {
+                id: "8",
+                title: "Haydarpaşa Train Station Arrivals",
+                summary: "Families from Anatolia arrived here with suitcases and dreams. The station felt like the gateway to a new world.",
+                author: "yusuf_b",
+                date_label: "1950s - 1970s",
+                latitude: 40.9977,
+                longitude: 29.0183,
+                location_name: "Haydarpaşa, Istanbul",
+                thumbnail: null
             }
-        );
-    });
+        ];
 
-    // ─── Create Markers ───
-    function createMarkerIcon() {
-        return L.divIcon({
-            className: "",
-            html: '<div class="story-marker"><span class="material-symbols-outlined" style="font-size:18px;">auto_stories</span></div>',
-            iconSize: [40, 40],
-            iconAnchor: [20, 20],
-            popupAnchor: [0, -24]
+        // ─── Initialize Map ───
+        const map = L.map("map", {
+            center: [41.015, 28.979],
+            zoom: 13,
+            zoomControl: false
         });
-    }
 
-    function createPopupContent(story) {
-        return `
+        // Tile layers
+        const osmLayer = L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+            maxZoom: 19
+        });
+
+        const topoLayer = L.tileLayer("https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png", {
+            attribution: '&copy; <a href="https://opentopomap.org">OpenTopoMap</a>',
+            maxZoom: 17
+        });
+
+        // Default layer
+        osmLayer.addTo(map);
+        let currentLayer = "osm";
+
+        // Zoom controls (Leaflet default position overridden by CSS, but we add custom)
+        L.control.zoom({ position: "topleft" }).addTo(map);
+
+        // ─── Layer Toggle ───
+        document.getElementById("btn-layers").addEventListener("click", function () {
+            if (currentLayer === "osm") {
+                map.removeLayer(osmLayer);
+                topoLayer.addTo(map);
+                currentLayer = "topo";
+            } else {
+                map.removeLayer(topoLayer);
+                osmLayer.addTo(map);
+                currentLayer = "osm";
+            }
+        });
+
+        // ─── Geolocation ───
+        document.getElementById("btn-locate").addEventListener("click", function () {
+            if (!navigator.geolocation) return;
+            navigator.geolocation.getCurrentPosition(
+                function (pos) {
+                    map.setView([pos.coords.latitude, pos.coords.longitude], 15);
+                },
+                function () {
+                    alert("Unable to access your location.");
+                }
+            );
+        });
+
+        // ─── Create Markers ───
+        function createMarkerIcon() {
+            return L.divIcon({
+                className: "",
+                html: '<div class="story-marker"><span class="material-symbols-outlined" style="font-size:18px;">auto_stories</span></div>',
+                iconSize: [40, 40],
+                iconAnchor: [20, 20],
+                popupAnchor: [0, -24]
+            });
+        }
+
+        function createPopupContent(story) {
+            return `
       <div style="width:300px;">
         <div style="background:linear-gradient(135deg,#e9dfcd,#f7f3eb);height:100px;display:flex;align-items:center;justify-content:center;position:relative;">
           <span class="material-symbols-outlined" style="font-size:36px;color:#775a19;opacity:0.4;">photo_library</span>
@@ -365,146 +393,147 @@
         </div>
       </div>
     `;
-    }
-
-    const markers = [];
-
-    function loadStories(stories) {
-        // Clear existing markers
-        markers.forEach(function (m) { map.removeLayer(m); });
-        markers.length = 0;
-
-        stories.forEach(function (story) {
-            const marker = L.marker([story.latitude, story.longitude], {
-                icon: createMarkerIcon()
-            });
-
-            marker.bindPopup(createPopupContent(story), {
-                maxWidth: 300,
-                minWidth: 300,
-                closeButton: true
-            });
-
-            marker.on("click", function () {
-                // Highlight active marker
-                document.querySelectorAll(".story-marker").forEach(function (el) {
-                    el.classList.remove("active");
-                });
-                var el = marker.getElement();
-                if (el) {
-                    var markerDiv = el.querySelector(".story-marker");
-                    if (markerDiv) markerDiv.classList.add("active");
-                }
-            });
-
-            marker.addTo(map);
-            markers.push(marker);
-        });
-
-        // Update count
-        document.getElementById("story-count").textContent = stories.length + " stories on the map";
-    }
-
-    // ─── Sidebar ───
-    function populateSidebar(stories) {
-        var container = document.getElementById("sidebar-stories");
-        container.innerHTML = "";
-
-        stories.forEach(function (story) {
-            var div = document.createElement("div");
-            div.className = "rounded-xl bg-white/80 p-3.5 border border-border/50 cursor-pointer hover:bg-white transition-colors";
-            div.innerHTML =
-                '<div class="text-[10px] font-bold text-tertiary tracking-widest uppercase mb-1">' + story.date_label + '</div>' +
-                '<h4 class="font-semibold text-sm text-textmain leading-snug mb-1">' + story.title + '</h4>' +
-                '<p class="text-xs text-textmuted line-clamp-2 leading-relaxed">' + story.summary + '</p>' +
-                '<div class="mt-2 flex items-center justify-between">' +
-                '<span class="text-[10px] text-textmuted">' + story.location_name + '</span>' +
-                '<a href="story-detail.html?id=' + story.id + '" class="text-[11px] font-bold text-primary hover:underline">View →</a>' +
-                '</div>';
-
-            div.addEventListener("click", function (e) {
-                if (e.target.tagName === "A") return;
-                map.setView([story.latitude, story.longitude], 16);
-                // Open the corresponding marker popup
-                markers.forEach(function (m) {
-                    if (m.getLatLng().lat === story.latitude && m.getLatLng().lng === story.longitude) {
-                        m.openPopup();
-                    }
-                });
-            });
-
-            container.appendChild(div);
-        });
-    }
-
-    // Close sidebar
-    document.getElementById("btn-close-sidebar").addEventListener("click", function () {
-        document.getElementById("sidebar").classList.add("hidden");
-    });
-
-    // ─── Search ───
-    var searchInput = document.getElementById("search-input");
-    var searchResults = document.getElementById("search-results");
-    var searchTimeout;
-
-    searchInput.addEventListener("input", function () {
-        clearTimeout(searchTimeout);
-        var query = searchInput.value.trim().toLowerCase();
-
-        if (query.length < 2) {
-            searchResults.classList.add("hidden");
-            searchResults.innerHTML = "";
-            return;
         }
 
-        searchTimeout = setTimeout(function () {
-            var filtered = MOCK_STORIES.filter(function (s) {
-                return s.title.toLowerCase().includes(query) ||
-                    s.location_name.toLowerCase().includes(query) ||
-                    s.summary.toLowerCase().includes(query) ||
-                    s.author.toLowerCase().includes(query);
+        const markers = [];
+
+        function loadStories(stories) {
+            // Clear existing markers
+            markers.forEach(function (m) { map.removeLayer(m); });
+            markers.length = 0;
+
+            stories.forEach(function (story) {
+                const marker = L.marker([story.latitude, story.longitude], {
+                    icon: createMarkerIcon()
+                });
+
+                marker.bindPopup(createPopupContent(story), {
+                    maxWidth: 300,
+                    minWidth: 300,
+                    closeButton: true
+                });
+
+                marker.on("click", function () {
+                    // Highlight active marker
+                    document.querySelectorAll(".story-marker").forEach(function (el) {
+                        el.classList.remove("active");
+                    });
+                    var el = marker.getElement();
+                    if (el) {
+                        var markerDiv = el.querySelector(".story-marker");
+                        if (markerDiv) markerDiv.classList.add("active");
+                    }
+                });
+
+                marker.addTo(map);
+                markers.push(marker);
             });
 
-            if (filtered.length === 0) {
-                searchResults.innerHTML = '<div class="px-4 py-3 text-sm text-textmuted">No stories found for "' + query + '"</div>';
-                searchResults.classList.remove("hidden");
-                return;
-            }
+            // Update count
+            document.getElementById("story-count").textContent = stories.length + " stories on the map";
+        }
 
-            searchResults.innerHTML = "";
-            filtered.forEach(function (story) {
-                var item = document.createElement("div");
-                item.className = "px-4 py-3 hover:bg-background cursor-pointer border-b border-border/30 last:border-0";
-                item.innerHTML =
-                    '<div class="font-semibold text-sm text-textmain">' + story.title + '</div>' +
-                    '<div class="text-xs text-textmuted mt-0.5">' + story.location_name + ' · ' + story.date_label + '</div>';
-                item.addEventListener("click", function () {
+        // ─── Sidebar ───
+        function populateSidebar(stories) {
+            var container = document.getElementById("sidebar-stories");
+            container.innerHTML = "";
+
+            stories.forEach(function (story) {
+                var div = document.createElement("div");
+                div.className = "rounded-xl bg-white/80 p-3.5 border border-border/50 cursor-pointer hover:bg-white transition-colors";
+                div.innerHTML =
+                    '<div class="text-[10px] font-bold text-tertiary tracking-widest uppercase mb-1">' + story.date_label + '</div>' +
+                    '<h4 class="font-semibold text-sm text-textmain leading-snug mb-1">' + story.title + '</h4>' +
+                    '<p class="text-xs text-textmuted line-clamp-2 leading-relaxed">' + story.summary + '</p>' +
+                    '<div class="mt-2 flex items-center justify-between">' +
+                    '<span class="text-[10px] text-textmuted">' + story.location_name + '</span>' +
+                    '<a href="story-detail.html?id=' + story.id + '" class="text-[11px] font-bold text-primary hover:underline">View →</a>' +
+                    '</div>';
+
+                div.addEventListener("click", function (e) {
+                    if (e.target.tagName === "A") return;
                     map.setView([story.latitude, story.longitude], 16);
+                    // Open the corresponding marker popup
                     markers.forEach(function (m) {
                         if (m.getLatLng().lat === story.latitude && m.getLatLng().lng === story.longitude) {
                             m.openPopup();
                         }
                     });
-                    searchResults.classList.add("hidden");
-                    searchInput.value = story.title;
                 });
-                searchResults.appendChild(item);
+
+                container.appendChild(div);
             });
-            searchResults.classList.remove("hidden");
-        }, 200);
-    });
-
-    // Close search results when clicking outside
-    document.addEventListener("click", function (e) {
-        if (!document.getElementById("search-container").contains(e.target)) {
-            searchResults.classList.add("hidden");
         }
-    });
 
-    // ─── Initialize ───
-    // In production, this would be: fetch("/api/stories").then(r => r.json()).then(loadStories)
-    loadStories(MOCK_STORIES);
-    populateSidebar(MOCK_STORIES);
-</script>
+        // Close sidebar
+        document.getElementById("btn-close-sidebar").addEventListener("click", function () {
+            document.getElementById("sidebar").classList.add("hidden");
+        });
+
+        // ─── Search ───
+        var searchInput = document.getElementById("search-input");
+        var searchResults = document.getElementById("search-results");
+        var searchTimeout;
+
+        searchInput.addEventListener("input", function () {
+            clearTimeout(searchTimeout);
+            var query = searchInput.value.trim().toLowerCase();
+
+            if (query.length < 2) {
+                searchResults.classList.add("hidden");
+                searchResults.innerHTML = "";
+                return;
+            }
+
+            searchTimeout = setTimeout(function () {
+                var filtered = MOCK_STORIES.filter(function (s) {
+                    return s.title.toLowerCase().includes(query) ||
+                        s.location_name.toLowerCase().includes(query) ||
+                        s.summary.toLowerCase().includes(query) ||
+                        s.author.toLowerCase().includes(query);
+                });
+
+                if (filtered.length === 0) {
+                    searchResults.innerHTML = '<div class="px-4 py-3 text-sm text-textmuted">No stories found for "' + query + '"</div>';
+                    searchResults.classList.remove("hidden");
+                    return;
+                }
+
+                searchResults.innerHTML = "";
+                filtered.forEach(function (story) {
+                    var item = document.createElement("div");
+                    item.className = "px-4 py-3 hover:bg-background cursor-pointer border-b border-border/30 last:border-0";
+                    item.innerHTML =
+                        '<div class="font-semibold text-sm text-textmain">' + story.title + '</div>' +
+                        '<div class="text-xs text-textmuted mt-0.5">' + story.location_name + ' · ' + story.date_label + '</div>';
+                    item.addEventListener("click", function () {
+                        map.setView([story.latitude, story.longitude], 16);
+                        markers.forEach(function (m) {
+                            if (m.getLatLng().lat === story.latitude && m.getLatLng().lng === story.longitude) {
+                                m.openPopup();
+                            }
+                        });
+                        searchResults.classList.add("hidden");
+                        searchInput.value = story.title;
+                    });
+                    searchResults.appendChild(item);
+                });
+                searchResults.classList.remove("hidden");
+            }, 200);
+        });
+
+        // Close search results when clicking outside
+        document.addEventListener("click", function (e) {
+            if (!document.getElementById("search-container").contains(e.target)) {
+                searchResults.classList.add("hidden");
+            }
+        });
+
+        // ─── Initialize ───
+        // In production, this would be: fetch("/api/stories").then(r => r.json()).then(loadStories)
+        loadStories(MOCK_STORIES);
+        populateSidebar(MOCK_STORIES);
+    </script>
 </body>
+
 </html>

--- a/frontend/map.html
+++ b/frontend/map.html
@@ -163,11 +163,11 @@
                         class="absolute top-full left-0 right-0 mt-1 bg-white border border-border rounded-xl shadow-soft overflow-hidden hidden z-50">
                     </div>
                 </div>
-                <button id="btn-profile" type="button"
+                <a href="profile.html" id="btn-profile"
                     class="inline-flex h-11 w-11 items-center justify-center rounded-full border border-border bg-white text-textmain shadow-sm transition hover:bg-stone-50"
                     aria-label="Open profile">
                     <span class="material-symbols-outlined text-[20px] leading-none">account_circle</span>
-                </button>
+                </a>
             </div>
         </div>
     </header>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7,7 +7,12 @@
     "": {
       "name": "frontend-tests",
       "version": "1.0.0",
+      "dependencies": {
+        "@capacitor/android": "^8.3.0",
+        "@capacitor/core": "^8.3.0"
+      },
       "devDependencies": {
+        "@capacitor/cli": "^8.3.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0"
       }
@@ -43,7 +48,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -509,6 +513,251 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@capacitor/android": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-8.3.0.tgz",
+      "integrity": "sha512-EQy6ByUuKayQBJmMm/e0byJiHavqsQHrvW23BuT2GNVQvenAvipqwaePiJHzrv2PZr7A0T0+se4kgDCeROj0mQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": "^8.3.0"
+      }
+    },
+    "node_modules/@capacitor/cli": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-8.3.0.tgz",
+      "integrity": "sha512-n3QDUimtFNbagoo8kLdjvTz3i3Y4jX1fOjvo6ptUKLzErmuqeamL8kECASoyQvg/OzJisZToGZrgLphBsptJcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ionic/cli-framework-output": "^2.2.8",
+        "@ionic/utils-subprocess": "^3.0.1",
+        "@ionic/utils-terminal": "^2.3.5",
+        "commander": "^12.1.0",
+        "debug": "^4.4.0",
+        "env-paths": "^2.2.0",
+        "fs-extra": "^11.2.0",
+        "kleur": "^4.1.5",
+        "native-run": "^2.0.3",
+        "open": "^8.4.0",
+        "plist": "^3.1.0",
+        "prompts": "^2.4.2",
+        "rimraf": "^6.0.1",
+        "semver": "^7.6.3",
+        "tar": "^7.5.3",
+        "tslib": "^2.8.1",
+        "xml2js": "^0.6.2"
+      },
+      "bin": {
+        "cap": "bin/capacitor",
+        "capacitor": "bin/capacitor"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@capacitor/cli/node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@capacitor/cli/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@capacitor/core": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-8.3.0.tgz",
+      "integrity": "sha512-S4ajn4G/fS3VJj8salxqH/3LO5PPWv1VxGKQ27OCajnDcLJjEg9VXwgMPnlypgkIOqCJ2fmQLtk8GT+BlI9/rw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@ionic/cli-framework-output": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@ionic/cli-framework-output/-/cli-framework-output-2.2.8.tgz",
+      "integrity": "sha512-TshtaFQsovB4NWRBydbNFawql6yul7d5bMiW1WYYf17hd99V6xdDdk3vtF51bw6sLkxON3bDQpWsnUc9/hVo3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ionic/utils-terminal": "2.3.5",
+        "debug": "^4.0.0",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@ionic/utils-array": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-array/-/utils-array-2.1.6.tgz",
+      "integrity": "sha512-0JZ1Zkp3wURnv8oq6Qt7fMPo5MpjbLoUoa9Bu2Q4PJuSDWM8H8gwF3dQO7VTeUj3/0o1IB1wGkFWZZYgUXZMUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.0.0",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@ionic/utils-fs": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-fs/-/utils-fs-3.1.7.tgz",
+      "integrity": "sha512-2EknRvMVfhnyhL1VhFkSLa5gOcycK91VnjfrTB0kbqkTFCOXyXgVLI5whzq7SLrgD9t1aqos3lMMQyVzaQ5gVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/fs-extra": "^8.0.0",
+        "debug": "^4.0.0",
+        "fs-extra": "^9.0.0",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@ionic/utils-fs/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@ionic/utils-fs/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@ionic/utils-object": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-object/-/utils-object-2.1.6.tgz",
+      "integrity": "sha512-vCl7sl6JjBHFw99CuAqHljYJpcE88YaH2ZW4ELiC/Zwxl5tiwn4kbdP/gxi2OT3MQb1vOtgAmSNRtusvgxI8ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.0.0",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@ionic/utils-process": {
+      "version": "2.1.12",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-process/-/utils-process-2.1.12.tgz",
+      "integrity": "sha512-Jqkgyq7zBs/v/J3YvKtQQiIcxfJyplPgECMWgdO0E1fKrrH8EF0QGHNJ9mJCn6PYe2UtHNS8JJf5G21e09DfYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ionic/utils-object": "2.1.6",
+        "@ionic/utils-terminal": "2.3.5",
+        "debug": "^4.0.0",
+        "signal-exit": "^3.0.3",
+        "tree-kill": "^1.2.2",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@ionic/utils-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-stream/-/utils-stream-3.1.7.tgz",
+      "integrity": "sha512-eSELBE7NWNFIHTbTC2jiMvh1ABKGIpGdUIvARsNPMNQhxJB3wpwdiVnoBoTYp+5a6UUIww4Kpg7v6S7iTctH1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.0.0",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@ionic/utils-subprocess": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-subprocess/-/utils-subprocess-3.0.1.tgz",
+      "integrity": "sha512-cT4te3AQQPeIM9WCwIg8ohroJ8TjsYaMb2G4ZEgv9YzeDqHZ4JpeIKqG2SoaA3GmVQ3sOfhPM6Ox9sxphV/d1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ionic/utils-array": "2.1.6",
+        "@ionic/utils-fs": "3.1.7",
+        "@ionic/utils-process": "2.1.12",
+        "@ionic/utils-stream": "3.1.7",
+        "@ionic/utils-terminal": "2.3.5",
+        "cross-spawn": "^7.0.3",
+        "debug": "^4.0.0",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@ionic/utils-terminal": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-terminal/-/utils-terminal-2.3.5.tgz",
+      "integrity": "sha512-3cKScz9Jx2/Pr9ijj1OzGlBDfcmx7OMVBt4+P1uRR0SSW4cm1/y3Mo4OY3lfkuaYifMNBW8Wz6lQHbs1bihr7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/slice-ansi": "^4.0.0",
+        "debug": "^4.0.0",
+        "signal-exit": "^3.0.3",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "tslib": "^2.0.1",
+        "untildify": "^4.0.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -960,6 +1209,16 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/fs-extra": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.5.tgz",
+      "integrity": "sha512-0dzKcwO+S8s2kuF5Z9oUWatQJj5Uq/iqphEtE3GQJVRRYm/tD1LglU2UnXi2A8jLq5umkGouOXOR9y0n613ZwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -1019,6 +1278,13 @@
         "undici-types": "~7.18.0"
       }
     },
+    "node_modules/@types/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-+OpjSaq85gvlZAYINyzKpLeiFkSC4EsC6IIiT6v6TLSU5k5U83fHGj9Lel8oKEXM0HqgrMVCjXPDPVICtxF7EQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -1049,6 +1315,16 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
+      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -1174,12 +1450,32 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -1304,6 +1600,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.13",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.13.tgz",
@@ -1315,6 +1632,29 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/big-integer": {
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "dev": true,
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/bplist-parser": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.3.2.tgz",
+      "integrity": "sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "big-integer": "1.6.x"
+      },
+      "engines": {
+        "node": ">= 5.10.0"
       }
     },
     "node_modules/brace-expansion": {
@@ -1361,7 +1701,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1384,6 +1723,16 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/buffer-from": {
@@ -1475,6 +1824,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/ci-info": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
@@ -1562,6 +1921,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/concat-map": {
@@ -1707,6 +2076,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1773,6 +2152,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/elementtree": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/elementtree/-/elementtree-0.1.7.tgz",
+      "integrity": "sha512-wkgGT6kugeQk/P6VZ/f4T+4HB41BVgNBq5CDIZVbQ02nvTVqAiVTbskxxu3eA/X96lMlfYOwnLQpN2v5E1zDEg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "sax": "1.1.4"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/emittery": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
@@ -1804,6 +2196,16 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/error-ex": {
@@ -2008,6 +2410,16 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -2050,6 +2462,31 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/fs-extra/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/fs.realpath": {
@@ -2381,6 +2818,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/ini": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
+      "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -2402,6 +2849,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -2452,6 +2915,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/isexe": {
@@ -3269,6 +3745,29 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonfile/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -3435,12 +3934,61 @@
         "node": "*"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/native-run": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/native-run/-/native-run-2.0.3.tgz",
+      "integrity": "sha512-U1PllBuzW5d1gfan+88L+Hky2eZx+9gv3Pf6rNBxKbORxi7boHzqiA6QFGSnqMem4j0A9tZ08NMIs5+0m/VS1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ionic/utils-fs": "^3.1.7",
+        "@ionic/utils-terminal": "^2.3.4",
+        "bplist-parser": "^0.3.2",
+        "debug": "^4.3.4",
+        "elementtree": "^0.1.7",
+        "ini": "^4.1.1",
+        "plist": "^3.1.0",
+        "split2": "^4.2.0",
+        "through2": "^4.0.2",
+        "tslib": "^2.6.2",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "native-run": "bin/native-run"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -3519,6 +4067,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/open": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -3573,6 +4139,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
@@ -3643,6 +4216,40 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.3.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.2.tgz",
+      "integrity": "sha512-wgWa6FWQ3QRRJbIjbsldRJZxdxYngT/dO0I5Ynmlnin8qy7tC6xYzbcJjtN4wHLXtkbVwHzk0C+OejVw1XM+DQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3684,6 +4291,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/plist": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
+      "integrity": "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.8",
+        "base64-js": "^1.5.1",
+        "xmlbuilder": "^15.1.1"
+      },
+      "engines": {
+        "node": ">=10.4.0"
       }
     },
     "node_modules/pretty-format": {
@@ -3782,6 +4404,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -3853,12 +4490,117 @@
         "node": ">=10"
       }
     },
+    "node_modules/rimraf": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
+      "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "glob": "^13.0.3",
+        "package-json-from-dist": "^1.0.1"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz",
+      "integrity": "sha512-5f3k2PbGGp+YtKJjOItpg3P99IMD84E4HOvcfleTb5joCHNXYLsR9yWFPOYGgaeMPDubQILTCMdsFb2OMeOjtg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -3930,6 +4672,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -3951,6 +4711,16 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -3969,6 +4739,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-length": {
@@ -4079,6 +4859,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tar": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -4092,6 +4899,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/through2": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "3"
       }
     },
     "node_modules/tmpl": {
@@ -4143,6 +4960,22 @@
         "node": ">=12"
       }
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -4181,6 +5014,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -4224,6 +5067,13 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -4398,6 +5248,40 @@
         "node": ">=12"
       }
     },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xml2js/node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
@@ -4449,6 +5333,17 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -43,6 +43,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1360,6 +1361,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,4466 @@
+{
+  "name": "frontend-tests",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "frontend-tests",
+      "version": "1.0.0",
+      "devDependencies": {
+        "jest": "^29.7.0",
+        "jest-environment-jsdom": "^29.7.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
+      "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+      "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
+      "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/reporters": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^29.7.0",
+        "jest-config": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-resolve-dependencies": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/environment": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@types/node": "*",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/globals": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "babel-plugin-istanbul": "^6.1.1",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^4.0.2"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/graceful-fs": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
+      "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jsdom": {
+      "version": "20.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
+      "integrity": "sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/abab": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
+      "deprecated": "Use your platform's native atob() and btoa() methods instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-globals": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
+      "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.1.0",
+        "acorn-walk": "^8.0.2"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/babel-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/transform": "^29.7.0",
+        "@types/babel__core": "^7.1.14",
+        "babel-plugin-istanbul": "^6.1.1",
+        "babel-preset-jest": "^29.6.3",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.8.0"
+      }
+    },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^5.0.4",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+      "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.1.14",
+        "@types/babel__traverse": "^7.0.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/babel-preset-current-node-syntax": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-preset-jest": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+      "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.13",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.13.tgz",
+      "integrity": "sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001784",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001784.tgz",
+      "integrity": "sha512-WU346nBTklUV9YfUl60fqRbU5ZqyXlqvo1SgigE1OAXK5bFL8LL9q1K7aap3N739l4BvNqnkm3YrGHiY9sfUQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+      "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "prompts": "^2.0.1"
+      },
+      "bin": {
+        "create-jest": "bin/create-jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cssom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssom": "~0.3.6"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cssstyle/node_modules/cssom": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
+      "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abab": "^2.0.6",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dedent": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/domexception": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
+      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.331",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.331.tgz",
+      "integrity": "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bser": "2.1.1"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "import-local": "^3.0.2",
+        "jest-cli": "^29.7.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.0.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^1.0.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.7.0",
+        "pure-rand": "^6.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "create-jest": "^29.7.0",
+        "exit": "^0.1.2",
+        "import-local": "^3.0.2",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz",
+      "integrity": "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/jsdom": "^20.0.0",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jsdom": "^20.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-environment-node": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+      "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-haste-map": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/graceful-fs": "^4.1.3",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.6.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-mock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^2.0.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "^29.6.3",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-leak-detector": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-resolve": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/globals": "^29.7.0",
+        "@jest/source-map": "^29.6.3",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^29.7.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "leven": "^3.1.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.7.0",
+        "string-length": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
+      "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abab": "^2.0.6",
+        "acorn": "^8.8.1",
+        "acorn-globals": "^7.0.0",
+        "cssom": "^0.5.0",
+        "cssstyle": "^2.3.0",
+        "data-urls": "^3.0.2",
+        "decimal.js": "^10.4.2",
+        "domexception": "^4.0.0",
+        "escodegen": "^2.0.0",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.2",
+        "parse5": "^7.1.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.2",
+        "w3c-xmlserializer": "^4.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^2.0.0",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0",
+        "ws": "^8.11.0",
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/makeerror": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve.exports": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tmpl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
+      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/walker": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,12 @@
     "test": "jest"
   },
   "devDependencies": {
+    "@capacitor/cli": "^8.3.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0"
+  },
+  "dependencies": {
+    "@capacitor/android": "^8.3.0",
+    "@capacitor/core": "^8.3.0"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "frontend-tests",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0"
+  }
+}

--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -7,8 +8,11 @@
   <script src="https://cdn.tailwindcss.com?plugins=forms"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Serif:wght@700;800&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet">
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Serif:wght@700;800&display=swap"
+    rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+    rel="stylesheet">
   <script>
     tailwind.config = {
       theme: {
@@ -37,49 +41,62 @@
   </script>
   <style>
     .material-symbols-outlined {
-        font-variation-settings: "FILL" 0, "wght" 400, "GRAD" 0, "opsz" 24;
+      font-variation-settings: "FILL" 0, "wght" 400, "GRAD" 0, "opsz" 24;
     }
   </style>
 </head>
+
 <body class="bg-background text-textmain font-body min-h-screen">
-  
+
   <!-- Top Navigation Bar -->
   <header class="fixed top-0 left-0 right-0 z-[1000] bg-[#f8f3ea]/95 backdrop-blur-sm border-b border-border/30">
     <div class="flex justify-between items-center w-full px-8 py-4 max-w-screen-2xl mx-auto">
-        <div class="flex items-center gap-8">
-            <h1 class="text-2xl font-bold font-headline text-textmain tracking-tight">Local History Map</h1>
-            <nav class="hidden md:flex items-center gap-6">
-                <a class="text-textmain font-medium hover:text-tertiary transition-colors" href="map.html">Map</a>
-                <a class="text-textmain font-medium hover:text-tertiary transition-colors" href="story-detail.html">Archive</a>
-                <a class="text-textmain font-medium hover:text-tertiary transition-colors" href="story-create.html">Create Story</a>
-                <a class="text-textmain font-medium hover:text-tertiary transition-colors" href="index.html">Login</a>
-            </nav>
-        </div>
-        <div class="flex items-center gap-3 sm:gap-4">
-            <a href="profile.html" class="inline-flex h-11 w-11 items-center justify-center rounded-full border border-primary bg-primary/10 text-primary shadow-sm transition hover:bg-primary/20" aria-label="Open profile">
-                <span class="material-symbols-outlined text-[20px] leading-none">account_circle</span>
-            </a>
-        </div>
+      <div class="flex items-center gap-8">
+        <h1 class="text-2xl font-bold font-headline text-textmain tracking-tight">Local History Map</h1>
+        <nav class="hidden md:flex items-center gap-6">
+          <a class="text-textmain font-medium hover:text-tertiary transition-colors" href="map.html">Map</a>
+          <a class="text-textmain font-medium hover:text-tertiary transition-colors"
+            href="story-detail.html">Archive</a>
+          <a class="text-textmain font-medium hover:text-tertiary transition-colors" href="story-create.html">Create
+            Story</a>
+          <a class="text-textmain font-medium hover:text-tertiary transition-colors" href="index.html">Login</a>
+        </nav>
+      </div>
+      <div class="flex items-center gap-3 sm:gap-4">
+        <a href="profile.html"
+          class="inline-flex h-11 w-11 items-center justify-center rounded-full border border-primary bg-primary/10 text-primary shadow-sm transition hover:bg-primary/20"
+          aria-label="Open profile">
+          <span class="material-symbols-outlined text-[20px] leading-none">account_circle</span>
+        </a>
+      </div>
     </div>
   </header>
 
   <main class="w-full px-4 pt-32 pb-10 lg:px-8 xl:px-10 2xl:px-14 max-w-7xl mx-auto">
     <!-- Profile Header Section -->
-    <header class="mb-12 flex flex-col gap-6 md:flex-row md:items-center bg-surface p-8 rounded-3xl border border-border shadow-soft">
-      <div class="w-24 h-24 md:w-32 md:h-32 bg-primary/20 rounded-full flex items-center justify-center border-4 border-white shadow-sm shrink-0">
-        <span class="material-symbols-outlined text-5xl md:text-6xl text-primary" style="font-variation-settings: 'FILL' 1;">person</span>
+    <header
+      class="mb-12 flex flex-col gap-6 md:flex-row md:items-center bg-surface p-8 rounded-3xl border border-border shadow-soft">
+      <div
+        class="w-24 h-24 md:w-32 md:h-32 bg-primary/20 rounded-full flex items-center justify-center border-4 border-white shadow-sm shrink-0">
+        <span class="material-symbols-outlined text-5xl md:text-6xl text-primary"
+          style="font-variation-settings: 'FILL' 1;">person</span>
       </div>
       <div class="flex-1">
-        <h1 id="profile-name" class="font-headline text-3xl md:text-4xl font-extrabold leading-tight text-textmain">Loading...</h1>
-        <p class="mt-2 text-textmuted text-base">Historian and native of Galata. Passionate about preserving the auditory and visual memories of old Istanbul.</p>
+        <h1 id="profile-name" class="font-headline text-3xl md:text-4xl font-extrabold leading-tight text-textmain">
+          Loading...</h1>
+        <p class="mt-2 text-textmuted text-base">Historian and native of Galata. Passionate about preserving the
+          auditory and visual memories of old Istanbul.</p>
         <div class="mt-4 flex flex-wrap gap-4 text-sm font-medium text-textmuted">
-            <span class="flex items-center gap-1"><span class="material-symbols-outlined text-[18px]">location_on</span> Istanbul, Turkey</span>
-            <span id="profile-joined" class="flex items-center gap-1"><span class="material-symbols-outlined text-[18px]">calendar_month</span> Joined...</span>
+          <span class="flex items-center gap-1"><span class="material-symbols-outlined text-[18px]">location_on</span>
+            Istanbul, Turkey</span>
+          <span id="profile-joined" class="flex items-center gap-1"><span
+              class="material-symbols-outlined text-[18px]">calendar_month</span> Joined...</span>
         </div>
       </div>
       <div class="flex gap-3 md:flex-col lg:flex-row">
-        <a href="edit-profile.html" class="px-5 py-2.5 rounded-xl border border-border bg-white text-sm font-semibold text-textmain transition hover:bg-stone-50 shadow-sm flex items-center gap-2">
-            <span class="material-symbols-outlined text-[18px]">edit</span> Edit Profile
+        <a href="edit-profile.html"
+          class="px-5 py-2.5 rounded-xl border border-border bg-white text-sm font-semibold text-textmain transition hover:bg-stone-50 shadow-sm flex items-center gap-2">
+          <span class="material-symbols-outlined text-[18px]">edit</span> Edit Profile
         </a>
       </div>
     </header>
@@ -90,52 +107,50 @@
       <aside class="space-y-6">
         <!-- Stats Card -->
         <div class="bg-surface rounded-2xl p-6 border border-border shadow-sm">
-            <h2 class="font-headline text-lg font-bold mb-4">Activity</h2>
-            <div class="grid grid-cols-2 gap-4">
-                <div class="text-center p-4 bg-background rounded-xl border border-border/50">
-                    <div class="text-2xl font-bold text-primary">0</div>
-                    <div class="text-xs text-textmuted font-semibold uppercase tracking-wider mt-1">Stories</div>
-                </div>
-                <div class="text-center p-4 bg-background rounded-xl border border-border/50">
-                    <div class="text-2xl font-bold text-tertiary">0</div>
-                    <div class="text-xs text-textmuted font-semibold uppercase tracking-wider mt-1">Comments</div>
-                </div>
-                <div class="text-center p-4 bg-background rounded-xl border border-border/50">
-                    <div class="text-2xl font-bold text-emerald-600">0</div>
-                    <div class="text-xs text-textmuted font-semibold uppercase tracking-wider mt-1">Likes</div>
-                </div>
-                <div class="text-center p-4 bg-background rounded-xl border border-border/50">
-                    <div class="text-2xl font-bold text-orange-600">0</div>
-                    <div class="text-xs text-textmuted font-semibold uppercase tracking-wider mt-1">Saved</div>
-                </div>
+          <h2 class="font-headline text-lg font-bold mb-4">Activity</h2>
+          <div class="grid grid-cols-2 gap-4">
+            <div class="text-center p-4 bg-background rounded-xl border border-border/50">
+              <div id="stat-stories" class="text-2xl font-bold text-primary">0</div>
+              <div class="text-xs text-textmuted font-semibold uppercase tracking-wider mt-1">Stories</div>
             </div>
+            <div class="text-center p-4 bg-background rounded-xl border border-border/50">
+              <div class="text-2xl font-bold text-tertiary">0</div>
+              <div class="text-xs text-textmuted font-semibold uppercase tracking-wider mt-1">Comments</div>
+            </div>
+            <div class="text-center p-4 bg-background rounded-xl border border-border/50">
+              <div class="text-2xl font-bold text-emerald-600">0</div>
+              <div class="text-xs text-textmuted font-semibold uppercase tracking-wider mt-1">Likes</div>
+            </div>
+            <div class="text-center p-4 bg-background rounded-xl border border-border/50">
+              <div class="text-2xl font-bold text-orange-600">0</div>
+              <div class="text-xs text-textmuted font-semibold uppercase tracking-wider mt-1">Saved</div>
+            </div>
+          </div>
         </div>
 
         <!-- Badges Card -->
         <div class="bg-surface rounded-2xl p-6 border border-border shadow-sm">
-            <h2 class="font-headline text-lg font-bold mb-4">Badges</h2>
-            <div class="flex flex-wrap gap-3">
-                <p class="text-sm text-textmuted italic">No badges earned yet.</p>
-            </div>
+          <h2 class="font-headline text-lg font-bold mb-4">Badges</h2>
+          <div class="flex flex-wrap gap-3">
+            <p class="text-sm text-textmuted italic">No badges earned yet.</p>
+          </div>
         </div>
       </aside>
 
       <!-- Right Column: User's Stories -->
       <section class="lg:col-span-2">
         <div class="flex justify-between items-center mb-6">
-            <h2 class="font-headline text-2xl font-bold text-textmain">My Published Stories</h2>
-            <a href="story-create.html" class="text-sm font-semibold text-primary hover:text-primary-light transition-colors flex items-center gap-1">
-                <span class="material-symbols-outlined text-[18px]">add</span> New Story
-            </a>
+          <h2 class="font-headline text-2xl font-bold text-textmain">My Published Stories</h2>
+          <a href="story-create.html"
+            class="text-sm font-semibold text-primary hover:text-primary-light transition-colors flex items-center gap-1">
+            <span class="material-symbols-outlined text-[18px]">add</span> New Story
+          </a>
         </div>
 
-        <div class="space-y-4">
-            <div class="bg-surface rounded-2xl p-8 border border-border flex flex-col items-center justify-center text-center shadow-sm">
-                <span class="material-symbols-outlined text-4xl text-stone-300 mb-3">auto_stories</span>
-                <p class="text-textmain font-medium">You haven't published any stories yet.</p>
-                <p class="text-sm text-textmuted mt-1">Start sharing your historical memories with the community.</p>
-                <a href="story-create.html" class="mt-4 px-4 py-2 rounded-xl bg-primary text-white text-sm font-semibold hover:opacity-95 transition">Create your first story</a>
-            </div>
+        <div id="profile-stories-container" class="space-y-4">
+          <div class="text-center p-8">
+            <p class="text-textmuted italic">Loading your stories...</p>
+          </div>
         </div>
       </section>
     </div>
@@ -145,4 +160,5 @@
   <script src="auth.js"></script>
   <script src="profile.js"></script>
 </body>
+
 </html>

--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -1,0 +1,190 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Local History Map - Profile</title>
+  <script src="https://cdn.tailwindcss.com?plugins=forms"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Serif:wght@700;800&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet">
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            background: "#fef9f0",
+            surface: "#ffffff",
+            primary: "#775a19",
+            "primary-light": "#c5a059",
+            secondary: "#506169",
+            tertiary: "#35618f",
+            border: "#e7e2d9",
+            textmain: "#1d1c16",
+            textmuted: "#5f584c"
+          },
+          fontFamily: {
+            body: ["Inter", "sans-serif"],
+            headline: ["Noto Serif", "serif"]
+          },
+          boxShadow: {
+            soft: "0 20px 50px rgba(0,0,0,0.08)"
+          }
+        }
+      }
+    };
+  </script>
+  <style>
+    .material-symbols-outlined {
+        font-variation-settings: "FILL" 0, "wght" 400, "GRAD" 0, "opsz" 24;
+    }
+  </style>
+</head>
+<body class="bg-background text-textmain font-body min-h-screen">
+  
+  <!-- Top Navigation Bar -->
+  <header class="fixed top-0 left-0 right-0 z-[1000] bg-[#f8f3ea]/95 backdrop-blur-sm border-b border-border/30">
+    <div class="flex justify-between items-center w-full px-8 py-4 max-w-screen-2xl mx-auto">
+        <div class="flex items-center gap-8">
+            <h1 class="text-2xl font-bold font-headline text-textmain tracking-tight">Local History Map</h1>
+            <nav class="hidden md:flex items-center gap-6">
+                <a class="text-textmain font-medium hover:text-tertiary transition-colors" href="map.html">Map</a>
+                <a class="text-textmain font-medium hover:text-tertiary transition-colors" href="story-detail.html">Archive</a>
+                <a class="text-textmain font-medium hover:text-tertiary transition-colors" href="story-create.html">Create Story</a>
+                <a class="text-textmain font-medium hover:text-tertiary transition-colors" href="index.html">Login</a>
+            </nav>
+        </div>
+        <div class="flex items-center gap-3 sm:gap-4">
+            <a href="profile.html" class="inline-flex h-11 w-11 items-center justify-center rounded-full border border-primary bg-primary/10 text-primary shadow-sm transition hover:bg-primary/20" aria-label="Open profile">
+                <span class="material-symbols-outlined text-[20px] leading-none">account_circle</span>
+            </a>
+        </div>
+    </div>
+  </header>
+
+  <main class="w-full px-4 pt-32 pb-10 lg:px-8 xl:px-10 2xl:px-14 max-w-7xl mx-auto">
+    <!-- Profile Header Section -->
+    <header class="mb-12 flex flex-col gap-6 md:flex-row md:items-center bg-surface p-8 rounded-3xl border border-border shadow-soft">
+      <div class="w-24 h-24 md:w-32 md:h-32 bg-primary/20 rounded-full flex items-center justify-center border-4 border-white shadow-sm shrink-0">
+        <span class="material-symbols-outlined text-5xl md:text-6xl text-primary" style="font-variation-settings: 'FILL' 1;">person</span>
+      </div>
+      <div class="flex-1">
+        <h1 class="font-headline text-3xl md:text-4xl font-extrabold leading-tight text-textmain">Mehmet Arif</h1>
+        <p class="mt-2 text-textmuted text-base">Historian and native of Galata. Passionate about preserving the auditory and visual memories of old Istanbul.</p>
+        <div class="mt-4 flex flex-wrap gap-4 text-sm font-medium text-textmuted">
+            <span class="flex items-center gap-1"><span class="material-symbols-outlined text-[18px]">location_on</span> Istanbul, Turkey</span>
+            <span class="flex items-center gap-1"><span class="material-symbols-outlined text-[18px]">calendar_month</span> Joined March 2026</span>
+        </div>
+      </div>
+      <div class="flex gap-3 md:flex-col lg:flex-row">
+        <a href="edit-profile.html" class="px-5 py-2.5 rounded-xl border border-border bg-white text-sm font-semibold text-textmain transition hover:bg-stone-50 shadow-sm flex items-center gap-2">
+            <span class="material-symbols-outlined text-[18px]">edit</span> Edit Profile
+        </a>
+      </div>
+    </header>
+
+    <!-- Content Sections -->
+    <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
+      <!-- Left Column: User Stats & Info -->
+      <aside class="space-y-6">
+        <!-- Stats Card -->
+        <div class="bg-surface rounded-2xl p-6 border border-border shadow-sm">
+            <h2 class="font-headline text-lg font-bold mb-4">Activity</h2>
+            <div class="grid grid-cols-2 gap-4">
+                <div class="text-center p-4 bg-background rounded-xl border border-border/50">
+                    <div class="text-2xl font-bold text-primary">12</div>
+                    <div class="text-xs text-textmuted font-semibold uppercase tracking-wider mt-1">Stories</div>
+                </div>
+                <div class="text-center p-4 bg-background rounded-xl border border-border/50">
+                    <div class="text-2xl font-bold text-tertiary">48</div>
+                    <div class="text-xs text-textmuted font-semibold uppercase tracking-wider mt-1">Comments</div>
+                </div>
+                <div class="text-center p-4 bg-background rounded-xl border border-border/50">
+                    <div class="text-2xl font-bold text-emerald-600">340</div>
+                    <div class="text-xs text-textmuted font-semibold uppercase tracking-wider mt-1">Likes</div>
+                </div>
+                <div class="text-center p-4 bg-background rounded-xl border border-border/50">
+                    <div class="text-2xl font-bold text-orange-600">5</div>
+                    <div class="text-xs text-textmuted font-semibold uppercase tracking-wider mt-1">Saved</div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Badges Card -->
+        <div class="bg-surface rounded-2xl p-6 border border-border shadow-sm">
+            <h2 class="font-headline text-lg font-bold mb-4">Badges</h2>
+            <div class="flex flex-wrap gap-3">
+                <div class="w-12 h-12 rounded-full bg-yellow-100 flex items-center justify-center border border-yellow-200 text-yellow-600" title="Prolific Storyteller">
+                    <span class="material-symbols-outlined" style="font-variation-settings: 'FILL' 1;">military_tech</span>
+                </div>
+                <div class="w-12 h-12 rounded-full bg-blue-100 flex items-center justify-center border border-blue-200 text-blue-600" title="Community Guide">
+                    <span class="material-symbols-outlined" style="font-variation-settings: 'FILL' 1;">explore</span>
+                </div>
+                <div class="w-12 h-12 rounded-full bg-green-100 flex items-center justify-center border border-green-200 text-green-600" title="Historian">
+                    <span class="material-symbols-outlined" style="font-variation-settings: 'FILL' 1;">history_edu</span>
+                </div>
+            </div>
+        </div>
+      </aside>
+
+      <!-- Right Column: User's Stories -->
+      <section class="lg:col-span-2">
+        <div class="flex justify-between items-center mb-6">
+            <h2 class="font-headline text-2xl font-bold text-textmain">My Published Stories</h2>
+            <a href="story-create.html" class="text-sm font-semibold text-primary hover:text-primary-light transition-colors flex items-center gap-1">
+                <span class="material-symbols-outlined text-[18px]">add</span> New Story
+            </a>
+        </div>
+
+        <div class="space-y-4">
+            <!-- Mock Story Item 1 -->
+            <article class="bg-surface rounded-2xl p-5 border border-border flex flex-col sm:flex-row gap-5 shadow-sm hover:shadow-soft transition-shadow">
+                <div class="w-full sm:w-32 h-32 bg-stone-100 rounded-xl flex items-center justify-center border border-border/50 shrink-0">
+                    <span class="material-symbols-outlined text-4xl text-stone-300">image</span>
+                </div>
+                <div class="flex-1 flex flex-col">
+                    <div class="flex justify-between items-start mb-1">
+                        <span class="text-xs font-bold text-tertiary uppercase tracking-widest">1970s Era</span>
+                        <div class="flex gap-2 text-textmuted">
+                            <button class="hover:text-primary"><span class="material-symbols-outlined text-[18px]">edit</span></button>
+                            <button class="hover:text-red-500"><span class="material-symbols-outlined text-[18px]">delete</span></button>
+                        </div>
+                    </div>
+                    <h3 class="font-headline text-lg font-bold text-textmain leading-tight mb-2">My Father's First Shop in Galata</h3>
+                    <p class="text-sm text-textmuted line-clamp-2 mb-3">The smell of fresh timber and roasted coffee always brings me back to that narrow cobblestone alley where my father started his first workshop...</p>
+                    <div class="mt-auto flex items-center justify-between text-xs font-medium text-textmuted">
+                        <span class="flex items-center gap-1"><span class="material-symbols-outlined text-[16px]">pin_drop</span> Galata, Istanbul</span>
+                        <a href="story-detail.html?id=1" class="text-primary font-bold hover:underline">Read Story →</a>
+                    </div>
+                </div>
+            </article>
+
+            <!-- Mock Story Item 2 -->
+             <article class="bg-surface rounded-2xl p-5 border border-border flex flex-col sm:flex-row gap-5 shadow-sm hover:shadow-soft transition-shadow">
+                <div class="w-full sm:w-32 h-32 bg-stone-100 rounded-xl flex items-center justify-center border border-border/50 shrink-0">
+                    <span class="material-symbols-outlined text-4xl text-stone-300">image</span>
+                </div>
+                <div class="flex-1 flex flex-col">
+                    <div class="flex justify-between items-start mb-1">
+                        <span class="text-xs font-bold text-tertiary uppercase tracking-widest">1985</span>
+                        <div class="flex gap-2 text-textmuted">
+                            <button class="hover:text-primary"><span class="material-symbols-outlined text-[18px]">edit</span></button>
+                            <button class="hover:text-red-500"><span class="material-symbols-outlined text-[18px]">delete</span></button>
+                        </div>
+                    </div>
+                    <h3 class="font-headline text-lg font-bold text-textmain leading-tight mb-2">The Winter of 85</h3>
+                    <p class="text-sm text-textmuted line-clamp-2 mb-3">When the Bosphorus brought chunks of ice to the shores, the whole city stood still. I remember walking across the bridge shivering but amazed...</p>
+                    <div class="mt-auto flex items-center justify-between text-xs font-medium text-textmuted">
+                        <span class="flex items-center gap-1"><span class="material-symbols-outlined text-[16px]">pin_drop</span> Eminönü, Istanbul</span>
+                        <a href="story-detail.html?id=12" class="text-primary font-bold hover:underline">Read Story →</a>
+                    </div>
+                </div>
+            </article>
+        </div>
+      </section>
+    </div>
+  </main>
+
+</body>
+</html>

--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -70,11 +70,11 @@
         <span class="material-symbols-outlined text-5xl md:text-6xl text-primary" style="font-variation-settings: 'FILL' 1;">person</span>
       </div>
       <div class="flex-1">
-        <h1 class="font-headline text-3xl md:text-4xl font-extrabold leading-tight text-textmain">Mehmet Arif</h1>
+        <h1 id="profile-name" class="font-headline text-3xl md:text-4xl font-extrabold leading-tight text-textmain">Loading...</h1>
         <p class="mt-2 text-textmuted text-base">Historian and native of Galata. Passionate about preserving the auditory and visual memories of old Istanbul.</p>
         <div class="mt-4 flex flex-wrap gap-4 text-sm font-medium text-textmuted">
             <span class="flex items-center gap-1"><span class="material-symbols-outlined text-[18px]">location_on</span> Istanbul, Turkey</span>
-            <span class="flex items-center gap-1"><span class="material-symbols-outlined text-[18px]">calendar_month</span> Joined March 2026</span>
+            <span id="profile-joined" class="flex items-center gap-1"><span class="material-symbols-outlined text-[18px]">calendar_month</span> Joined...</span>
         </div>
       </div>
       <div class="flex gap-3 md:flex-col lg:flex-row">
@@ -186,5 +186,8 @@
     </div>
   </main>
 
+  <script src="config.js"></script>
+  <script src="auth.js"></script>
+  <script src="profile.js"></script>
 </body>
 </html>

--- a/frontend/profile.js
+++ b/frontend/profile.js
@@ -8,19 +8,76 @@ async function loadProfile() {
             throw new Error("Failed to load profile");
         }
         var data = await res.json();
-        
+
         var nameEl = document.getElementById("profile-name");
         var joinedEl = document.getElementById("profile-joined");
-        
+
         if (nameEl) nameEl.textContent = data.display_name || data.username;
         if (joinedEl && data.created_at) {
             var date = new Date(data.created_at);
             var options = { month: 'long', year: 'numeric' };
             joinedEl.innerHTML = '<span class="material-symbols-outlined text-[18px]">calendar_month</span> Joined ' + date.toLocaleDateString('en-US', options);
         }
-        
-    } catch(err) {
+        await loadUserStories(data.username);
+    } catch (err) {
         console.error("Error loading profile:", err);
+    }
+}
+
+async function loadUserStories(username) {
+    const container = document.getElementById("profile-stories-container");
+    if (!container) return;
+
+    try {
+        // Tüm hikayeleri çek
+        const res = await authFetch(API_BASE + "/stories");
+        if (!res.ok) throw new Error("Failed to fetch stories");
+
+        const data = await res.json();
+
+        // Sadece bu kullanıcıya ait olanları filtrele
+        const myStories = (data.stories || []).filter(s => s.author === username);
+
+        // Update the Stories Activity Counter
+        const statStoriesEl = document.getElementById("stat-stories");
+        if (statStoriesEl) statStoriesEl.textContent = myStories.length;
+
+        // EĞER HİKAYE YOKSA: Senin orijinal güzel tasarımını göster
+        if (myStories.length === 0) {
+            container.innerHTML = `
+                <div class="bg-surface rounded-2xl p-8 border border-border flex flex-col items-center justify-center text-center shadow-sm">
+                    <span class="material-symbols-outlined text-4xl text-stone-300 mb-3">auto_stories</span>
+                    <p class="text-textmain font-medium">You haven't published any stories yet.</p>
+                    <p class="text-sm text-textmuted mt-1">Start sharing your historical memories with the community.</p>
+                    <a href="story-create.html" class="mt-4 px-4 py-2 rounded-xl bg-primary text-white text-sm font-semibold hover:opacity-95 transition">Create your first story</a>
+                </div>
+            `;
+            return;
+        }
+
+        // EĞER HİKAYE VARSA: Hikaye kartlarını oluştur ve ekrana bas
+        container.innerHTML = myStories.map(story => `
+            <article class="bg-surface rounded-2xl p-6 border border-border shadow-sm hover:shadow-md transition-shadow">
+                <div class="flex justify-between items-start mb-2">
+                    <h3 class="font-headline text-xl font-bold text-textmain">${story.title}</h3>
+                    <span class="text-xs font-medium px-2 py-1 bg-background rounded-full border border-border">
+                        ${new Date(story.created_at || Date.now()).toLocaleDateString()}
+                    </span>
+                </div>
+                <p class="text-textmuted text-sm line-clamp-2 mb-4">${story.content}</p>
+                <div class="flex items-center justify-between text-xs text-textmuted">
+                    <span class="flex items-center gap-1">
+                        <span class="material-symbols-outlined text-sm">location_on</span> 
+                        ${story.location_name || 'Galata, Istanbul'}
+                    </span>
+                    <a href="story-detail.html?id=${story.id}" class="text-primary font-semibold hover:underline">Read more</a>
+                </div>
+            </article>
+        `).join('');
+
+    } catch (err) {
+        console.error("Error loading user stories:", err);
+        container.innerHTML = `<p class="text-red-500 text-center p-4">Error loading stories. Please try again.</p>`;
     }
 }
 

--- a/frontend/profile.js
+++ b/frontend/profile.js
@@ -1,0 +1,35 @@
+async function loadProfile() {
+    if (typeof requireAuth === "function" && !requireAuth()) return;
+
+    try {
+        var res = await authFetch(API_BASE + "/auth/me");
+        if (!res.ok) {
+            if (res.status === 401 && typeof logout === "function") logout();
+            throw new Error("Failed to load profile");
+        }
+        var data = await res.json();
+        
+        var nameEl = document.getElementById("profile-name");
+        var joinedEl = document.getElementById("profile-joined");
+        
+        if (nameEl) nameEl.textContent = data.display_name || data.username;
+        if (joinedEl && data.created_at) {
+            var date = new Date(data.created_at);
+            var options = { month: 'long', year: 'numeric' };
+            joinedEl.innerHTML = '<span class="material-symbols-outlined text-[18px]">calendar_month</span> Joined ' + date.toLocaleDateString('en-US', options);
+        }
+        
+    } catch(err) {
+        console.error("Error loading profile:", err);
+    }
+}
+
+if (typeof document !== "undefined") {
+    document.addEventListener("DOMContentLoaded", loadProfile);
+}
+
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = {
+        loadProfile: loadProfile
+    };
+}

--- a/frontend/profile.test.js
+++ b/frontend/profile.test.js
@@ -1,0 +1,60 @@
+global.API_BASE = "http://localhost";
+global.requireAuth = jest.fn();
+global.authFetch = jest.fn();
+global.logout = jest.fn();
+
+const { loadProfile } = require("./profile");
+
+describe("profile page unit tests", () => {
+    beforeEach(() => {
+        document.body.innerHTML = "";
+        global.requireAuth.mockReset().mockReturnValue(true);
+        global.authFetch.mockReset();
+        global.logout.mockReset();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test("loadProfile returns early if not authenticated", async () => {
+        global.requireAuth.mockReturnValue(false);
+        await loadProfile();
+        expect(global.authFetch).not.toHaveBeenCalled();
+    });
+
+    test("loadProfile calls logout on 401 response", async () => {
+        global.authFetch.mockResolvedValueOnce({
+            ok: false,
+            status: 401
+        });
+        
+        // suppress console.error for clean test output
+        const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        await loadProfile();
+        expect(global.logout).toHaveBeenCalledTimes(1);
+        
+        consoleSpy.mockRestore();
+    });
+
+    test("loadProfile populates DOM elements on success", async () => {
+        document.body.innerHTML = `
+            <h1 id="profile-name"></h1>
+            <span id="profile-joined"></span>
+        `;
+        
+        global.authFetch.mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve({ 
+                display_name: "Test User",
+                created_at: "2026-04-07T00:00:00Z"
+            })
+        });
+
+        await loadProfile();
+
+        expect(document.getElementById("profile-name").textContent).toBe("Test User");
+        expect(document.getElementById("profile-joined").innerHTML).toContain("Joined ");
+    });
+});

--- a/frontend/register.html
+++ b/frontend/register.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -7,7 +8,9 @@
     <script src="https://cdn.tailwindcss.com?plugins=forms"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Serif:wght@700;800&display=swap" rel="stylesheet">
+    <link
+        href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Serif:wght@700;800&display=swap"
+        rel="stylesheet">
     <script>
         tailwind.config = {
             theme: {
@@ -37,265 +40,253 @@
     <style>
         body {
             background:
-                    linear-gradient(rgba(254, 249, 240, 0.88), rgba(254, 249, 240, 0.88)),
-                    url("https://images.unsplash.com/photo-1512453979798-5ea266f8880c?auto=format&fit=crop&w=1600&q=80");
+                linear-gradient(rgba(254, 249, 240, 0.88), rgba(254, 249, 240, 0.88)),
+                url("https://images.unsplash.com/photo-1512453979798-5ea266f8880c?auto=format&fit=crop&w=1600&q=80");
             background-size: cover;
             background-position: center;
             background-attachment: fixed;
         }
     </style>
 </head>
+
 <body class="font-body text-textmain min-h-screen">
-<div class="min-h-screen flex items-center justify-center px-6 py-10">
-    <div class="w-full max-w-6xl grid lg:grid-cols-2 bg-white/70 backdrop-blur-md rounded-3xl overflow-hidden shadow-soft border border-white/50">
+    <div class="min-h-screen flex items-center justify-center px-6 py-10">
+        <div
+            class="w-full max-w-6xl grid lg:grid-cols-2 bg-white/70 backdrop-blur-md rounded-3xl overflow-hidden shadow-soft border border-white/50">
 
-        <!-- Left panel -->
-        <section class="hidden lg:flex flex-col justify-between p-12 bg-[rgba(119,90,25,0.08)]">
-            <div>
-                <div class="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-white/80 text-primary text-sm font-semibold border border-border">
-                    <span>Local History Map</span>
+            <!-- Left panel -->
+            <section class="hidden lg:flex flex-col justify-between p-12 bg-[rgba(119,90,25,0.08)]">
+                <div>
+                    <div
+                        class="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-white/80 text-primary text-sm font-semibold border border-border">
+                        <span>Local History Map</span>
+                    </div>
+
+                    <h1 class="mt-8 font-headline text-5xl leading-tight font-extrabold text-textmain">
+                        Join and share the stories behind every street.
+                    </h1>
+
+                    <p class="mt-6 text-lg leading-8 text-textmuted max-w-xl">
+                        Create an account to contribute your own memories, bookmark favorite stories, and become part of
+                        a community preserving local history.
+                    </p>
                 </div>
 
-                <h1 class="mt-8 font-headline text-5xl leading-tight font-extrabold text-textmain">
-                    Join and share the stories behind every street.
-                </h1>
-
-                <p class="mt-6 text-lg leading-8 text-textmuted max-w-xl">
-                    Create an account to contribute your own memories, bookmark favorite stories, and become part of a community preserving local history.
-                </p>
-            </div>
-
-            <div class="grid sm:grid-cols-3 gap-4 mt-10">
-                <div class="bg-white/80 rounded-2xl p-4 border border-border">
-                    <p class="text-2xl font-bold text-primary">500+</p>
-                    <p class="mt-1 text-sm text-textmuted">Stories shared by locals</p>
+                <div class="grid sm:grid-cols-3 gap-4 mt-10">
+                    <div class="bg-white/80 rounded-2xl p-4 border border-border">
+                        <p class="text-2xl font-bold text-primary">500+</p>
+                        <p class="mt-1 text-sm text-textmuted">Stories shared by locals</p>
+                    </div>
+                    <div class="bg-white/80 rounded-2xl p-4 border border-border">
+                        <p class="text-2xl font-bold text-primary">120+</p>
+                        <p class="mt-1 text-sm text-textmuted">Neighborhoods covered</p>
+                    </div>
+                    <div class="bg-white/80 rounded-2xl p-4 border border-border">
+                        <p class="text-2xl font-bold text-primary">Free</p>
+                        <p class="mt-1 text-sm text-textmuted">Always open to everyone</p>
+                    </div>
                 </div>
-                <div class="bg-white/80 rounded-2xl p-4 border border-border">
-                    <p class="text-2xl font-bold text-primary">120+</p>
-                    <p class="mt-1 text-sm text-textmuted">Neighborhoods covered</p>
-                </div>
-                <div class="bg-white/80 rounded-2xl p-4 border border-border">
-                    <p class="text-2xl font-bold text-primary">Free</p>
-                    <p class="mt-1 text-sm text-textmuted">Always open to everyone</p>
-                </div>
-            </div>
-        </section>
+            </section>
 
-        <!-- Right panel - Registration form -->
-        <section class="flex items-center justify-center p-8 sm:p-12 bg-white/75">
-            <div class="w-full max-w-md">
-                <div class="lg:hidden mb-8 text-center">
-                    <h1 class="font-headline text-3xl font-extrabold text-textmain">Local History Map</h1>
-                    <p class="mt-2 text-sm text-textmuted">Create an account to start exploring.</p>
-                </div>
+            <!-- Right panel - Registration form -->
+            <section class="flex items-center justify-center p-8 sm:p-12 bg-white/75">
+                <div class="w-full max-w-md">
+                    <div class="lg:hidden mb-8 text-center">
+                        <h1 class="font-headline text-3xl font-extrabold text-textmain">Local History Map</h1>
+                        <p class="mt-2 text-sm text-textmuted">Create an account to start exploring.</p>
+                    </div>
 
-                <div class="mb-8">
-                    <h2 class="text-3xl font-bold text-textmain">Create your account</h2>
-                    <p class="mt-2 text-textmuted">Start preserving and discovering local stories.</p>
-                </div>
+                    <div class="mb-8">
+                        <h2 class="text-3xl font-bold text-textmain">Create your account</h2>
+                        <p class="mt-2 text-textmuted">Start preserving and discovering local stories.</p>
+                    </div>
 
-                <!-- Error message area -->
-                <div id="error-message" class="hidden mb-4 p-3 rounded-xl bg-red-50 border border-red-200 text-red-700 text-sm"></div>
+                    <!-- Error message area -->
+                    <div id="error-message"
+                        class="hidden mb-4 p-3 rounded-xl bg-red-50 border border-red-200 text-red-700 text-sm"></div>
 
-                <!-- Success message area -->
-                <div id="success-message" class="hidden mb-4 p-3 rounded-xl bg-green-50 border border-green-200 text-green-700 text-sm"></div>
+                    <!-- Success message area -->
+                    <div id="success-message"
+                        class="hidden mb-4 p-3 rounded-xl bg-green-50 border border-green-200 text-green-700 text-sm">
+                    </div>
 
-                <form id="register-form" class="space-y-5">
-                    <div>
-                        <label for="username" class="block text-sm font-semibold mb-2 text-textmain">Username</label>
-                        <input
-                                id="username"
-                                type="text"
-                                placeholder="Choose a username"
-                                minlength="3"
+                    <form id="register-form" class="space-y-5">
+                        <div>
+                            <label for="username"
+                                class="block text-sm font-semibold mb-2 text-textmain">Username</label>
+                            <input id="username" type="text" placeholder="Choose a username" minlength="3"
                                 maxlength="50"
                                 class="w-full rounded-xl border border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary"
-                                required
-                        />
-                    </div>
+                                required />
+                        </div>
 
-                    <div>
-                        <label for="email" class="block text-sm font-semibold mb-2 text-textmain">Email</label>
-                        <input
-                                id="email"
-                                type="email"
-                                placeholder="you@example.com"
+                        <div>
+                            <label for="email" class="block text-sm font-semibold mb-2 text-textmain">Email</label>
+                            <input id="email" type="email" placeholder="you@example.com"
                                 class="w-full rounded-xl border border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary"
-                                required
-                        />
-                    </div>
+                                required />
+                        </div>
 
-                    <div>
-                        <label for="display-name" class="block text-sm font-semibold mb-2 text-textmain">
-                            Display Name
-                            <span class="font-normal text-textmuted">(optional)</span>
-                        </label>
-                        <input
-                                id="display-name"
-                                type="text"
-                                placeholder="How you'd like to appear"
-                                maxlength="100"
+                        <div>
+                            <label for="display-name" class="block text-sm font-semibold mb-2 text-textmain">
+                                Display Name
+                                <span class="font-normal text-textmuted">(optional)</span>
+                            </label>
+                            <input id="display-name" type="text" placeholder="How you'd like to appear" maxlength="100"
+                                class="w-full rounded-xl border border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary" />
+                        </div>
+
+                        <div>
+                            <label for="password"
+                                class="block text-sm font-semibold mb-2 text-textmain">Password</label>
+                            <input id="password" type="password" placeholder="At least 8 characters" minlength="8"
                                 class="w-full rounded-xl border border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary"
-                        />
-                    </div>
+                                required />
+                        </div>
 
-                    <div>
-                        <label for="password" class="block text-sm font-semibold mb-2 text-textmain">Password</label>
-                        <input
-                                id="password"
-                                type="password"
-                                placeholder="At least 8 characters"
+                        <div>
+                            <label for="confirm-password" class="block text-sm font-semibold mb-2 text-textmain">Confirm
+                                Password</label>
+                            <input id="confirm-password" type="password" placeholder="Re-enter your password"
                                 minlength="8"
                                 class="w-full rounded-xl border border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary"
-                                required
-                        />
-                    </div>
+                                required />
+                        </div>
 
-                    <div>
-                        <label for="confirm-password" class="block text-sm font-semibold mb-2 text-textmain">Confirm Password</label>
-                        <input
-                                id="confirm-password"
-                                type="password"
-                                placeholder="Re-enter your password"
-                                minlength="8"
-                                class="w-full rounded-xl border border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary"
-                                required
-                        />
-                    </div>
+                        <div class="flex items-start gap-3">
+                            <input id="terms" type="checkbox"
+                                class="mt-0.5 rounded border-border text-primary focus:ring-primary" required />
+                            <label for="terms" class="text-sm text-textmuted">
+                                I agree to the <a href="#" class="text-tertiary hover:underline">Terms of Service</a>
+                                and
+                                <a href="#" class="text-tertiary hover:underline">Privacy Policy</a>.
+                            </label>
+                        </div>
 
-                    <div class="flex items-start gap-3">
-                        <input id="terms" type="checkbox" class="mt-0.5 rounded border-border text-primary focus:ring-primary" required />
-                        <label for="terms" class="text-sm text-textmuted">
-                            I agree to the <a href="#" class="text-tertiary hover:underline">Terms of Service</a> and
-                            <a href="#" class="text-tertiary hover:underline">Privacy Policy</a>.
-                        </label>
+                        <button type="submit" id="submit-button"
+                            class="w-full rounded-xl bg-primary px-4 py-3 text-white font-semibold hover:opacity-95 transition">
+                            Create Account
+                        </button>
+                    </form>
+
+                    <div class="relative my-6">
+                        <div class="absolute inset-0 flex items-center">
+                            <div class="w-full border-t border-border"></div>
+                        </div>
+                        <div class="relative flex justify-center text-sm">
+                            <span class="bg-white px-4 text-textmuted">or</span>
+                        </div>
                     </div>
 
                     <button
-                            type="submit"
-                            id="submit-button"
-                            class="w-full rounded-xl bg-primary px-4 py-3 text-white font-semibold hover:opacity-95 transition"
-                    >
-                        Create Account
+                        class="w-full inline-flex items-center justify-center rounded-xl border border-border bg-white px-4 py-3 text-sm font-medium hover:bg-gray-50 transition">
+                        Sign up with Google
                     </button>
-                </form>
 
-                <div class="relative my-6">
-                    <div class="absolute inset-0 flex items-center">
-                        <div class="w-full border-t border-border"></div>
-                    </div>
-                    <div class="relative flex justify-center text-sm">
-                        <span class="bg-white px-4 text-textmuted">or</span>
-                    </div>
+                    <p class="mt-6 text-sm text-textmuted text-center">
+                        Already have an account?
+                        <a href="index.html" class="font-semibold text-primary hover:underline">Sign in</a>
+                    </p>
                 </div>
-
-                <button class="w-full inline-flex items-center justify-center rounded-xl border border-border bg-white px-4 py-3 text-sm font-medium hover:bg-gray-50 transition">
-                    Sign up with Google
-                </button>
-
-                <p class="mt-6 text-sm text-textmuted text-center">
-                    Already have an account?
-                    <a href="index.html" class="font-semibold text-primary hover:underline">Sign in</a>
-                </p>
-            </div>
-        </section>
+            </section>
+        </div>
     </div>
-</div>
 
-<script src="config.js"></script>
-<script>
-    function showError(message) {
-        const errorEl = document.getElementById("error-message");
-        const successEl = document.getElementById("success-message");
-        successEl.classList.add("hidden");
-        errorEl.textContent = message;
-        errorEl.classList.remove("hidden");
-    }
-
-    function showSuccess(message) {
-        const errorEl = document.getElementById("error-message");
-        const successEl = document.getElementById("success-message");
-        errorEl.classList.add("hidden");
-        successEl.textContent = message;
-        successEl.classList.remove("hidden");
-    }
-
-    function validateForm() {
-        const password = document.getElementById("password").value;
-        const confirmPassword = document.getElementById("confirm-password").value;
-
-        if (password !== confirmPassword) {
-            showError("Passwords do not match.");
-            return false;
+    <script src="config.js"></script>
+    <script>
+        function showError(message) {
+            const errorEl = document.getElementById("error-message");
+            const successEl = document.getElementById("success-message");
+            successEl.classList.add("hidden");
+            errorEl.textContent = message;
+            errorEl.classList.remove("hidden");
         }
 
-        if (password.length < 8) {
-            showError("Password must be at least 8 characters long.");
-            return false;
+        function showSuccess(message) {
+            const errorEl = document.getElementById("error-message");
+            const successEl = document.getElementById("success-message");
+            errorEl.classList.add("hidden");
+            successEl.textContent = message;
+            successEl.classList.remove("hidden");
         }
 
-        var errors = [];
-        if (!/[A-Z]/.test(password)) errors.push("one uppercase letter");
-        if (!/[a-z]/.test(password)) errors.push("one lowercase letter");
-        if (!/[0-9]/.test(password)) errors.push("one digit");
-        if (!/[!@#$%^&*()\-_=+\[\]{}|;:',.<>?/`~]/.test(password)) errors.push("one special character");
-        if (errors.length > 0) {
-            showError("Password must contain at least: " + errors.join(", ") + ".");
-            return false;
-        }
+        function validateForm() {
+            const password = document.getElementById("password").value;
+            const confirmPassword = document.getElementById("confirm-password").value;
 
-        return true;
-    }
-
-    async function handleRegister(event) {
-        event.preventDefault();
-
-        if (!validateForm()) return;
-
-        const username = document.getElementById("username").value.trim();
-        const email = document.getElementById("email").value.trim();
-        const password = document.getElementById("password").value;
-        const displayName = document.getElementById("display-name").value.trim();
-
-        const submitButton = document.getElementById("submit-button");
-        submitButton.disabled = true;
-        submitButton.textContent = "Creating account…";
-
-        try {
-            const response = await fetch(API_BASE + "/auth/register", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                    username,
-                    email,
-                    password,
-                    display_name: displayName || null,
-                }),
-            });
-
-            if (response.ok) {
-                showSuccess("Account created successfully! Redirecting to login…");
-                setTimeout(() => {
-                    window.location.assign("index.html");
-                }, 1500);
-            } else {
-                const data = await response.json();
-                showError(data.detail || "Registration failed. Please try again.");
+            if (password !== confirmPassword) {
+                showError("Passwords do not match.");
+                return false;
             }
-        } catch (err) {
-            showError("Unable to connect to the server. Please try again later.");
-        } finally {
-            submitButton.disabled = false;
-            submitButton.textContent = "Create Account";
-        }
-    }
 
-    document.addEventListener("DOMContentLoaded", function () {
-        const form = document.getElementById("register-form");
-        if (form) {
-            form.addEventListener("submit", handleRegister);
+            if (password.length < 8) {
+                showError("Password must be at least 8 characters long.");
+                return false;
+            }
+
+            var errors = [];
+            if (!/[A-Z]/.test(password)) errors.push("one uppercase letter");
+            if (!/[a-z]/.test(password)) errors.push("one lowercase letter");
+            if (!/[0-9]/.test(password)) errors.push("one digit");
+            if (!/[!@#$%^&*()\-_=+\[\]{}|;:',.<>?/`~]/.test(password)) errors.push("one special character");
+            if (errors.length > 0) {
+                showError("Password must contain at least: " + errors.join(", ") + ".");
+                return false;
+            }
+
+            return true;
         }
-    });
-</script>
+
+        async function handleRegister(event) {
+            event.preventDefault();
+
+            if (!validateForm()) return;
+
+            const username = document.getElementById("username").value.trim();
+            const email = document.getElementById("email").value.trim();
+            const password = document.getElementById("password").value;
+            const displayName = document.getElementById("display-name").value.trim();
+
+            const submitButton = document.getElementById("submit-button");
+            submitButton.disabled = true;
+            submitButton.textContent = "Creating account…";
+
+            try {
+                const response = await fetch(API_BASE + "/auth/register", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({
+                        username,
+                        email,
+                        password,
+                        display_name: displayName || null,
+                    }),
+                });
+
+                if (response.ok) {
+                    showSuccess("Account created successfully! Redirecting to login…");
+                    setTimeout(() => {
+                        window.location.assign("index.html");
+                    }, 1500);
+                } else {
+                    const data = await response.json();
+                    showError(data.detail || "Registration failed. Please try again.");
+                }
+            } catch (err) {
+                showError("Unable to connect to the server. Please try again later.");
+            } finally {
+                submitButton.disabled = false;
+                submitButton.textContent = "Create Account";
+            }
+        }
+
+        document.addEventListener("DOMContentLoaded", function () {
+            const form = document.getElementById("register-form");
+            if (form) {
+                form.addEventListener("submit", handleRegister);
+            }
+        });
+    </script>
 </body>
+
 </html>

--- a/frontend/register.html
+++ b/frontend/register.html
@@ -1,0 +1,290 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Local History Map - Register</title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Serif:wght@700;800&display=swap" rel="stylesheet">
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: {
+                        background: "#fef9f0",
+                        surface: "#ffffff",
+                        primary: "#775a19",
+                        "primary-light": "#c5a059",
+                        secondary: "#506169",
+                        tertiary: "#35618f",
+                        border: "#e7e2d9",
+                        textmain: "#1d1c16",
+                        textmuted: "#5f584c"
+                    },
+                    fontFamily: {
+                        body: ["Inter", "sans-serif"],
+                        headline: ["Noto Serif", "serif"]
+                    },
+                    boxShadow: {
+                        soft: "0 20px 50px rgba(0,0,0,0.08)"
+                    }
+                }
+            }
+        };
+    </script>
+    <style>
+        body {
+            background:
+                    linear-gradient(rgba(254, 249, 240, 0.88), rgba(254, 249, 240, 0.88)),
+                    url("https://images.unsplash.com/photo-1512453979798-5ea266f8880c?auto=format&fit=crop&w=1600&q=80");
+            background-size: cover;
+            background-position: center;
+            background-attachment: fixed;
+        }
+    </style>
+</head>
+<body class="font-body text-textmain min-h-screen">
+<div class="min-h-screen flex items-center justify-center px-6 py-10">
+    <div class="w-full max-w-6xl grid lg:grid-cols-2 bg-white/70 backdrop-blur-md rounded-3xl overflow-hidden shadow-soft border border-white/50">
+
+        <!-- Left panel -->
+        <section class="hidden lg:flex flex-col justify-between p-12 bg-[rgba(119,90,25,0.08)]">
+            <div>
+                <div class="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-white/80 text-primary text-sm font-semibold border border-border">
+                    <span>Local History Map</span>
+                </div>
+
+                <h1 class="mt-8 font-headline text-5xl leading-tight font-extrabold text-textmain">
+                    Join and share the stories behind every street.
+                </h1>
+
+                <p class="mt-6 text-lg leading-8 text-textmuted max-w-xl">
+                    Create an account to contribute your own memories, bookmark favorite stories, and become part of a community preserving local history.
+                </p>
+            </div>
+
+            <div class="grid sm:grid-cols-3 gap-4 mt-10">
+                <div class="bg-white/80 rounded-2xl p-4 border border-border">
+                    <p class="text-2xl font-bold text-primary">500+</p>
+                    <p class="mt-1 text-sm text-textmuted">Stories shared by locals</p>
+                </div>
+                <div class="bg-white/80 rounded-2xl p-4 border border-border">
+                    <p class="text-2xl font-bold text-primary">120+</p>
+                    <p class="mt-1 text-sm text-textmuted">Neighborhoods covered</p>
+                </div>
+                <div class="bg-white/80 rounded-2xl p-4 border border-border">
+                    <p class="text-2xl font-bold text-primary">Free</p>
+                    <p class="mt-1 text-sm text-textmuted">Always open to everyone</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Right panel - Registration form -->
+        <section class="flex items-center justify-center p-8 sm:p-12 bg-white/75">
+            <div class="w-full max-w-md">
+                <div class="lg:hidden mb-8 text-center">
+                    <h1 class="font-headline text-3xl font-extrabold text-textmain">Local History Map</h1>
+                    <p class="mt-2 text-sm text-textmuted">Create an account to start exploring.</p>
+                </div>
+
+                <div class="mb-8">
+                    <h2 class="text-3xl font-bold text-textmain">Create your account</h2>
+                    <p class="mt-2 text-textmuted">Start preserving and discovering local stories.</p>
+                </div>
+
+                <!-- Error message area -->
+                <div id="error-message" class="hidden mb-4 p-3 rounded-xl bg-red-50 border border-red-200 text-red-700 text-sm"></div>
+
+                <!-- Success message area -->
+                <div id="success-message" class="hidden mb-4 p-3 rounded-xl bg-green-50 border border-green-200 text-green-700 text-sm"></div>
+
+                <form id="register-form" class="space-y-5">
+                    <div>
+                        <label for="username" class="block text-sm font-semibold mb-2 text-textmain">Username</label>
+                        <input
+                                id="username"
+                                type="text"
+                                placeholder="Choose a username"
+                                minlength="3"
+                                maxlength="50"
+                                class="w-full rounded-xl border border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary"
+                                required
+                        />
+                    </div>
+
+                    <div>
+                        <label for="email" class="block text-sm font-semibold mb-2 text-textmain">Email</label>
+                        <input
+                                id="email"
+                                type="email"
+                                placeholder="you@example.com"
+                                class="w-full rounded-xl border border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary"
+                                required
+                        />
+                    </div>
+
+                    <div>
+                        <label for="display-name" class="block text-sm font-semibold mb-2 text-textmain">
+                            Display Name
+                            <span class="font-normal text-textmuted">(optional)</span>
+                        </label>
+                        <input
+                                id="display-name"
+                                type="text"
+                                placeholder="How you'd like to appear"
+                                maxlength="100"
+                                class="w-full rounded-xl border border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary"
+                        />
+                    </div>
+
+                    <div>
+                        <label for="password" class="block text-sm font-semibold mb-2 text-textmain">Password</label>
+                        <input
+                                id="password"
+                                type="password"
+                                placeholder="At least 8 characters"
+                                minlength="8"
+                                class="w-full rounded-xl border border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary"
+                                required
+                        />
+                    </div>
+
+                    <div>
+                        <label for="confirm-password" class="block text-sm font-semibold mb-2 text-textmain">Confirm Password</label>
+                        <input
+                                id="confirm-password"
+                                type="password"
+                                placeholder="Re-enter your password"
+                                minlength="8"
+                                class="w-full rounded-xl border border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary"
+                                required
+                        />
+                    </div>
+
+                    <div class="flex items-start gap-3">
+                        <input id="terms" type="checkbox" class="mt-0.5 rounded border-border text-primary focus:ring-primary" required />
+                        <label for="terms" class="text-sm text-textmuted">
+                            I agree to the <a href="#" class="text-tertiary hover:underline">Terms of Service</a> and
+                            <a href="#" class="text-tertiary hover:underline">Privacy Policy</a>.
+                        </label>
+                    </div>
+
+                    <button
+                            type="submit"
+                            id="submit-button"
+                            class="w-full rounded-xl bg-primary px-4 py-3 text-white font-semibold hover:opacity-95 transition"
+                    >
+                        Create Account
+                    </button>
+                </form>
+
+                <div class="relative my-6">
+                    <div class="absolute inset-0 flex items-center">
+                        <div class="w-full border-t border-border"></div>
+                    </div>
+                    <div class="relative flex justify-center text-sm">
+                        <span class="bg-white px-4 text-textmuted">or</span>
+                    </div>
+                </div>
+
+                <button class="w-full inline-flex items-center justify-center rounded-xl border border-border bg-white px-4 py-3 text-sm font-medium hover:bg-gray-50 transition">
+                    Sign up with Google
+                </button>
+
+                <p class="mt-6 text-sm text-textmuted text-center">
+                    Already have an account?
+                    <a href="index.html" class="font-semibold text-primary hover:underline">Sign in</a>
+                </p>
+            </div>
+        </section>
+    </div>
+</div>
+
+<script>
+    function showError(message) {
+        const errorEl = document.getElementById("error-message");
+        const successEl = document.getElementById("success-message");
+        successEl.classList.add("hidden");
+        errorEl.textContent = message;
+        errorEl.classList.remove("hidden");
+    }
+
+    function showSuccess(message) {
+        const errorEl = document.getElementById("error-message");
+        const successEl = document.getElementById("success-message");
+        errorEl.classList.add("hidden");
+        successEl.textContent = message;
+        successEl.classList.remove("hidden");
+    }
+
+    function validateForm() {
+        const password = document.getElementById("password").value;
+        const confirmPassword = document.getElementById("confirm-password").value;
+
+        if (password !== confirmPassword) {
+            showError("Passwords do not match.");
+            return false;
+        }
+
+        if (password.length < 8) {
+            showError("Password must be at least 8 characters long.");
+            return false;
+        }
+
+        return true;
+    }
+
+    async function handleRegister(event) {
+        event.preventDefault();
+
+        if (!validateForm()) return;
+
+        const username = document.getElementById("username").value.trim();
+        const email = document.getElementById("email").value.trim();
+        const password = document.getElementById("password").value;
+        const displayName = document.getElementById("display-name").value.trim();
+
+        const submitButton = document.getElementById("submit-button");
+        submitButton.disabled = true;
+        submitButton.textContent = "Creating account…";
+
+        try {
+            const response = await fetch("/api/register", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    username,
+                    email,
+                    password,
+                    display_name: displayName || null,
+                }),
+            });
+
+            if (response.ok) {
+                showSuccess("Account created successfully! Redirecting to login…");
+                setTimeout(() => {
+                    window.location.assign("index.html");
+                }, 1500);
+            } else {
+                const data = await response.json();
+                showError(data.detail || "Registration failed. Please try again.");
+            }
+        } catch (err) {
+            showError("Unable to connect to the server. Please try again later.");
+        } finally {
+            submitButton.disabled = false;
+            submitButton.textContent = "Create Account";
+        }
+    }
+
+    document.addEventListener("DOMContentLoaded", function () {
+        const form = document.getElementById("register-form");
+        if (form) {
+            form.addEventListener("submit", handleRegister);
+        }
+    });
+</script>
+</body>
+</html>

--- a/frontend/register.html
+++ b/frontend/register.html
@@ -202,6 +202,7 @@
     </div>
 </div>
 
+<script src="config.js"></script>
 <script>
     function showError(message) {
         const errorEl = document.getElementById("error-message");
@@ -233,6 +234,16 @@
             return false;
         }
 
+        var errors = [];
+        if (!/[A-Z]/.test(password)) errors.push("one uppercase letter");
+        if (!/[a-z]/.test(password)) errors.push("one lowercase letter");
+        if (!/[0-9]/.test(password)) errors.push("one digit");
+        if (!/[!@#$%^&*()\-_=+\[\]{}|;:',.<>?/`~]/.test(password)) errors.push("one special character");
+        if (errors.length > 0) {
+            showError("Password must contain at least: " + errors.join(", ") + ".");
+            return false;
+        }
+
         return true;
     }
 
@@ -251,7 +262,7 @@
         submitButton.textContent = "Creating account…";
 
         try {
-            const response = await fetch("/api/register", {
+            const response = await fetch(API_BASE + "/auth/register", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({

--- a/frontend/search.html
+++ b/frontend/search.html
@@ -1,0 +1,244 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Search Stories - Local History Map</title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Serif:wght@700;800&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet">
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: {
+                        background: "#fef9f0",
+                        surface: "#ffffff",
+                        primary: "#775a19",
+                        "primary-light": "#c5a059",
+                        secondary: "#506169",
+                        tertiary: "#35618f",
+                        border: "#e7e2d9",
+                        textmain: "#1d1c16",
+                        textmuted: "#5f584c"
+                    },
+                    fontFamily: {
+                        body: ["Inter", "sans-serif"],
+                        headline: ["Noto Serif", "serif"]
+                    },
+                    boxShadow: {
+                        soft: "0 20px 50px rgba(0,0,0,0.08)"
+                    }
+                }
+            }
+        };
+    </script>
+    <style>
+        .material-symbols-outlined {
+            font-variation-settings: "FILL" 0, "wght" 400, "GRAD" 0, "opsz" 24;
+        }
+    </style>
+</head>
+<body class="bg-background text-textmain font-body min-h-screen">
+
+    <!-- Header -->
+    <header class="sticky top-0 z-50 bg-[#f8f3ea]/95 backdrop-blur-sm border-b border-border/30">
+        <div class="flex items-center gap-4 w-full px-6 py-4 max-w-screen-xl mx-auto">
+            <a href="map.html" class="flex items-center gap-2 text-textmuted hover:text-textmain transition-colors shrink-0">
+                <span class="material-symbols-outlined text-xl">arrow_back</span>
+                <span class="text-sm font-semibold hidden sm:inline">Map</span>
+            </a>
+            <form id="search-form" class="flex-1 flex items-center gap-3">
+                <div class="relative flex-1 max-w-2xl">
+                    <span class="absolute left-3.5 top-1/2 -translate-y-1/2 material-symbols-outlined text-textmuted text-xl">search</span>
+                    <input id="search-input" name="q" type="text" autocomplete="off"
+                        class="w-full pl-11 pr-4 py-3 bg-white border border-border rounded-xl text-sm focus:border-primary focus:ring-primary transition-all"
+                        placeholder="Search stories by place name..." />
+                </div>
+                <button type="submit"
+                    class="shrink-0 inline-flex items-center gap-2 bg-primary text-white px-5 py-3 rounded-xl text-sm font-semibold hover:opacity-95 transition-all">
+                    Search
+                </button>
+            </form>
+        </div>
+    </header>
+
+    <!-- Content -->
+    <main class="max-w-screen-xl mx-auto px-6 py-8">
+
+        <!-- Status -->
+        <div id="status" class="mb-6">
+            <p class="text-textmuted text-sm">Enter a place name to search for stories.</p>
+        </div>
+
+        <!-- Loading -->
+        <div id="loading" class="hidden flex flex-col items-center justify-center py-20">
+            <div class="w-8 h-8 border-3 border-primary/30 border-t-primary rounded-full animate-spin"></div>
+            <p class="mt-4 text-sm text-textmuted">Searching stories...</p>
+        </div>
+
+        <!-- Results Grid -->
+        <div id="results" class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3"></div>
+
+        <!-- Empty State -->
+        <div id="empty" class="hidden flex flex-col items-center justify-center py-20">
+            <span class="material-symbols-outlined text-5xl text-textmuted/40">search_off</span>
+            <p class="mt-4 text-base font-semibold text-textmain">No stories found</p>
+            <p id="empty-detail" class="mt-1 text-sm text-textmuted">Try a different place name.</p>
+        </div>
+    </main>
+
+    <script src="config.js"></script>
+    <script>
+        var searchForm = document.getElementById("search-form");
+        var searchInput = document.getElementById("search-input");
+        var statusEl = document.getElementById("status");
+        var loadingEl = document.getElementById("loading");
+        var resultsEl = document.getElementById("results");
+        var emptyEl = document.getElementById("empty");
+        var emptyDetail = document.getElementById("empty-detail");
+
+        // Cache: storyId -> full detail (with media_files)
+        var storyCache = {};
+
+        // Read initial query from URL
+        var urlParams = new URLSearchParams(window.location.search);
+        var initialQuery = urlParams.get("q") || "";
+        if (initialQuery) {
+            searchInput.value = initialQuery;
+            performSearch(initialQuery);
+        }
+
+        searchForm.addEventListener("submit", function (e) {
+            e.preventDefault();
+            var query = searchInput.value.trim();
+            if (query.length < 1) return;
+
+            // Update URL without reload
+            var url = new URL(window.location);
+            url.searchParams.set("q", query);
+            window.history.replaceState({}, "", url);
+
+            performSearch(query);
+        });
+
+        async function performSearch(query) {
+            // Show loading
+            statusEl.classList.add("hidden");
+            emptyEl.classList.add("hidden");
+            resultsEl.innerHTML = "";
+            loadingEl.classList.remove("hidden");
+
+            try {
+                var response = await fetch(API_BASE + "/stories/search?place_name=" + encodeURIComponent(query));
+                if (!response.ok) throw new Error("Search request failed");
+                var data = await response.json();
+                var stories = data.stories || [];
+
+                loadingEl.classList.add("hidden");
+
+                if (stories.length === 0) {
+                    emptyEl.classList.remove("hidden");
+                    emptyDetail.textContent = 'No stories found for "' + query + '". Try a different place name.';
+                    return;
+                }
+
+                statusEl.classList.remove("hidden");
+                statusEl.innerHTML = '<p class="text-textmuted text-sm">Found <strong class="text-textmain">' + stories.length + '</strong> ' + (stories.length === 1 ? 'story' : 'stories') + ' for "<strong class="text-textmain">' + escapeHtml(query) + '</strong>"</p>';
+
+                // Render cards immediately with basic info
+                stories.forEach(function (story) {
+                    resultsEl.appendChild(createStoryCard(story, null));
+                });
+
+                // Fetch full details (with media) for each story in parallel
+                var detailPromises = stories.map(function (story) {
+                    return fetchStoryDetail(story.id);
+                });
+                var details = await Promise.allSettled(detailPromises);
+
+                // Update cards with media once details arrive
+                details.forEach(function (result, i) {
+                    if (result.status === "fulfilled" && result.value) {
+                        var detail = result.value;
+                        storyCache[detail.id] = detail;
+                        updateCardWithMedia(stories[i].id, detail);
+                    }
+                });
+
+            } catch (err) {
+                loadingEl.classList.add("hidden");
+                statusEl.classList.remove("hidden");
+                statusEl.innerHTML = '<p class="text-red-600 text-sm">Failed to search stories. Please try again.</p>';
+                console.error("Search error:", err);
+            }
+        }
+
+        async function fetchStoryDetail(storyId) {
+            // Return from cache if available
+            if (storyCache[storyId]) return storyCache[storyId];
+
+            var response = await fetch(API_BASE + "/stories/" + storyId);
+            if (!response.ok) return null;
+            var detail = await response.json();
+            storyCache[storyId] = detail;
+            return detail;
+        }
+
+        function createStoryCard(story, detail) {
+            var card = document.createElement("a");
+            card.href = "story-detail.html?id=" + story.id;
+            card.id = "card-" + story.id;
+            card.className = "group block overflow-hidden rounded-2xl border border-border bg-surface shadow-sm hover:shadow-soft transition-all";
+
+            var placeName = story.place_name || "";
+            var dateLabel = story.date_label || "";
+            var preview = (story.content || "").length > 150
+                ? story.content.substring(0, 150) + "..."
+                : (story.content || "");
+
+            card.innerHTML =
+                '<div id="media-' + story.id + '" class="h-44 bg-gradient-to-br from-[#e9dfcd] to-[#f7f3eb] flex items-center justify-center relative overflow-hidden">' +
+                    '<span class="material-symbols-outlined text-4xl text-primary/30">photo_library</span>' +
+                '</div>' +
+                '<div class="p-5">' +
+                    '<div class="flex items-center gap-2 mb-2">' +
+                        (dateLabel ? '<span class="text-[10px] font-bold text-tertiary tracking-widest uppercase">' + escapeHtml(dateLabel) + '</span>' : '') +
+                        (dateLabel && placeName ? '<span class="text-border">|</span>' : '') +
+                        (placeName ? '<span class="text-[11px] font-semibold text-primary truncate">' + escapeHtml(placeName) + '</span>' : '') +
+                    '</div>' +
+                    '<h3 class="font-headline font-bold text-base text-textmain leading-snug group-hover:text-primary transition-colors">' + escapeHtml(story.title) + '</h3>' +
+                    (story.author ? '<p class="mt-1 text-xs text-textmuted">by ' + escapeHtml(story.author) + '</p>' : '') +
+                    '<p class="mt-2.5 text-sm text-textmuted leading-relaxed line-clamp-3">' + escapeHtml(preview) + '</p>' +
+                    '<div class="mt-4 flex items-center gap-1 text-xs font-bold text-primary">' +
+                        'Read Story' +
+                        '<span class="material-symbols-outlined text-sm group-hover:translate-x-0.5 transition-transform">arrow_forward</span>' +
+                    '</div>' +
+                '</div>';
+
+            return card;
+        }
+
+        function updateCardWithMedia(storyId, detail) {
+            var mediaContainer = document.getElementById("media-" + storyId);
+            if (!mediaContainer) return;
+            if (!detail.media_files || detail.media_files.length === 0) return;
+
+            var images = detail.media_files.filter(function (m) { return m.media_type === "image"; });
+            if (images.length === 0) return;
+
+            mediaContainer.innerHTML =
+                '<img src="' + escapeHtml(images[0].media_url) + '" alt="' + escapeHtml(detail.title) + '" class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300" />' +
+                (images.length > 1 ? '<div class="absolute bottom-2 right-2 bg-black/50 text-white text-[10px] font-bold px-2 py-0.5 rounded-full">+' + (images.length - 1) + '</div>' : '');
+        }
+
+        function escapeHtml(str) {
+            var div = document.createElement("div");
+            div.appendChild(document.createTextNode(str));
+            return div.innerHTML;
+        }
+    </script>
+</body>
+</html>

--- a/frontend/story-create.html
+++ b/frontend/story-create.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Local History Map - Story Creation</title>
+  <script src="https://cdn.tailwindcss.com?plugins=forms"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Serif:wght@700;800&display=swap" rel="stylesheet">
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            background: "#fef9f0",
+            surface: "#ffffff",
+            primary: "#775a19",
+            "primary-light": "#c5a059",
+            secondary: "#506169",
+            tertiary: "#35618f",
+            border: "#e7e2d9",
+            textmain: "#1d1c16",
+            textmuted: "#5f584c"
+          },
+          fontFamily: {
+            body: ["Inter", "sans-serif"],
+            headline: ["Noto Serif", "serif"]
+          },
+          boxShadow: {
+            soft: "0 20px 50px rgba(0,0,0,0.08)"
+          }
+        }
+      }
+    };
+  </script>
+</head>
+<body class="bg-background text-textmain font-body min-h-screen">
+  <main class="max-w-5xl mx-auto px-6 py-10 lg:px-10">
+    <header class="mb-10 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+      <div>
+        <p class="text-sm font-semibold uppercase tracking-[0.2em] text-primary">Story Creation</p>
+        <h1 class="mt-3 font-headline text-4xl font-extrabold leading-tight text-textmain">Share a piece of local history</h1>
+        <p class="mt-4 max-w-2xl text-base leading-7 text-textmuted">
+          Add a memory, attach media, choose a location, and place your story on the map for others to discover.
+        </p>
+      </div>
+      <a href="story-detail.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-surface px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">
+        Preview Story Detail
+      </a>
+    </header>
+
+    <section class="grid gap-8 lg:grid-cols-[1.2fr_0.8fr]">
+      <form class="rounded-3xl border border-border bg-surface p-8 shadow-soft">
+        <div class="space-y-6">
+          <div>
+            <label for="title" class="mb-2 block text-sm font-semibold text-textmain">Title</label>
+            <input id="title" type="text" placeholder="Give your story a title" class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary" />
+          </div>
+
+          <div>
+            <label for="story" class="mb-2 block text-sm font-semibold text-textmain">Your Story</label>
+            <textarea id="story" rows="7" placeholder="Write what happened here, who was involved, and why this place matters." class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm leading-6 focus:border-primary focus:ring-primary"></textarea>
+          </div>
+
+          <div class="grid gap-6 md:grid-cols-2">
+            <div>
+              <label for="location" class="mb-2 block text-sm font-semibold text-textmain">Location</label>
+              <input id="location" type="text" placeholder="Kadikoy, Istanbul" class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary" />
+            </div>
+            <div>
+              <label for="date" class="mb-2 block text-sm font-semibold text-textmain">Date</label>
+              <input id="date" type="date" class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary" />
+            </div>
+          </div>
+
+          <div>
+            <label class="mb-2 block text-sm font-semibold text-textmain">Media Upload</label>
+            <div class="rounded-2xl border border-dashed border-primary-light bg-[rgba(197,160,89,0.08)] px-6 py-10 text-center">
+              <p class="text-base font-semibold text-primary">Drop photos, videos, or audio here</p>
+              <p class="mt-2 text-sm text-textmuted">Or click to browse files from your device</p>
+              <button type="button" class="mt-5 rounded-xl bg-primary px-5 py-3 text-sm font-semibold text-white transition hover:opacity-95">
+                Choose Files
+              </button>
+            </div>
+          </div>
+
+          <div class="grid gap-4 md:grid-cols-2">
+            <button type="button" class="rounded-xl border border-border bg-white px-4 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">
+              Save as Draft
+            </button>
+            <button type="submit" class="rounded-xl bg-primary px-4 py-3 text-sm font-semibold text-white transition hover:opacity-95">
+              Publish Story
+            </button>
+          </div>
+        </div>
+      </form>
+
+      <aside class="rounded-3xl border border-border bg-[rgba(119,90,25,0.06)] p-8">
+        <h2 class="font-headline text-2xl font-bold text-textmain">Publishing Checklist</h2>
+        <ul class="mt-6 space-y-4 text-sm text-textmuted">
+          <li class="rounded-2xl bg-white/80 p-4">Add a clear title that helps others identify the place or event.</li>
+          <li class="rounded-2xl bg-white/80 p-4">Use the story field to capture who, what, when, and why it matters.</li>
+          <li class="rounded-2xl bg-white/80 p-4">Attach media if available to make the archive entry richer.</li>
+          <li class="rounded-2xl bg-white/80 p-4">Confirm the location and date so the story can be mapped correctly.</li>
+        </ul>
+
+        <div class="mt-8 rounded-2xl border border-border bg-surface p-5">
+          <p class="text-sm font-semibold text-primary">Map Placement</p>
+          <div class="mt-4 flex h-56 items-center justify-center rounded-2xl bg-[linear-gradient(135deg,#efe7d5,#f8f4ec)] text-center text-sm text-textmuted">
+            Interactive map placeholder
+          </div>
+        </div>
+      </aside>
+    </section>
+  </main>
+</body>
+</html>

--- a/frontend/story-create.html
+++ b/frontend/story-create.html
@@ -357,8 +357,9 @@
     return /^(0[1-9]|1[0-2])\/(0[1-9]|[12][0-9]|3[01])\/\d{4}$/.test(value);
   }
 
-  function getYearFromDateInput(value) {
-    return parseInt(value.slice(-4), 10);
+  function getISODateFromDateInput(value) {
+    var parts = value.split("/");
+    return parts[2] + "-" + parts[0] + "-" + parts[1];
   }
 
   document.getElementById("date-range-toggle").addEventListener("change", function () {
@@ -534,8 +535,8 @@
       return;
     }
 
-    if (usingDateRange && getYearFromDateInput(dateEnd) < getYearFromDateInput(dateStart)) {
-      errorEl.textContent = "End date year must be greater than or equal to the start date year.";
+    if (usingDateRange && getISODateFromDateInput(dateEnd) < getISODateFromDateInput(dateStart)) {
+      errorEl.textContent = "End date must be greater than or equal to the start date.";
       errorEl.classList.remove("hidden");
       return;
     }
@@ -555,8 +556,8 @@
       latitude: parseFloat(lat),
       longitude: parseFloat(lng),
       place_name: placeName,
-      date_start: usingDateRange ? getYearFromDateInput(dateStart) : getYearFromDateInput(dateSingle),
-      date_end: usingDateRange ? getYearFromDateInput(dateEnd) : null
+      date_start: usingDateRange ? getISODateFromDateInput(dateStart) : getISODateFromDateInput(dateSingle),
+      date_end: usingDateRange ? getISODateFromDateInput(dateEnd) : null
     };
 
     setSubmittingState(true, "Creating Story...");

--- a/frontend/story-create.html
+++ b/frontend/story-create.html
@@ -36,22 +36,30 @@
   </script>
 </head>
 <body class="bg-background text-textmain font-body min-h-screen">
-  <main class="max-w-5xl mx-auto px-6 py-10 lg:px-10">
+  <main class="w-full px-4 py-10 lg:px-8 xl:px-10 2xl:px-14">
     <header class="mb-10 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
       <div>
         <p class="text-sm font-semibold uppercase tracking-[0.2em] text-primary">Story Creation</p>
         <h1 class="mt-3 font-headline text-4xl font-extrabold leading-tight text-textmain">Share a piece of local history</h1>
-        <p class="mt-4 max-w-2xl text-base leading-7 text-textmuted">
+        <p class="mt-4 max-w-4xl text-base leading-7 text-textmuted">
           Add a memory, attach media, choose a location, and place your story on the map for others to discover.
         </p>
       </div>
-      <a href="story-detail.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-surface px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">
-        Preview Story Detail
-      </a>
+      <div class="flex flex-wrap gap-3">
+        <a href="index.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-surface px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">
+          Login Page
+        </a>
+        <a href="map.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-surface px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">
+          Map Page
+        </a>
+        <a href="story-detail.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-surface px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">
+          Preview Story Detail
+        </a>
+      </div>
     </header>
 
-    <section class="grid gap-8 lg:grid-cols-[1.2fr_0.8fr]">
-      <form class="rounded-3xl border border-border bg-surface p-8 shadow-soft">
+    <section class="grid gap-8 lg:grid-cols-[minmax(0,2.25fr)_17rem] xl:grid-cols-[minmax(0,2.7fr)_16rem] 2xl:grid-cols-[minmax(0,3fr)_16rem]">
+      <form action="story-detail.html" class="rounded-3xl border border-border bg-surface p-8 shadow-soft">
         <div class="space-y-6">
           <div>
             <label for="title" class="mb-2 block text-sm font-semibold text-textmain">Title</label>
@@ -62,6 +70,24 @@
             <label for="story" class="mb-2 block text-sm font-semibold text-textmain">Your Story</label>
             <textarea id="story" rows="7" placeholder="Write what happened here, who was involved, and why this place matters." class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm leading-6 focus:border-primary focus:ring-primary"></textarea>
           </div>
+
+          <section>
+            <div>
+              <p class="text-sm font-semibold uppercase tracking-[0.18em] text-primary">Map Placement</p>
+              <h2 class="mt-2 font-headline text-3xl font-bold text-textmain">Choose where the story belongs</h2>
+              <p class="mt-3 max-w-3xl text-sm leading-7 text-textmuted">
+                Place the memory on the map before publishing so the story becomes part of the shared city archive.
+              </p>
+            </div>
+            <div class="mt-6 flex h-[24rem] items-center justify-center rounded-[1.75rem] bg-[linear-gradient(135deg,#e7dcc8,#f6f1e8)] text-center text-base text-textmuted lg:h-[32rem]">
+              Interactive map placeholder
+            </div>
+            <div class="mt-4">
+              <a href="map.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-white px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">
+                Open Full Map
+              </a>
+            </div>
+          </section>
 
           <div class="grid gap-6 md:grid-cols-2">
             <div>
@@ -86,9 +112,9 @@
           </div>
 
           <div class="grid gap-4 md:grid-cols-2">
-            <button type="button" class="rounded-xl border border-border bg-white px-4 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">
+            <a href="map.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-white px-4 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">
               Save as Draft
-            </button>
+            </a>
             <button type="submit" class="rounded-xl bg-primary px-4 py-3 text-sm font-semibold text-white transition hover:opacity-95">
               Publish Story
             </button>
@@ -96,21 +122,14 @@
         </div>
       </form>
 
-      <aside class="rounded-3xl border border-border bg-[rgba(119,90,25,0.06)] p-8">
-        <h2 class="font-headline text-2xl font-bold text-textmain">Publishing Checklist</h2>
-        <ul class="mt-6 space-y-4 text-sm text-textmuted">
-          <li class="rounded-2xl bg-white/80 p-4">Add a clear title that helps others identify the place or event.</li>
-          <li class="rounded-2xl bg-white/80 p-4">Use the story field to capture who, what, when, and why it matters.</li>
-          <li class="rounded-2xl bg-white/80 p-4">Attach media if available to make the archive entry richer.</li>
-          <li class="rounded-2xl bg-white/80 p-4">Confirm the location and date so the story can be mapped correctly.</li>
+      <aside class="rounded-3xl border border-border bg-[rgba(119,90,25,0.06)] p-6 lg:self-start">
+        <h2 class="font-headline text-xl font-bold text-textmain">Publishing Checklist</h2>
+        <ul class="mt-5 space-y-3 text-sm leading-6 text-textmuted">
+          <li class="rounded-2xl bg-white/80 p-4">Add a title that identifies the place or event.</li>
+          <li class="rounded-2xl bg-white/80 p-4">Explain what happened and why it matters.</li>
+          <li class="rounded-2xl bg-white/80 p-4">Attach media when available.</li>
+          <li class="rounded-2xl bg-white/80 p-4">Confirm the date and location.</li>
         </ul>
-
-        <div class="mt-8 rounded-2xl border border-border bg-surface p-5">
-          <p class="text-sm font-semibold text-primary">Map Placement</p>
-          <div class="mt-4 flex h-56 items-center justify-center rounded-2xl bg-[linear-gradient(135deg,#efe7d5,#f8f4ec)] text-center text-sm text-textmuted">
-            Interactive map placeholder
-          </div>
-        </div>
       </aside>
     </section>
   </main>

--- a/frontend/story-create.html
+++ b/frontend/story-create.html
@@ -198,10 +198,14 @@
   </section>
 </main>
 
+<!-- Auth -->
+<script src="config.js"></script>
+<script src="auth.js"></script>
 <!-- Leaflet JS -->
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 
 <script>
+  if (!requireAuth()) throw new Error("redirect");
   // ─── Map Init ───
   var createMap = L.map("create-map", {
     center: [41.015, 28.979],

--- a/frontend/story-create.html
+++ b/frontend/story-create.html
@@ -37,6 +37,14 @@
     };
   </script>
   <style>
+    #location-search-container {
+      position: relative;
+      z-index: 1000;
+    }
+    #create-map {
+      position: relative;
+      z-index: 0;
+    }
     .leaflet-container { font-family: "Inter", sans-serif; }
     .leaflet-control-zoom a {
       background: rgba(254,249,240,0.9) !important;
@@ -181,7 +189,7 @@
           <button type="button" id="btn-draft" class="inline-flex items-center justify-center rounded-xl border border-border bg-white px-4 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">
             Save as Draft
           </button>
-          <button type="submit" class="rounded-xl bg-primary px-4 py-3 text-sm font-semibold text-white transition hover:opacity-95">
+          <button type="submit" id="btn-publish" class="rounded-xl bg-primary px-4 py-3 text-sm font-semibold text-white transition hover:opacity-95">
             Publish Story
           </button>
         </div>
@@ -349,6 +357,10 @@
     return /^(0[1-9]|1[0-2])\/(0[1-9]|[12][0-9]|3[01])\/\d{4}$/.test(value);
   }
 
+  function getYearFromDateInput(value) {
+    return parseInt(value.slice(-4), 10);
+  }
+
   document.getElementById("date-range-toggle").addEventListener("change", function () {
     document.getElementById("date-range-fields").classList.toggle("hidden", !this.checked);
     document.getElementById("date-single").closest("div").classList.toggle("hidden", this.checked);
@@ -368,6 +380,52 @@
     }
     fileList.textContent = names.length + " file(s) selected: " + names.join(", ");
   });
+
+  function getSelectedFiles() {
+    return Array.prototype.slice.call(document.getElementById("media-files").files || []);
+  }
+
+  function getMediaType(file) {
+    if (!file || !file.type) return null;
+    if (file.type.indexOf("image/") === 0) return "image";
+    if (file.type.indexOf("video/") === 0) return "video";
+    if (file.type.indexOf("audio/") === 0) return "audio";
+    if (
+      file.type === "application/pdf" ||
+      file.type === "text/plain" ||
+      file.type === "application/msword" ||
+      file.type === "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    ) {
+      return "document";
+    }
+    return null;
+  }
+
+  async function readErrorMessage(response, fallbackMessage) {
+    try {
+      var data = await response.json();
+      if (data && typeof data.detail === "string") {
+        return data.detail;
+      }
+    } catch (err) {
+      // Ignore JSON parse errors and fall back to generic messaging.
+    }
+    return fallbackMessage;
+  }
+
+  function setSubmittingState(isSubmitting, publishLabel) {
+    var publishButton = document.getElementById("btn-publish");
+    var draftButton = document.getElementById("btn-draft");
+
+    publishButton.disabled = isSubmitting;
+    draftButton.disabled = isSubmitting;
+
+    publishButton.textContent = publishLabel || "Publish Story";
+    publishButton.classList.toggle("opacity-70", isSubmitting);
+    publishButton.classList.toggle("cursor-not-allowed", isSubmitting);
+    draftButton.classList.toggle("opacity-70", isSubmitting);
+    draftButton.classList.toggle("cursor-not-allowed", isSubmitting);
+  }
 
   // ─── Checklist Updates ───
   function updateChecklist() {
@@ -406,8 +464,16 @@
     document.getElementById(id).addEventListener("input", updateChecklist);
   });
 
+  document.getElementById("btn-draft").addEventListener("click", function () {
+    var errorEl = document.getElementById("form-error");
+    var successEl = document.getElementById("form-success");
+    successEl.classList.add("hidden");
+    errorEl.textContent = "Draft save is not available in the current API. Publishing now creates a public story directly.";
+    errorEl.classList.remove("hidden");
+  });
+
   // ─── Form Submission ───
-  document.getElementById("story-form").addEventListener("submit", function (e) {
+  document.getElementById("story-form").addEventListener("submit", async function (e) {
     e.preventDefault();
 
     var errorEl = document.getElementById("form-error");
@@ -417,12 +483,14 @@
 
     var title = document.getElementById("title").value.trim();
     var content = document.getElementById("story").value.trim();
+    var placeName = document.getElementById("location").value.trim();
     var lat = document.getElementById("latitude").value;
     var lng = document.getElementById("longitude").value;
     var dateSingle = document.getElementById("date-single").value.trim();
     var dateStart = document.getElementById("date-start").value.trim();
     var usingDateRange = document.getElementById("date-range-toggle").checked;
     var dateEnd = document.getElementById("date-end").value.trim();
+    var selectedFiles = getSelectedFiles();
 
     if (!title || !content) {
       errorEl.textContent = "Please fill in the title and story content.";
@@ -436,8 +504,8 @@
       return;
     }
 
-    if (!usingDateRange && !dateSingle) {
-      errorEl.textContent = "Please provide a date in mm/dd/yyyy format.";
+    if (!placeName) {
+      errorEl.textContent = "Please provide a location name for the pinned place.";
       errorEl.classList.remove("hidden");
       return;
     }
@@ -466,24 +534,90 @@
       return;
     }
 
-    // In production: POST to /api/stories
+    if (usingDateRange && getYearFromDateInput(dateEnd) < getYearFromDateInput(dateStart)) {
+      errorEl.textContent = "End date year must be greater than or equal to the start date year.";
+      errorEl.classList.remove("hidden");
+      return;
+    }
+
+    for (var i = 0; i < selectedFiles.length; i++) {
+      if (!getMediaType(selectedFiles[i])) {
+        errorEl.textContent = "One or more selected files are not supported by the upload API.";
+        errorEl.classList.remove("hidden");
+        return;
+      }
+    }
+
     var payload = {
       title: title,
       content: content,
+      summary: null,
       latitude: parseFloat(lat),
       longitude: parseFloat(lng),
-      location_name: document.getElementById("location").value.trim(),
-      date_start: usingDateRange ? dateStart : dateSingle,
-      date_end: usingDateRange ? dateEnd : null
+      place_name: placeName,
+      date_start: usingDateRange ? getYearFromDateInput(dateStart) : getYearFromDateInput(dateSingle),
+      date_end: usingDateRange ? getYearFromDateInput(dateEnd) : null
     };
 
-    console.log("Story payload:", payload);
-    successEl.textContent = "Story published successfully! Redirecting to map...";
-    successEl.classList.remove("hidden");
+    setSubmittingState(true, "Creating Story...");
 
-    setTimeout(function () {
-      window.location.assign("map.html");
-    }, 1500);
+    try {
+      var createResponse = await authFetch(API_BASE + "/stories", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify(payload)
+      });
+
+      if (!createResponse.ok) {
+        throw new Error(await readErrorMessage(createResponse, "Failed to create the story."));
+      }
+
+      var createdStory = await createResponse.json();
+      var failedUploads = [];
+
+      for (var fileIndex = 0; fileIndex < selectedFiles.length; fileIndex++) {
+        var file = selectedFiles[fileIndex];
+        var mediaType = getMediaType(file);
+        var formData = new FormData();
+
+        setSubmittingState(true, "Uploading " + (fileIndex + 1) + " / " + selectedFiles.length + "...");
+
+        formData.append("file", file);
+        formData.append("media_type", mediaType);
+        formData.append("sort_order", String(fileIndex));
+
+        var uploadResponse = await authFetch(API_BASE + "/stories/" + createdStory.id + "/media", {
+          method: "POST",
+          body: formData
+        });
+
+        if (!uploadResponse.ok) {
+          failedUploads.push(file.name + ": " + await readErrorMessage(uploadResponse, "Upload failed"));
+        }
+      }
+
+      if (failedUploads.length > 0) {
+        successEl.textContent = "Story published, but some media uploads failed.";
+        successEl.classList.remove("hidden");
+        errorEl.textContent = failedUploads.join(" ");
+        errorEl.classList.remove("hidden");
+        return;
+      }
+
+      successEl.textContent = "Story published successfully! Redirecting to the map...";
+      successEl.classList.remove("hidden");
+
+      setTimeout(function () {
+        window.location.assign("map.html");
+      }, 1500);
+    } catch (error) {
+      errorEl.textContent = error && error.message ? error.message : "Failed to publish the story.";
+      errorEl.classList.remove("hidden");
+    } finally {
+      setSubmittingState(false, "Publish Story");
+    }
   });
 
   function syncCreateMapSize() {

--- a/frontend/story-create.html
+++ b/frontend/story-create.html
@@ -62,19 +62,16 @@
 <main class="w-full px-4 py-10 lg:px-8 xl:px-10 2xl:px-14">
   <header class="mb-10 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
     <div>
-      <p class="text-sm font-semibold uppercase tracking-[0.2em] text-primary">Story Creation</p>
-      <h1 class="mt-3 font-headline text-4xl font-extrabold leading-tight text-textmain">Share a piece of local history</h1>
+      <a href="map.html" class="inline-flex items-center gap-2 text-sm font-semibold text-primary hover:underline">
+        <span aria-hidden="true">&larr;</span>
+        Back to map
+      </a>
+      <h1 class="mt-5 font-headline text-4xl font-extrabold leading-tight text-textmain">Share a piece of local history</h1>
       <p class="mt-4 max-w-4xl text-base leading-7 text-textmuted">
         Add a memory, attach media, choose a location, and place your story on the map for others to discover.
       </p>
     </div>
     <div class="flex flex-wrap gap-3">
-      <a href="index.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-surface px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">
-        Login Page
-      </a>
-      <a href="map.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-surface px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">
-        Map Page
-      </a>
       <a href="story-detail.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-surface px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">
         Preview Story Detail
       </a>
@@ -97,8 +94,7 @@
         <!-- Map Placement Section -->
         <section>
           <div>
-            <p class="text-sm font-semibold uppercase tracking-[0.18em] text-primary">Map Placement</p>
-            <h2 class="mt-2 font-headline text-3xl font-bold text-textmain">Choose where the story belongs</h2>
+            <h2 class="font-headline text-3xl font-bold text-textmain">Choose where the story belongs</h2>
             <p class="mt-3 max-w-3xl text-sm leading-7 text-textmuted">
               Search for an address or click directly on the map to pin the story's location.
             </p>
@@ -141,8 +137,8 @@
             <input id="location" type="text" placeholder="Kadikoy, Istanbul" class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary" />
           </div>
           <div>
-            <label for="date-start" class="mb-2 block text-sm font-semibold text-textmain">Date / Year</label>
-            <input id="date-start" type="number" min="1" max="2026" placeholder="e.g. 1987" class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary" />
+            <label for="date-single" class="mb-2 block text-sm font-semibold text-textmain">Date</label>
+            <input id="date-single" type="text" inputmode="numeric" placeholder="mm/dd/yyyy" class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary" />
           </div>
         </div>
 
@@ -150,11 +146,17 @@
         <div>
           <label class="flex items-center gap-3 cursor-pointer">
             <input id="date-range-toggle" type="checkbox" class="rounded border-border text-primary focus:ring-primary" />
-            <span class="text-sm text-textmuted">Specify a date range (e.g. 1965–1985)</span>
+            <span class="text-sm text-textmuted">Specify a date range</span>
           </label>
-          <div id="date-range-end" class="mt-3 hidden">
-            <label for="date-end" class="mb-2 block text-sm font-semibold text-textmain">End Year</label>
-            <input id="date-end" type="number" min="1" max="2026" placeholder="e.g. 1995" class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary" />
+          <div id="date-range-fields" class="mt-3 hidden grid gap-4 md:grid-cols-2">
+            <div>
+              <label for="date-start" class="mb-2 block text-sm font-semibold text-textmain">Start Date</label>
+              <input id="date-start" type="text" inputmode="numeric" placeholder="mm/dd/yyyy" class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary" />
+            </div>
+            <div>
+              <label for="date-end" class="mb-2 block text-sm font-semibold text-textmain">End Date</label>
+              <input id="date-end" type="text" inputmode="numeric" placeholder="mm/dd/yyyy" class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary" />
+            </div>
           </div>
         </div>
 
@@ -343,8 +345,14 @@
   }
 
   // ─── Date Range Toggle ───
+  function isValidDateInput(value) {
+    return /^(0[1-9]|1[0-2])\/(0[1-9]|[12][0-9]|3[01])\/\d{4}$/.test(value);
+  }
+
   document.getElementById("date-range-toggle").addEventListener("change", function () {
-    document.getElementById("date-range-end").classList.toggle("hidden", !this.checked);
+    document.getElementById("date-range-fields").classList.toggle("hidden", !this.checked);
+    document.getElementById("date-single").closest("div").classList.toggle("hidden", this.checked);
+    updateChecklist();
   });
 
   // ─── File Upload Display ───
@@ -366,7 +374,13 @@
     var titleOk = document.getElementById("title").value.trim().length > 0;
     var storyOk = document.getElementById("story").value.trim().length > 0;
     var locationOk = document.getElementById("latitude").value !== "";
-    var dateOk = document.getElementById("date-start").value.trim().length > 0;
+    var dateSingle = document.getElementById("date-single").value.trim();
+    var dateStart = document.getElementById("date-start").value.trim();
+    var dateEnd = document.getElementById("date-end").value.trim();
+    var usingDateRange = document.getElementById("date-range-toggle").checked;
+    var dateOk = usingDateRange
+      ? isValidDateInput(dateStart) && isValidDateInput(dateEnd)
+      : isValidDateInput(dateSingle);
 
     setCheckState("check-title", titleOk);
     setCheckState("check-story", storyOk);
@@ -388,7 +402,7 @@
   }
 
   // Listen for changes to update checklist
-  ["title", "story", "date-start"].forEach(function (id) {
+  ["title", "story", "date-single", "date-start", "date-end"].forEach(function (id) {
     document.getElementById(id).addEventListener("input", updateChecklist);
   });
 
@@ -405,7 +419,10 @@
     var content = document.getElementById("story").value.trim();
     var lat = document.getElementById("latitude").value;
     var lng = document.getElementById("longitude").value;
+    var dateSingle = document.getElementById("date-single").value.trim();
     var dateStart = document.getElementById("date-start").value.trim();
+    var usingDateRange = document.getElementById("date-range-toggle").checked;
+    var dateEnd = document.getElementById("date-end").value.trim();
 
     if (!title || !content) {
       errorEl.textContent = "Please fill in the title and story content.";
@@ -419,8 +436,32 @@
       return;
     }
 
-    if (!dateStart) {
-      errorEl.textContent = "Please provide a date or year for the story.";
+    if (!usingDateRange && !dateSingle) {
+      errorEl.textContent = "Please provide a date in mm/dd/yyyy format.";
+      errorEl.classList.remove("hidden");
+      return;
+    }
+
+    if (!usingDateRange && !isValidDateInput(dateSingle)) {
+      errorEl.textContent = "Date must use mm/dd/yyyy format.";
+      errorEl.classList.remove("hidden");
+      return;
+    }
+
+    if (usingDateRange && (!dateStart || !dateEnd)) {
+      errorEl.textContent = "Please provide both start and end dates.";
+      errorEl.classList.remove("hidden");
+      return;
+    }
+
+    if (usingDateRange && !isValidDateInput(dateStart)) {
+      errorEl.textContent = "Start date must use mm/dd/yyyy format.";
+      errorEl.classList.remove("hidden");
+      return;
+    }
+
+    if (usingDateRange && !isValidDateInput(dateEnd)) {
+      errorEl.textContent = "End date must use mm/dd/yyyy format.";
       errorEl.classList.remove("hidden");
       return;
     }
@@ -432,8 +473,8 @@
       latitude: parseFloat(lat),
       longitude: parseFloat(lng),
       location_name: document.getElementById("location").value.trim(),
-      date_start: parseInt(dateStart),
-      date_end: document.getElementById("date-range-toggle").checked ? parseInt(document.getElementById("date-end").value) : null
+      date_start: usingDateRange ? dateStart : dateSingle,
+      date_end: usingDateRange ? dateEnd : null
     };
 
     console.log("Story payload:", payload);

--- a/frontend/story-create.html
+++ b/frontend/story-create.html
@@ -8,6 +8,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Serif:wght@700;800&display=swap" rel="stylesheet">
+  <!-- Leaflet CSS -->
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
   <script>
     tailwind.config = {
       theme: {
@@ -34,104 +36,413 @@
       }
     };
   </script>
+  <style>
+    .leaflet-container { font-family: "Inter", sans-serif; }
+    .leaflet-control-zoom a {
+      background: rgba(254,249,240,0.9) !important;
+      backdrop-filter: blur(12px);
+      color: #775a19 !important;
+      border: 1px solid #e7e2d9 !important;
+      font-weight: 600;
+    }
+    .leaflet-control-zoom a:hover { background: #ffffff !important; }
+    .leaflet-control-attribution {
+      background: rgba(254,249,240,0.75) !important;
+      font-size: 10px;
+    }
+    #location-search-results {
+      max-height: 200px;
+      overflow-y: auto;
+    }
+    #location-search-results::-webkit-scrollbar { width: 4px; }
+    #location-search-results::-webkit-scrollbar-thumb { background: #c5a059; border-radius: 4px; }
+  </style>
 </head>
 <body class="bg-background text-textmain font-body min-h-screen">
-  <main class="w-full px-4 py-10 lg:px-8 xl:px-10 2xl:px-14">
-    <header class="mb-10 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
-      <div>
-        <p class="text-sm font-semibold uppercase tracking-[0.2em] text-primary">Story Creation</p>
-        <h1 class="mt-3 font-headline text-4xl font-extrabold leading-tight text-textmain">Share a piece of local history</h1>
-        <p class="mt-4 max-w-4xl text-base leading-7 text-textmuted">
-          Add a memory, attach media, choose a location, and place your story on the map for others to discover.
-        </p>
-      </div>
-      <div class="flex flex-wrap gap-3">
-        <a href="index.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-surface px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">
-          Login Page
-        </a>
-        <a href="map.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-surface px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">
-          Map Page
-        </a>
-        <a href="story-detail.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-surface px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">
-          Preview Story Detail
-        </a>
-      </div>
-    </header>
+<main class="w-full px-4 py-10 lg:px-8 xl:px-10 2xl:px-14">
+  <header class="mb-10 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+    <div>
+      <p class="text-sm font-semibold uppercase tracking-[0.2em] text-primary">Story Creation</p>
+      <h1 class="mt-3 font-headline text-4xl font-extrabold leading-tight text-textmain">Share a piece of local history</h1>
+      <p class="mt-4 max-w-4xl text-base leading-7 text-textmuted">
+        Add a memory, attach media, choose a location, and place your story on the map for others to discover.
+      </p>
+    </div>
+    <div class="flex flex-wrap gap-3">
+      <a href="index.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-surface px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">
+        Login Page
+      </a>
+      <a href="map.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-surface px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">
+        Map Page
+      </a>
+      <a href="story-detail.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-surface px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">
+        Preview Story Detail
+      </a>
+    </div>
+  </header>
 
-    <section class="grid gap-8 lg:grid-cols-[minmax(0,2.25fr)_17rem] xl:grid-cols-[minmax(0,2.7fr)_16rem] 2xl:grid-cols-[minmax(0,3fr)_16rem]">
-      <form action="story-detail.html" class="rounded-3xl border border-border bg-surface p-8 shadow-soft">
-        <div class="space-y-6">
+  <section class="grid gap-8 lg:grid-cols-[minmax(0,2.25fr)_17rem] xl:grid-cols-[minmax(0,2.7fr)_16rem] 2xl:grid-cols-[minmax(0,3fr)_16rem]">
+    <form id="story-form" class="rounded-3xl border border-border bg-surface p-8 shadow-soft">
+      <div class="space-y-6">
+        <div>
+          <label for="title" class="mb-2 block text-sm font-semibold text-textmain">Title</label>
+          <input id="title" type="text" placeholder="Give your story a title" required class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary" />
+        </div>
+
+        <div>
+          <label for="story" class="mb-2 block text-sm font-semibold text-textmain">Your Story</label>
+          <textarea id="story" rows="7" placeholder="Write what happened here, who was involved, and why this place matters." required class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm leading-6 focus:border-primary focus:ring-primary"></textarea>
+        </div>
+
+        <!-- Map Placement Section -->
+        <section>
           <div>
-            <label for="title" class="mb-2 block text-sm font-semibold text-textmain">Title</label>
-            <input id="title" type="text" placeholder="Give your story a title" class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary" />
+            <p class="text-sm font-semibold uppercase tracking-[0.18em] text-primary">Map Placement</p>
+            <h2 class="mt-2 font-headline text-3xl font-bold text-textmain">Choose where the story belongs</h2>
+            <p class="mt-3 max-w-3xl text-sm leading-7 text-textmuted">
+              Search for an address or click directly on the map to pin the story's location.
+            </p>
           </div>
 
+          <!-- Location Search -->
+          <div class="mt-4 relative" id="location-search-container">
+            <input
+                    id="location-search"
+                    type="text"
+                    placeholder="Search for an address (e.g. Boğaziçi Üniversitesi)"
+                    autocomplete="off"
+                    class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary"
+            />
+            <div id="location-search-results" class="absolute top-full left-0 right-0 mt-1 bg-white border border-border rounded-xl shadow-soft overflow-hidden hidden z-50"></div>
+          </div>
+
+          <!-- Map -->
+          <div class="mt-4 rounded-[1.75rem] overflow-hidden border border-border/50" style="height: 400px;">
+            <div id="create-map" style="height: 100%; width: 100%;"></div>
+          </div>
+
+          <!-- Selected Location Display -->
+          <div id="selected-location" class="mt-3 hidden">
+            <div class="flex items-center gap-2 rounded-xl bg-[rgba(53,97,143,0.08)] px-4 py-3 text-sm">
+              <span class="text-tertiary font-semibold">📍 Pinned:</span>
+              <span id="selected-location-text" class="text-textmain"></span>
+              <button type="button" id="clear-location" class="ml-auto text-xs text-red-500 hover:underline">Clear</button>
+            </div>
+          </div>
+
+          <!-- Hidden fields for coordinates -->
+          <input type="hidden" id="latitude" name="latitude" />
+          <input type="hidden" id="longitude" name="longitude" />
+        </section>
+
+        <div class="grid gap-6 md:grid-cols-2">
           <div>
-            <label for="story" class="mb-2 block text-sm font-semibold text-textmain">Your Story</label>
-            <textarea id="story" rows="7" placeholder="Write what happened here, who was involved, and why this place matters." class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm leading-6 focus:border-primary focus:ring-primary"></textarea>
+            <label for="location" class="mb-2 block text-sm font-semibold text-textmain">Location Name</label>
+            <input id="location" type="text" placeholder="Kadikoy, Istanbul" class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary" />
           </div>
-
-          <section>
-            <div>
-              <p class="text-sm font-semibold uppercase tracking-[0.18em] text-primary">Map Placement</p>
-              <h2 class="mt-2 font-headline text-3xl font-bold text-textmain">Choose where the story belongs</h2>
-              <p class="mt-3 max-w-3xl text-sm leading-7 text-textmuted">
-                Place the memory on the map before publishing so the story becomes part of the shared city archive.
-              </p>
-            </div>
-            <div class="mt-6 flex h-[24rem] items-center justify-center rounded-[1.75rem] bg-[linear-gradient(135deg,#e7dcc8,#f6f1e8)] text-center text-base text-textmuted lg:h-[32rem]">
-              Interactive map placeholder
-            </div>
-            <div class="mt-4">
-              <a href="map.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-white px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">
-                Open Full Map
-              </a>
-            </div>
-          </section>
-
-          <div class="grid gap-6 md:grid-cols-2">
-            <div>
-              <label for="location" class="mb-2 block text-sm font-semibold text-textmain">Location</label>
-              <input id="location" type="text" placeholder="Kadikoy, Istanbul" class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary" />
-            </div>
-            <div>
-              <label for="date" class="mb-2 block text-sm font-semibold text-textmain">Date</label>
-              <input id="date" type="date" class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary" />
-            </div>
-          </div>
-
           <div>
-            <label class="mb-2 block text-sm font-semibold text-textmain">Media Upload</label>
-            <div class="rounded-2xl border border-dashed border-primary-light bg-[rgba(197,160,89,0.08)] px-6 py-10 text-center">
-              <p class="text-base font-semibold text-primary">Drop photos, videos, or audio here</p>
-              <p class="mt-2 text-sm text-textmuted">Or click to browse files from your device</p>
-              <button type="button" class="mt-5 rounded-xl bg-primary px-5 py-3 text-sm font-semibold text-white transition hover:opacity-95">
-                Choose Files
-              </button>
-            </div>
-          </div>
-
-          <div class="grid gap-4 md:grid-cols-2">
-            <a href="map.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-white px-4 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">
-              Save as Draft
-            </a>
-            <button type="submit" class="rounded-xl bg-primary px-4 py-3 text-sm font-semibold text-white transition hover:opacity-95">
-              Publish Story
-            </button>
+            <label for="date-start" class="mb-2 block text-sm font-semibold text-textmain">Date / Year</label>
+            <input id="date-start" type="number" min="1" max="2026" placeholder="e.g. 1987" class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary" />
           </div>
         </div>
-      </form>
 
-      <aside class="rounded-3xl border border-border bg-[rgba(119,90,25,0.06)] p-6 lg:self-start">
-        <h2 class="font-headline text-xl font-bold text-textmain">Publishing Checklist</h2>
-        <ul class="mt-5 space-y-3 text-sm leading-6 text-textmuted">
-          <li class="rounded-2xl bg-white/80 p-4">Add a title that identifies the place or event.</li>
-          <li class="rounded-2xl bg-white/80 p-4">Explain what happened and why it matters.</li>
-          <li class="rounded-2xl bg-white/80 p-4">Attach media when available.</li>
-          <li class="rounded-2xl bg-white/80 p-4">Confirm the date and location.</li>
-        </ul>
-      </aside>
-    </section>
-  </main>
+        <!-- Date Range Toggle -->
+        <div>
+          <label class="flex items-center gap-3 cursor-pointer">
+            <input id="date-range-toggle" type="checkbox" class="rounded border-border text-primary focus:ring-primary" />
+            <span class="text-sm text-textmuted">Specify a date range (e.g. 1965–1985)</span>
+          </label>
+          <div id="date-range-end" class="mt-3 hidden">
+            <label for="date-end" class="mb-2 block text-sm font-semibold text-textmain">End Year</label>
+            <input id="date-end" type="number" min="1" max="2026" placeholder="e.g. 1995" class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary" />
+          </div>
+        </div>
+
+        <div>
+          <label class="mb-2 block text-sm font-semibold text-textmain">Media Upload</label>
+          <div class="rounded-2xl border border-dashed border-primary-light bg-[rgba(197,160,89,0.08)] px-6 py-10 text-center">
+            <p class="text-base font-semibold text-primary">Drop photos, videos, or audio here</p>
+            <p class="mt-2 text-sm text-textmuted">Or click to browse files from your device</p>
+            <input type="file" id="media-files" multiple accept="image/*,video/*,audio/*" class="hidden" />
+            <button type="button" onclick="document.getElementById('media-files').click()" class="mt-5 rounded-xl bg-primary px-5 py-3 text-sm font-semibold text-white transition hover:opacity-95">
+              Choose Files
+            </button>
+            <div id="file-list" class="mt-4 text-sm text-textmuted"></div>
+          </div>
+        </div>
+
+        <!-- Error / Success Messages -->
+        <div id="form-error" class="hidden rounded-xl bg-red-50 border border-red-200 p-3 text-sm text-red-700"></div>
+        <div id="form-success" class="hidden rounded-xl bg-green-50 border border-green-200 p-3 text-sm text-green-700"></div>
+
+        <div class="grid gap-4 md:grid-cols-2">
+          <button type="button" id="btn-draft" class="inline-flex items-center justify-center rounded-xl border border-border bg-white px-4 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">
+            Save as Draft
+          </button>
+          <button type="submit" class="rounded-xl bg-primary px-4 py-3 text-sm font-semibold text-white transition hover:opacity-95">
+            Publish Story
+          </button>
+        </div>
+      </div>
+    </form>
+
+    <aside class="rounded-3xl border border-border bg-[rgba(119,90,25,0.06)] p-6 lg:self-start">
+      <h2 class="font-headline text-xl font-bold text-textmain">Publishing Checklist</h2>
+      <ul id="checklist" class="mt-5 space-y-3 text-sm leading-6 text-textmuted">
+        <li id="check-title" class="rounded-2xl bg-white/80 p-4 transition-colors">Add a title that identifies the place or event.</li>
+        <li id="check-story" class="rounded-2xl bg-white/80 p-4 transition-colors">Explain what happened and why it matters.</li>
+        <li id="check-location" class="rounded-2xl bg-white/80 p-4 transition-colors">Pin the location on the map.</li>
+        <li id="check-date" class="rounded-2xl bg-white/80 p-4 transition-colors">Confirm the date or year.</li>
+      </ul>
+    </aside>
+  </section>
+</main>
+
+<!-- Leaflet JS -->
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+
+<script>
+  // ─── Map Init ───
+  var createMap = L.map("create-map", {
+    center: [41.015, 28.979],
+    zoom: 12
+  });
+
+  L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+    maxZoom: 19
+  }).addTo(createMap);
+
+  var pinMarker = null;
+
+  function setPin(lat, lng, label) {
+    if (pinMarker) createMap.removeLayer(pinMarker);
+
+    pinMarker = L.marker([lat, lng], {
+      draggable: true
+    }).addTo(createMap);
+
+    pinMarker.on("dragend", function () {
+      var pos = pinMarker.getLatLng();
+      updateLocationFields(pos.lat, pos.lng, null);
+      reverseGeocode(pos.lat, pos.lng);
+    });
+
+    document.getElementById("latitude").value = lat.toFixed(6);
+    document.getElementById("longitude").value = lng.toFixed(6);
+
+    var display = label || (lat.toFixed(4) + ", " + lng.toFixed(4));
+    document.getElementById("selected-location-text").textContent = display;
+    document.getElementById("selected-location").classList.remove("hidden");
+
+    updateChecklist();
+  }
+
+  function updateLocationFields(lat, lng, name) {
+    document.getElementById("latitude").value = lat.toFixed(6);
+    document.getElementById("longitude").value = lng.toFixed(6);
+    if (name) {
+      document.getElementById("location").value = name;
+      document.getElementById("selected-location-text").textContent = name + " (" + lat.toFixed(4) + ", " + lng.toFixed(4) + ")";
+    } else {
+      document.getElementById("selected-location-text").textContent = lat.toFixed(4) + ", " + lng.toFixed(4);
+    }
+    document.getElementById("selected-location").classList.remove("hidden");
+    updateChecklist();
+  }
+
+  // Click on map to pin
+  createMap.on("click", function (e) {
+    setPin(e.latlng.lat, e.latlng.lng, null);
+    reverseGeocode(e.latlng.lat, e.latlng.lng);
+  });
+
+  // Clear location
+  document.getElementById("clear-location").addEventListener("click", function () {
+    if (pinMarker) createMap.removeLayer(pinMarker);
+    pinMarker = null;
+    document.getElementById("latitude").value = "";
+    document.getElementById("longitude").value = "";
+    document.getElementById("location").value = "";
+    document.getElementById("selected-location").classList.add("hidden");
+    updateChecklist();
+  });
+
+  // ─── Geocoding (Nominatim / OpenStreetMap) ───
+  var searchInput = document.getElementById("location-search");
+  var searchResults = document.getElementById("location-search-results");
+  var searchTimeout;
+
+  searchInput.addEventListener("input", function () {
+    clearTimeout(searchTimeout);
+    var query = searchInput.value.trim();
+    if (query.length < 3) {
+      searchResults.classList.add("hidden");
+      return;
+    }
+
+    searchTimeout = setTimeout(function () {
+      fetch("https://nominatim.openstreetmap.org/search?format=json&q=" + encodeURIComponent(query) + "&limit=5&addressdetails=1")
+              .then(function (r) { return r.json(); })
+              .then(function (data) {
+                if (!data.length) {
+                  searchResults.innerHTML = '<div class="px-4 py-3 text-sm text-textmuted">No results found</div>';
+                  searchResults.classList.remove("hidden");
+                  return;
+                }
+
+                searchResults.innerHTML = "";
+                data.forEach(function (item) {
+                  var div = document.createElement("div");
+                  div.className = "px-4 py-3 hover:bg-background cursor-pointer border-b border-border/30 last:border-0 text-sm";
+                  div.textContent = item.display_name;
+                  div.addEventListener("click", function () {
+                    var lat = parseFloat(item.lat);
+                    var lon = parseFloat(item.lon);
+                    createMap.setView([lat, lon], 16);
+                    setPin(lat, lon, item.display_name.split(",").slice(0, 2).join(","));
+                    document.getElementById("location").value = item.display_name.split(",").slice(0, 2).join(",").trim();
+                    searchInput.value = item.display_name.split(",").slice(0, 3).join(",");
+                    searchResults.classList.add("hidden");
+                  });
+                  searchResults.appendChild(div);
+                });
+                searchResults.classList.remove("hidden");
+              })
+              .catch(function () {
+                searchResults.innerHTML = '<div class="px-4 py-3 text-sm text-textmuted">Search unavailable</div>';
+                searchResults.classList.remove("hidden");
+              });
+    }, 400);
+  });
+
+  // Close search dropdown on outside click
+  document.addEventListener("click", function (e) {
+    if (!document.getElementById("location-search-container").contains(e.target)) {
+      searchResults.classList.add("hidden");
+    }
+  });
+
+  // Reverse geocode when clicking on map
+  function reverseGeocode(lat, lng) {
+    fetch("https://nominatim.openstreetmap.org/reverse?format=json&lat=" + lat + "&lon=" + lng + "&zoom=16")
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+              if (data && data.display_name) {
+                var shortName = data.display_name.split(",").slice(0, 3).join(",").trim();
+                var locationName = data.display_name.split(",").slice(0, 2).join(",").trim();
+                document.getElementById("location").value = locationName;
+                document.getElementById("selected-location-text").textContent = shortName + " (" + lat.toFixed(4) + ", " + lng.toFixed(4) + ")";
+              }
+            })
+            .catch(function () { /* silent fail */ });
+  }
+
+  // ─── Date Range Toggle ───
+  document.getElementById("date-range-toggle").addEventListener("change", function () {
+    document.getElementById("date-range-end").classList.toggle("hidden", !this.checked);
+  });
+
+  // ─── File Upload Display ───
+  document.getElementById("media-files").addEventListener("change", function () {
+    var fileList = document.getElementById("file-list");
+    if (this.files.length === 0) {
+      fileList.textContent = "";
+      return;
+    }
+    var names = [];
+    for (var i = 0; i < this.files.length; i++) {
+      names.push(this.files[i].name);
+    }
+    fileList.textContent = names.length + " file(s) selected: " + names.join(", ");
+  });
+
+  // ─── Checklist Updates ───
+  function updateChecklist() {
+    var titleOk = document.getElementById("title").value.trim().length > 0;
+    var storyOk = document.getElementById("story").value.trim().length > 0;
+    var locationOk = document.getElementById("latitude").value !== "";
+    var dateOk = document.getElementById("date-start").value.trim().length > 0;
+
+    setCheckState("check-title", titleOk);
+    setCheckState("check-story", storyOk);
+    setCheckState("check-location", locationOk);
+    setCheckState("check-date", dateOk);
+  }
+
+  function setCheckState(id, done) {
+    var el = document.getElementById(id);
+    if (done) {
+      el.style.background = "rgba(53,97,143,0.1)";
+      el.style.color = "#35618f";
+      el.style.fontWeight = "600";
+    } else {
+      el.style.background = "";
+      el.style.color = "";
+      el.style.fontWeight = "";
+    }
+  }
+
+  // Listen for changes to update checklist
+  ["title", "story", "date-start"].forEach(function (id) {
+    document.getElementById(id).addEventListener("input", updateChecklist);
+  });
+
+  // ─── Form Submission ───
+  document.getElementById("story-form").addEventListener("submit", function (e) {
+    e.preventDefault();
+
+    var errorEl = document.getElementById("form-error");
+    var successEl = document.getElementById("form-success");
+    errorEl.classList.add("hidden");
+    successEl.classList.add("hidden");
+
+    var title = document.getElementById("title").value.trim();
+    var content = document.getElementById("story").value.trim();
+    var lat = document.getElementById("latitude").value;
+    var lng = document.getElementById("longitude").value;
+    var dateStart = document.getElementById("date-start").value.trim();
+
+    if (!title || !content) {
+      errorEl.textContent = "Please fill in the title and story content.";
+      errorEl.classList.remove("hidden");
+      return;
+    }
+
+    if (!lat || !lng) {
+      errorEl.textContent = "Please pin a location on the map.";
+      errorEl.classList.remove("hidden");
+      return;
+    }
+
+    if (!dateStart) {
+      errorEl.textContent = "Please provide a date or year for the story.";
+      errorEl.classList.remove("hidden");
+      return;
+    }
+
+    // In production: POST to /api/stories
+    var payload = {
+      title: title,
+      content: content,
+      latitude: parseFloat(lat),
+      longitude: parseFloat(lng),
+      location_name: document.getElementById("location").value.trim(),
+      date_start: parseInt(dateStart),
+      date_end: document.getElementById("date-range-toggle").checked ? parseInt(document.getElementById("date-end").value) : null
+    };
+
+    console.log("Story payload:", payload);
+    successEl.textContent = "Story published successfully! Redirecting to map...";
+    successEl.classList.remove("hidden");
+
+    setTimeout(function () {
+      window.location.assign("map.html");
+    }, 1500);
+  });
+
+  // Fix Leaflet map rendering when container is initially hidden or laid out
+  setTimeout(function () { createMap.invalidateSize(); }, 200);
+</script>
 </body>
 </html>

--- a/frontend/story-create.html
+++ b/frontend/story-create.html
@@ -117,7 +117,7 @@
           </div>
 
           <!-- Map -->
-          <div class="mt-4 rounded-[1.75rem] overflow-hidden border border-border/50" style="height: 400px;">
+          <div class="mt-4 -mx-8 h-[360px] overflow-hidden border-y border-border/50 sm:mx-0 sm:h-[400px] sm:rounded-[1.75rem] sm:border">
             <div id="create-map" style="height: 100%; width: 100%;"></div>
           </div>
 
@@ -441,8 +441,15 @@
     }, 1500);
   });
 
+  function syncCreateMapSize() {
+    window.requestAnimationFrame(function () {
+      createMap.invalidateSize();
+    });
+  }
+
   // Fix Leaflet map rendering when container is initially hidden or laid out
-  setTimeout(function () { createMap.invalidateSize(); }, 200);
+  setTimeout(syncCreateMapSize, 200);
+  window.addEventListener("resize", syncCreateMapSize);
 </script>
 </body>
 </html>

--- a/frontend/story-detail.html
+++ b/frontend/story-detail.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Local History Map - Story Detail</title>
+  <script src="https://cdn.tailwindcss.com?plugins=forms"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Serif:wght@700;800&display=swap" rel="stylesheet">
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            background: "#fef9f0",
+            surface: "#ffffff",
+            primary: "#775a19",
+            "primary-light": "#c5a059",
+            secondary: "#506169",
+            tertiary: "#35618f",
+            border: "#e7e2d9",
+            textmain: "#1d1c16",
+            textmuted: "#5f584c"
+          },
+          fontFamily: {
+            body: ["Inter", "sans-serif"],
+            headline: ["Noto Serif", "serif"]
+          },
+          boxShadow: {
+            soft: "0 20px 50px rgba(0,0,0,0.08)"
+          }
+        }
+      }
+    };
+  </script>
+</head>
+<body class="bg-background text-textmain font-body min-h-screen">
+  <main class="max-w-6xl mx-auto px-6 py-10 lg:px-10">
+    <header class="mb-8 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+      <div>
+        <p class="text-sm font-semibold uppercase tracking-[0.2em] text-primary">Story Detail</p>
+        <h1 class="mt-3 font-headline text-4xl font-extrabold leading-tight text-textmain">The Old Fisherman's Quarter of Kadikoy</h1>
+        <p class="mt-4 max-w-3xl text-base leading-7 text-textmuted">
+          A remembered shoreline community, carried through family memory, neighborhood ritual, and the changing urban texture of Istanbul.
+        </p>
+      </div>
+      <a href="story-create.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-surface px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">
+        Open Story Creation
+      </a>
+    </header>
+
+    <section class="grid gap-8 lg:grid-cols-[1.4fr_0.8fr]">
+      <article class="overflow-hidden rounded-3xl border border-border bg-surface shadow-soft">
+        <div class="h-72 bg-[url('https://images.unsplash.com/photo-1524231757912-21f4fe3a7200?auto=format&fit=crop&w=1600&q=80')] bg-cover bg-center"></div>
+
+        <div class="p-8">
+          <div class="flex flex-wrap items-center gap-3 text-sm text-textmuted">
+            <span class="rounded-full bg-[rgba(119,90,25,0.1)] px-3 py-1 font-semibold text-primary">Kadikoy, Istanbul</span>
+            <span>1965 - 1985</span>
+            <span>by mehmet_arif</span>
+          </div>
+
+          <div class="mt-6 space-y-5 text-base leading-8 text-textmain">
+            <p>
+              In the narrow streets behind the market, a row of wooden houses once stood where fishermen repaired their nets in the evening. My grandfather was one of them.
+            </p>
+            <p>
+              Before dawn he walked to the pier carrying a worn leather bag, with the smell of salt and diesel filling the air. The neighborhood cats followed his routine as if they had memorized the tides.
+            </p>
+            <p>
+              By the 1980s, most of those houses had been replaced with concrete apartments. Still, one stone fountain survives in the back streets, and for those who know where to look, it is enough to recover the shape of the older quarter.
+            </p>
+          </div>
+
+          <div class="mt-8 grid gap-4 md:grid-cols-3">
+            <div class="rounded-2xl bg-[linear-gradient(135deg,#e9dfcd,#f7f3eb)] p-4 text-center text-sm text-textmuted">Photo Archive</div>
+            <div class="rounded-2xl bg-[linear-gradient(135deg,#e9dfcd,#f7f3eb)] p-4 text-center text-sm text-textmuted">Audio Memory</div>
+            <div class="rounded-2xl bg-[linear-gradient(135deg,#e9dfcd,#f7f3eb)] p-4 text-center text-sm text-textmuted">Street View Reference</div>
+          </div>
+
+          <div class="mt-8 flex flex-wrap gap-3">
+            <button class="rounded-xl bg-primary px-5 py-3 text-sm font-semibold text-white transition hover:opacity-95">Like Story</button>
+            <button class="rounded-xl border border-border bg-white px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">Save for Later</button>
+            <button class="rounded-xl border border-border bg-white px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">Share</button>
+          </div>
+        </div>
+      </article>
+
+      <aside class="space-y-6">
+        <section class="rounded-3xl border border-border bg-surface p-6">
+          <h2 class="font-headline text-2xl font-bold text-textmain">Location</h2>
+          <div class="mt-4 flex h-56 items-center justify-center rounded-2xl bg-[linear-gradient(135deg,#efe7d5,#f8f4ec)] text-center text-sm text-textmuted">
+            Map placeholder for story location
+          </div>
+        </section>
+
+        <section class="rounded-3xl border border-border bg-surface p-6">
+          <h2 class="font-headline text-2xl font-bold text-textmain">Comments</h2>
+          <div class="mt-5 space-y-4">
+            <div class="rounded-2xl bg-[rgba(119,90,25,0.06)] p-4">
+              <p class="text-sm font-semibold text-textmain">ayse_k</p>
+              <p class="mt-2 text-sm leading-6 text-textmuted">My grandmother used to describe the same streets and the cats near the pier. This brought that image back immediately.</p>
+            </div>
+            <div class="rounded-2xl bg-[rgba(53,97,143,0.06)] p-4">
+              <p class="text-sm font-semibold text-textmain">can_photo</p>
+              <p class="mt-2 text-sm leading-6 text-textmuted">I photographed the old fountain last year. The inscription is fading, but it is still visible if you visit in the morning light.</p>
+            </div>
+          </div>
+        </section>
+      </aside>
+    </section>
+  </main>
+</body>
+</html>

--- a/frontend/story-detail.html
+++ b/frontend/story-detail.html
@@ -8,6 +8,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Serif:wght@700;800&display=swap" rel="stylesheet">
+  <!-- Leaflet CSS -->
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
   <script>
     tailwind.config = {
       theme: {
@@ -34,90 +36,128 @@
       }
     };
   </script>
+  <style>
+    .leaflet-container { font-family: "Inter", sans-serif; }
+    .leaflet-control-attribution {
+      background: rgba(254,249,240,0.75) !important;
+      font-size: 10px;
+    }
+  </style>
 </head>
 <body class="bg-background text-textmain font-body min-h-screen">
-  <main class="max-w-6xl mx-auto px-6 py-10 lg:px-10">
-    <header class="mb-8 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-      <div>
-        <p class="text-sm font-semibold uppercase tracking-[0.2em] text-primary">Story Detail</p>
-        <h1 class="mt-3 font-headline text-4xl font-extrabold leading-tight text-textmain">The Old Fisherman's Quarter of Kadikoy</h1>
-        <p class="mt-4 max-w-3xl text-base leading-7 text-textmuted">
-          A remembered shoreline community, carried through family memory, neighborhood ritual, and the changing urban texture of Istanbul.
-        </p>
+<main class="max-w-6xl mx-auto px-6 py-10 lg:px-10">
+  <header class="mb-8 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+    <div>
+      <p class="text-sm font-semibold uppercase tracking-[0.2em] text-primary">Story Detail</p>
+      <h1 class="mt-3 font-headline text-4xl font-extrabold leading-tight text-textmain">The Old Fisherman's Quarter of Kadikoy</h1>
+      <p class="mt-4 max-w-3xl text-base leading-7 text-textmuted">
+        A remembered shoreline community, carried through family memory, neighborhood ritual, and the changing urban texture of Istanbul.
+      </p>
+    </div>
+    <div class="flex flex-wrap gap-3">
+      <a href="index.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-surface px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">
+        Login Page
+      </a>
+      <a href="map.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-surface px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">
+        Map Page
+      </a>
+      <a href="story-create.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-surface px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">
+        Open Story Creation
+      </a>
+    </div>
+  </header>
+
+  <section class="grid gap-8 lg:grid-cols-[1.4fr_0.8fr]">
+    <article class="overflow-hidden rounded-3xl border border-border bg-surface shadow-soft">
+      <div class="h-72 bg-[url('https://images.unsplash.com/photo-1524231757912-21f4fe3a7200?auto=format&fit=crop&w=1600&q=80')] bg-cover bg-center"></div>
+
+      <div class="p-8">
+        <div class="flex flex-wrap items-center gap-3 text-sm text-textmuted">
+          <span class="rounded-full bg-[rgba(119,90,25,0.1)] px-3 py-1 font-semibold text-primary">Kadikoy, Istanbul</span>
+          <span>1965 - 1985</span>
+          <span>by mehmet_arif</span>
+        </div>
+
+        <div class="mt-6 space-y-5 text-base leading-8 text-textmain">
+          <p>
+            In the narrow streets behind the market, a row of wooden houses once stood where fishermen repaired their nets in the evening. My grandfather was one of them.
+          </p>
+          <p>
+            Before dawn he walked to the pier carrying a worn leather bag, with the smell of salt and diesel filling the air. The neighborhood cats followed his routine as if they had memorized the tides.
+          </p>
+          <p>
+            By the 1980s, most of those houses had been replaced with concrete apartments. Still, one stone fountain survives in the back streets, and for those who know where to look, it is enough to recover the shape of the older quarter.
+          </p>
+        </div>
+
+        <div class="mt-8 grid gap-4 md:grid-cols-3">
+          <div class="rounded-2xl bg-[linear-gradient(135deg,#e9dfcd,#f7f3eb)] p-4 text-center text-sm text-textmuted">Photo Archive</div>
+          <div class="rounded-2xl bg-[linear-gradient(135deg,#e9dfcd,#f7f3eb)] p-4 text-center text-sm text-textmuted">Audio Memory</div>
+          <div class="rounded-2xl bg-[linear-gradient(135deg,#e9dfcd,#f7f3eb)] p-4 text-center text-sm text-textmuted">Street View Reference</div>
+        </div>
+
+        <div class="mt-8 flex flex-wrap gap-3">
+          <a href="map.html" class="inline-flex items-center justify-center rounded-xl bg-primary px-5 py-3 text-sm font-semibold text-white transition hover:opacity-95">Back to Map</a>
+          <a href="story-create.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-white px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">Create Another Story</a>
+          <a href="index.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-white px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">Return to Login</a>
+        </div>
       </div>
-      <div class="flex flex-wrap gap-3">
-        <a href="index.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-surface px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">
-          Login Page
-        </a>
-        <a href="map.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-surface px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">
-          Map Page
-        </a>
-        <a href="story-create.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-surface px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">
-          Open Story Creation
-        </a>
-      </div>
-    </header>
+    </article>
 
-    <section class="grid gap-8 lg:grid-cols-[1.4fr_0.8fr]">
-      <article class="overflow-hidden rounded-3xl border border-border bg-surface shadow-soft">
-        <div class="h-72 bg-[url('https://images.unsplash.com/photo-1524231757912-21f4fe3a7200?auto=format&fit=crop&w=1600&q=80')] bg-cover bg-center"></div>
+    <aside class="space-y-6">
+      <section class="rounded-3xl border border-border bg-surface p-6">
+        <h2 class="font-headline text-2xl font-bold text-textmain">Location</h2>
+        <div class="mt-4 rounded-2xl overflow-hidden border border-border/50" style="height: 224px;">
+          <div id="detail-map" style="height: 100%; width: 100%;"></div>
+        </div>
+        <p class="mt-3 text-sm text-textmuted">Kadikoy, Istanbul — <a href="map.html" class="text-primary font-semibold hover:underline">View on full map →</a></p>
+      </section>
 
-        <div class="p-8">
-          <div class="flex flex-wrap items-center gap-3 text-sm text-textmuted">
-            <span class="rounded-full bg-[rgba(119,90,25,0.1)] px-3 py-1 font-semibold text-primary">Kadikoy, Istanbul</span>
-            <span>1965 - 1985</span>
-            <span>by mehmet_arif</span>
+      <section class="rounded-3xl border border-border bg-surface p-6">
+        <h2 class="font-headline text-2xl font-bold text-textmain">Comments</h2>
+        <div class="mt-5 space-y-4">
+          <div class="rounded-2xl bg-[rgba(119,90,25,0.06)] p-4">
+            <p class="text-sm font-semibold text-textmain">ayse_k</p>
+            <p class="mt-2 text-sm leading-6 text-textmuted">My grandmother used to describe the same streets and the cats near the pier. This brought that image back immediately.</p>
           </div>
-
-          <div class="mt-6 space-y-5 text-base leading-8 text-textmain">
-            <p>
-              In the narrow streets behind the market, a row of wooden houses once stood where fishermen repaired their nets in the evening. My grandfather was one of them.
-            </p>
-            <p>
-              Before dawn he walked to the pier carrying a worn leather bag, with the smell of salt and diesel filling the air. The neighborhood cats followed his routine as if they had memorized the tides.
-            </p>
-            <p>
-              By the 1980s, most of those houses had been replaced with concrete apartments. Still, one stone fountain survives in the back streets, and for those who know where to look, it is enough to recover the shape of the older quarter.
-            </p>
-          </div>
-
-          <div class="mt-8 grid gap-4 md:grid-cols-3">
-            <div class="rounded-2xl bg-[linear-gradient(135deg,#e9dfcd,#f7f3eb)] p-4 text-center text-sm text-textmuted">Photo Archive</div>
-            <div class="rounded-2xl bg-[linear-gradient(135deg,#e9dfcd,#f7f3eb)] p-4 text-center text-sm text-textmuted">Audio Memory</div>
-            <div class="rounded-2xl bg-[linear-gradient(135deg,#e9dfcd,#f7f3eb)] p-4 text-center text-sm text-textmuted">Street View Reference</div>
-          </div>
-
-          <div class="mt-8 flex flex-wrap gap-3">
-            <a href="map.html" class="inline-flex items-center justify-center rounded-xl bg-primary px-5 py-3 text-sm font-semibold text-white transition hover:opacity-95">Back to Map</a>
-            <a href="story-create.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-white px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">Create Another Story</a>
-            <a href="index.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-white px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">Return to Login</a>
+          <div class="rounded-2xl bg-[rgba(53,97,143,0.06)] p-4">
+            <p class="text-sm font-semibold text-textmain">can_photo</p>
+            <p class="mt-2 text-sm leading-6 text-textmuted">I photographed the old fountain last year. The inscription is fading, but it is still visible if you visit in the morning light.</p>
           </div>
         </div>
-      </article>
+      </section>
+    </aside>
+  </section>
+</main>
 
-      <aside class="space-y-6">
-        <section class="rounded-3xl border border-border bg-surface p-6">
-          <h2 class="font-headline text-2xl font-bold text-textmain">Location</h2>
-          <div class="mt-4 flex h-56 items-center justify-center rounded-2xl bg-[linear-gradient(135deg,#efe7d5,#f8f4ec)] text-center text-sm text-textmuted">
-            Map placeholder for story location
-          </div>
-        </section>
+<!-- Leaflet JS -->
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 
-        <section class="rounded-3xl border border-border bg-surface p-6">
-          <h2 class="font-headline text-2xl font-bold text-textmain">Comments</h2>
-          <div class="mt-5 space-y-4">
-            <div class="rounded-2xl bg-[rgba(119,90,25,0.06)] p-4">
-              <p class="text-sm font-semibold text-textmain">ayse_k</p>
-              <p class="mt-2 text-sm leading-6 text-textmuted">My grandmother used to describe the same streets and the cats near the pier. This brought that image back immediately.</p>
-            </div>
-            <div class="rounded-2xl bg-[rgba(53,97,143,0.06)] p-4">
-              <p class="text-sm font-semibold text-textmain">can_photo</p>
-              <p class="mt-2 text-sm leading-6 text-textmuted">I photographed the old fountain last year. The inscription is fading, but it is still visible if you visit in the morning light.</p>
-            </div>
-          </div>
-        </section>
-      </aside>
-    </section>
-  </main>
+<script>
+  // Mock story coordinates (in production: parsed from API response or page data)
+  var storyLat = 40.9903;
+  var storyLng = 29.0230;
+  var storyTitle = "The Old Fisherman's Quarter of Kadikoy";
+
+  // Initialize mini-map
+  var detailMap = L.map("detail-map", {
+    center: [storyLat, storyLng],
+    zoom: 15,
+    zoomControl: false,
+    dragging: true,
+    scrollWheelZoom: false
+  });
+
+  L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OSM</a>',
+    maxZoom: 19
+  }).addTo(detailMap);
+
+  // Story marker
+  L.marker([storyLat, storyLng])
+          .addTo(detailMap)
+          .bindPopup('<div style="font-family:Inter,sans-serif;"><strong style="font-size:13px;">' + storyTitle + '</strong><br><span style="font-size:11px;color:#5f584c;">Kadikoy, Istanbul</span></div>')
+          .openPopup();
+</script>
 </body>
 </html>

--- a/frontend/story-detail.html
+++ b/frontend/story-detail.html
@@ -45,9 +45,17 @@
           A remembered shoreline community, carried through family memory, neighborhood ritual, and the changing urban texture of Istanbul.
         </p>
       </div>
-      <a href="story-create.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-surface px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">
-        Open Story Creation
-      </a>
+      <div class="flex flex-wrap gap-3">
+        <a href="index.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-surface px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">
+          Login Page
+        </a>
+        <a href="map.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-surface px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">
+          Map Page
+        </a>
+        <a href="story-create.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-surface px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">
+          Open Story Creation
+        </a>
+      </div>
     </header>
 
     <section class="grid gap-8 lg:grid-cols-[1.4fr_0.8fr]">
@@ -80,9 +88,9 @@
           </div>
 
           <div class="mt-8 flex flex-wrap gap-3">
-            <button class="rounded-xl bg-primary px-5 py-3 text-sm font-semibold text-white transition hover:opacity-95">Like Story</button>
-            <button class="rounded-xl border border-border bg-white px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">Save for Later</button>
-            <button class="rounded-xl border border-border bg-white px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">Share</button>
+            <a href="map.html" class="inline-flex items-center justify-center rounded-xl bg-primary px-5 py-3 text-sm font-semibold text-white transition hover:opacity-95">Back to Map</a>
+            <a href="story-create.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-white px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">Create Another Story</a>
+            <a href="index.html" class="inline-flex items-center justify-center rounded-xl border border-border bg-white px-5 py-3 text-sm font-semibold text-textmain transition hover:bg-stone-50">Return to Login</a>
           </div>
         </div>
       </article>

--- a/frontend/story-detail.html
+++ b/frontend/story-detail.html
@@ -49,9 +49,8 @@
   <header class="mb-8 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
     <div>
       <p class="text-sm font-semibold uppercase tracking-[0.2em] text-primary">Story Detail</p>
-      <h1 class="mt-3 font-headline text-4xl font-extrabold leading-tight text-textmain">The Old Fisherman's Quarter of Kadikoy</h1>
-      <p class="mt-4 max-w-3xl text-base leading-7 text-textmuted">
-        A remembered shoreline community, carried through family memory, neighborhood ritual, and the changing urban texture of Istanbul.
+      <h1 id="story-title" class="mt-3 font-headline text-4xl font-extrabold leading-tight text-textmain">Loading Story...</h1>
+      <p id="story-summary" class="mt-4 max-w-3xl text-base leading-7 text-textmuted italic">
       </p>
     </div>
     <div class="flex flex-wrap gap-3">
@@ -69,31 +68,21 @@
 
   <section class="grid gap-8 lg:grid-cols-[1.4fr_0.8fr]">
     <article class="overflow-hidden rounded-3xl border border-border bg-surface shadow-soft">
-      <div class="h-72 bg-[url('https://images.unsplash.com/photo-1524231757912-21f4fe3a7200?auto=format&fit=crop&w=1600&q=80')] bg-cover bg-center"></div>
+      <div id="story-cover" class="h-72 bg-[url('https://images.unsplash.com/photo-1524231757912-21f4fe3a7200?auto=format&fit=crop&w=1600&q=80')] bg-cover bg-center"></div>
 
       <div class="p-8">
         <div class="flex flex-wrap items-center gap-3 text-sm text-textmuted">
-          <span class="rounded-full bg-[rgba(119,90,25,0.1)] px-3 py-1 font-semibold text-primary">Kadikoy, Istanbul</span>
-          <span>1965 - 1985</span>
-          <span>by mehmet_arif</span>
+          <span id="story-location" class="rounded-full bg-[rgba(119,90,25,0.1)] px-3 py-1 font-semibold text-primary">Map Reference</span>
+          <span id="story-date">Date Unknown</span>
+          <span id="story-author">by Author</span>
         </div>
 
-        <div class="mt-6 space-y-5 text-base leading-8 text-textmain">
-          <p>
-            In the narrow streets behind the market, a row of wooden houses once stood where fishermen repaired their nets in the evening. My grandfather was one of them.
-          </p>
-          <p>
-            Before dawn he walked to the pier carrying a worn leather bag, with the smell of salt and diesel filling the air. The neighborhood cats followed his routine as if they had memorized the tides.
-          </p>
-          <p>
-            By the 1980s, most of those houses had been replaced with concrete apartments. Still, one stone fountain survives in the back streets, and for those who know where to look, it is enough to recover the shape of the older quarter.
-          </p>
+        <div id="story-content" class="mt-6 space-y-5 text-base leading-8 text-textmain whitespace-pre-wrap">
+          <!-- Content injected via JS -->
         </div>
 
-        <div class="mt-8 grid gap-4 md:grid-cols-3">
-          <div class="rounded-2xl bg-[linear-gradient(135deg,#e9dfcd,#f7f3eb)] p-4 text-center text-sm text-textmuted">Photo Archive</div>
-          <div class="rounded-2xl bg-[linear-gradient(135deg,#e9dfcd,#f7f3eb)] p-4 text-center text-sm text-textmuted">Audio Memory</div>
-          <div class="rounded-2xl bg-[linear-gradient(135deg,#e9dfcd,#f7f3eb)] p-4 text-center text-sm text-textmuted">Street View Reference</div>
+        <div id="story-media" class="mt-8 grid gap-4 grid-cols-1 md:grid-cols-2">
+          <!-- Media injected via JS -->
         </div>
 
         <div class="mt-8 flex flex-wrap gap-3">
@@ -133,15 +122,11 @@
 <!-- Leaflet JS -->
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 
+<script src="config.js"></script>
 <script>
-  // Mock story coordinates (in production: parsed from API response or page data)
-  var storyLat = 40.9903;
-  var storyLng = 29.0230;
-  var storyTitle = "The Old Fisherman's Quarter of Kadikoy";
-
-  // Initialize mini-map
+  // Initialize mini-map with arbitrary center initially
   var detailMap = L.map("detail-map", {
-    center: [storyLat, storyLng],
+    center: [41.015, 28.979],
     zoom: 15,
     zoomControl: false,
     dragging: true,
@@ -153,11 +138,58 @@
     maxZoom: 19
   }).addTo(detailMap);
 
-  // Story marker
-  L.marker([storyLat, storyLng])
-          .addTo(detailMap)
-          .bindPopup('<div style="font-family:Inter,sans-serif;"><strong style="font-size:13px;">' + storyTitle + '</strong><br><span style="font-size:11px;color:#5f584c;">Kadikoy, Istanbul</span></div>')
-          .openPopup();
+  const urlParams = new URLSearchParams(window.location.search);
+  const storyId = urlParams.get('id');
+  
+  if (!storyId) {
+    document.getElementById('story-title').textContent = "Story not found";
+    document.getElementById('story-summary').textContent = "No ID provided in the URL.";
+  } else {
+    fetch(API_BASE + "/stories/" + storyId)
+      .then(res => res.json())
+      .then(story => {
+          document.getElementById('story-title').textContent = story.title || "Untitled";
+          document.getElementById('story-summary').textContent = story.summary || "";
+          document.getElementById('story-author').innerHTML = 'by ' + (story.author || "Unknown");
+          document.getElementById('story-date').textContent = story.date_label || "No Date";
+          document.getElementById('story-location').textContent = story.place_name || "Istanbul";
+          document.getElementById('story-content').textContent = story.content || "No content available.";
+          
+          if (story.latitude && story.longitude) {
+            detailMap.setView([story.latitude, story.longitude], 15);
+            L.marker([story.latitude, story.longitude])
+              .addTo(detailMap)
+              .bindPopup('<div style="font-family:Inter,sans-serif;"><strong style="font-size:13px;">' + story.title + '</strong><br><span style="font-size:11px;color:#5f584c;">' + (story.place_name || "") + '</span></div>')
+              .openPopup();
+          } else {
+             document.getElementById('detail-map').parentElement.style.display = 'none';
+          }
+          
+          if (story.media_files && story.media_files.length > 0) {
+             const images = story.media_files.filter(m => m.media_type === "image");
+             if (images.length > 0) {
+                 document.getElementById('story-cover').style.backgroundImage = "url('" + images[0].media_url + "')";
+             }
+             
+             let mediaHtml = "";
+             story.media_files.forEach(m => {
+                 if (m.media_type === "image") {
+                     mediaHtml += '<img src="' + m.media_url + '" class="w-full rounded-2xl border border-border shadow-sm object-cover" style="max-height: 300px;">';
+                 } else if (m.media_type === "video") {
+                     mediaHtml += '<video src="' + m.media_url + '" controls class="w-full rounded-2xl border border-border shadow-sm object-cover" style="max-height: 300px;"></video>';
+                 } else if (m.media_type === "audio") {
+                     mediaHtml += '<div class="p-4 bg-background border border-border rounded-xl w-full flex flex-col gap-2"><span class="text-sm font-semibold material-symbols-outlined text-primary">audio</span><audio src="' + m.media_url + '" controls class="w-full"></audio></div>';
+                 }
+             });
+             document.getElementById('story-media').innerHTML = mediaHtml;
+          }
+      })
+      .catch(err => {
+         console.error("Error loading story details:", err);
+         document.getElementById('story-title').textContent = "Failed to load story";
+         document.getElementById('story-summary').textContent = "There was a problem communicating with the server.";
+      });
+  }
 </script>
 </body>
 </html>


### PR DESCRIPTION
 Summary

  - Create dedicated search.html page that queries GET /stories/search?place_name= endpoint
  - Fetch full story details including media files via GET /stories/{id} for each search result
  - Cache all fetched story details client-side to avoid redundant API calls
  - Replace client-side-only search filtering in map.html with a form that navigates to the new search page

  Test plan

  - Navigate to map page and type a place name in the search bar, press Enter — should redirect to search.html?q=<query>
  - Verify search results display with title, author, place name, date label, and content preview
  - Verify story cover images load from media files when available
  - Click a search result card — should navigate to story-detail.html?id=<id>
  - Search for a non-existent place — should show "No stories found" empty state
  - Verify the back arrow on search page returns to map