### PR TITLE
CI Lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,54 @@ on:
   pull_request:
 
 jobs:
-  # ── 0. HEALTH CHECK ──────────────────────────────────────────────────────────
+  # ── 0a. LINT & FORMAT ───────────────────────────────────────────────────────
+
+  backend-lint:
+    name: Backend Lint & Format Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install ruff
+        run: pip install ruff
+
+      - name: Run ruff linter
+        working-directory: backend
+        run: ruff check .
+
+      - name: Run ruff format check
+        working-directory: backend
+        run: ruff format --check .
+
+  frontend-lint:
+    name: Frontend Lint Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Run ESLint
+        working-directory: frontend
+        run: npm run lint
+
+  # ── 0b. HEALTH CHECK ────────────────────────────────────────────────────────
 
   backend-health:
     name: Backend Health Check
@@ -83,7 +130,7 @@ jobs:
   backend-unit:
     name: Backend Unit Tests
     runs-on: ubuntu-latest
-    needs: [backend-health]
+    needs: [backend-health, backend-lint]
 
     steps:
       - name: Checkout code
@@ -116,6 +163,7 @@ jobs:
   frontend-unit:
     name: Frontend Unit Tests
     runs-on: ubuntu-latest
+    needs: [frontend-lint]
 
     steps:
       - name: Checkout code

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -5,7 +5,6 @@ from sqlalchemy import pool
 from sqlalchemy.ext.asyncio import create_async_engine
 
 from alembic import context
-
 from app.core.config import settings
 from app.db.base import Base  # noqa: F401 — import all models here so autogenerate sees them
 from app.db.media_file import MediaFile  # noqa: F401
@@ -19,9 +18,7 @@ if config.config_file_name is not None:
 
 target_metadata = Base.metadata
 
-_url = settings.DATABASE_URL.replace(
-    "postgresql://", "postgresql+asyncpg://", 1
-).replace(
+_url = settings.DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://", 1).replace(
     "postgres://", "postgresql+asyncpg://", 1
 )
 

--- a/backend/alembic/versions/20260402_0001_create_core_schema.py
+++ b/backend/alembic/versions/20260402_0001_create_core_schema.py
@@ -7,10 +7,10 @@ Create Date: 2026-04-02 00:01:00
 
 from typing import Sequence, Union
 
-from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "20260402_0001"

--- a/backend/alembic/versions/20260403_0002_add_location_and_date_to_stories.py
+++ b/backend/alembic/versions/20260403_0002_add_location_and_date_to_stories.py
@@ -7,9 +7,9 @@ Create Date: 2026-04-03 00:00:00
 
 from typing import Sequence, Union
 
-from alembic import op
 import sqlalchemy as sa
 
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "20260403_0002"

--- a/backend/alembic/versions/20260407_0003_convert_story_dates_to_date_range.py
+++ b/backend/alembic/versions/20260407_0003_convert_story_dates_to_date_range.py
@@ -7,9 +7,9 @@ Create Date: 2026-04-07 00:00:00
 
 from typing import Sequence, Union
 
-from alembic import op
 import sqlalchemy as sa
 
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "20260407_0003"

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -18,8 +18,7 @@ elif _raw_url.startswith("postgres://"):
     _url = _raw_url.replace("postgres://", "postgresql+asyncpg://", 1)
 else:
     raise ValueError(
-        f"DATABASE_URL has an unexpected scheme. "
-        f"Expected postgresql:// or postgres://, got: {_raw_url[:30]!r}"
+        f"DATABASE_URL has an unexpected scheme. Expected postgresql:// or postgres://, got: {_raw_url[:30]!r}"
     )
 
 # SQL query logging
@@ -32,9 +31,7 @@ if settings.LOG_SQL:
     _log_path = Path(__file__).resolve().parents[3] / "logs" / "sql.log"
     _log_path.parent.mkdir(exist_ok=True)
 
-    _handler = logging.handlers.RotatingFileHandler(
-        _log_path, maxBytes=5 * 1024 * 1024, backupCount=3
-    )
+    _handler = logging.handlers.RotatingFileHandler(_log_path, maxBytes=5 * 1024 * 1024, backupCount=3)
     _handler.setFormatter(logging.Formatter("%(asctime)s %(message)s"))
 
     _sql_logger = logging.getLogger("sqlalchemy.engine")

--- a/backend/app/models/story.py
+++ b/backend/app/models/story.py
@@ -105,9 +105,7 @@ class StoryBoundsFilter(BaseModel):
         provided_count = sum(v is not None for v in values)
 
         if provided_count not in (0, 4):
-            raise ValueError(
-                "min_lat, max_lat, min_lng, max_lng must be provided together"
-            )
+            raise ValueError("min_lat, max_lat, min_lng, max_lng must be provided together")
 
         if provided_count == 4:
             if self.min_lat > self.max_lat:
@@ -167,11 +165,7 @@ class StoryResponse(BaseModel):
             else:
                 date_label = f"{date_start.isoformat()} - {date_end.isoformat()}"
         elif date_start:
-            date_label = (
-                str(date_start.year)
-                if date_precision == DatePrecision.YEAR
-                else date_start.isoformat()
-            )
+            date_label = str(date_start.year) if date_precision == DatePrecision.YEAR else date_start.isoformat()
         else:
             date_label = None
 

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -25,16 +25,13 @@ class UserRegisterRequest(BaseModel):
         if not any(c in "!@#$%^&*()-_=+[]{}|;:',.<>?/`~" for c in v):
             errors.append("one special character")
         if errors:
-            raise ValueError(
-                "Password must contain at least: " + ", ".join(errors)
-            )
+            raise ValueError("Password must contain at least: " + ", ".join(errors))
         return v
 
 
 class UserLoginRequest(BaseModel):
     email: EmailStr
     password: str
-
 
 
 class UserResponse(BaseModel):
@@ -51,4 +48,3 @@ class UserResponse(BaseModel):
 class TokenResponse(BaseModel):
     access_token: str
     token_type: str = "bearer"
-

--- a/backend/app/routers/story.py
+++ b/backend/app/routers/story.py
@@ -1,7 +1,6 @@
 import uuid
 
-from fastapi import APIRouter, Depends, File, Form, Query, UploadFile, status
-from fastapi import HTTPException
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile, status
 from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -13,8 +12,8 @@ from app.models.story import (
     MediaUploadRequest,
     MediaUploadResponse,
     StoryBoundsFilter,
-    StoryDateRangeFilter,
     StoryCreateRequest,
+    StoryDateRangeFilter,
     StoryDetailResponse,
     StoryListResponse,
     StoryUpdateRequest,

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -32,9 +32,7 @@ def create_access_token(user: User) -> str:
     return jwt.encode(payload, settings.JWT_SECRET_KEY, algorithm=settings.JWT_ALGORITHM)
 
 
-async def register_user(
-    db: AsyncSession, payload: UserRegisterRequest
-) -> UserResponse:
+async def register_user(db: AsyncSession, payload: UserRegisterRequest) -> UserResponse:
     email = payload.email.strip().lower()
     username = payload.username.strip()
 
@@ -67,9 +65,7 @@ async def register_user(
     return UserResponse.model_validate(user)
 
 
-async def login_user(
-    db: AsyncSession, payload: UserLoginRequest
-) -> TokenResponse:
+async def login_user(db: AsyncSession, payload: UserLoginRequest) -> TokenResponse:
     email = payload.email.strip().lower()
 
     result = await db.execute(select(User).where(User.email == email))

--- a/backend/app/services/storage.py
+++ b/backend/app/services/storage.py
@@ -1,6 +1,7 @@
+from urllib.parse import quote
+
 import boto3
 from botocore.config import Config
-from urllib.parse import quote
 
 from app.core.config import settings
 from app.db.enums import MediaType

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -44,10 +44,7 @@ ALLOWED_MIME_TYPES = {
 
 
 def _map_story_rows(rows: list[tuple[Story, str]]) -> StoryListResponse:
-    stories = [
-        StoryResponse.from_orm_with_author(story, author_username)
-        for story, author_username in rows
-    ]
+    stories = [StoryResponse.from_orm_with_author(story, author_username) for story, author_username in rows]
     return StoryListResponse(stories=stories, total=len(stories))
 
 
@@ -95,10 +92,7 @@ def _validate_media_upload(file: UploadFile, payload: MediaUploadRequest) -> Non
     if file.content_type not in allowed_for_type:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=(
-                f"Unsupported mime type '{file.content_type}' for media type "
-                f"'{payload.media_type.value}'"
-            ),
+            detail=(f"Unsupported mime type '{file.content_type}' for media type '{payload.media_type.value}'"),
         )
 
 
@@ -217,9 +211,7 @@ async def create_story_with_location(
             detail="place_name is required for story location binding",
         )
 
-    normalized_date_start, normalized_date_end, normalized_date_precision = (
-        payload.normalize_date_range()
-    )
+    normalized_date_start, normalized_date_end, normalized_date_precision = payload.normalize_date_range()
 
     story = Story(
         user_id=current_user.id,
@@ -250,9 +242,7 @@ async def update_story_with_location_and_dates(
     current_user: User,
     payload: StoryUpdateRequest,
 ) -> StoryDetailResponse:
-    story_result = await db.execute(
-        select(Story).where(Story.id == story_id, Story.user_id == current_user.id)
-    )
+    story_result = await db.execute(select(Story).where(Story.id == story_id, Story.user_id == current_user.id))
     story = story_result.scalar_one_or_none()
     if story is None:
         raise HTTPException(
@@ -267,9 +257,7 @@ async def update_story_with_location_and_dates(
             detail="place_name is required for story location binding",
         )
 
-    normalized_date_start, normalized_date_end, normalized_date_precision = (
-        payload.normalize_date_range()
-    )
+    normalized_date_start, normalized_date_end, normalized_date_precision = payload.normalize_date_range()
 
     story.title = payload.title
     story.summary = payload.summary

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -23,3 +23,6 @@ python-multipart
 
 # Object storage (S3-compatible — works with MinIO locally and Supabase Storage in prod)
 boto3
+
+# Linting & formatting
+ruff

--- a/backend/ruff.toml
+++ b/backend/ruff.toml
@@ -1,0 +1,16 @@
+target-version = "py311"
+line-length = 120
+
+[lint]
+select = [
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # pyflakes
+    "I",   # isort (import ordering)
+]
+ignore = [
+    "E501", # line too long — handled by formatter
+]
+
+[lint.isort]
+known-first-party = ["app"]

--- a/backend/tests/api/test_auth_api.py
+++ b/backend/tests/api/test_auth_api.py
@@ -73,24 +73,33 @@ class TestRegistrationAPI:
 
     async def test_register_missing_fields(self, client):
         # Missing username
-        resp = await client.post("/auth/register", json={
-            "email": "missing@example.com",
-            "password": "ApiPass1!",
-        })
+        resp = await client.post(
+            "/auth/register",
+            json={
+                "email": "missing@example.com",
+                "password": "ApiPass1!",
+            },
+        )
         assert resp.status_code == 422
 
         # Missing email
-        resp = await client.post("/auth/register", json={
-            "username": "missingmail",
-            "password": "ApiPass1!",
-        })
+        resp = await client.post(
+            "/auth/register",
+            json={
+                "username": "missingmail",
+                "password": "ApiPass1!",
+            },
+        )
         assert resp.status_code == 422
 
         # Missing password
-        resp = await client.post("/auth/register", json={
-            "username": "misspwd",
-            "email": "misspwd@example.com",
-        })
+        resp = await client.post(
+            "/auth/register",
+            json={
+                "username": "misspwd",
+                "email": "misspwd@example.com",
+            },
+        )
         assert resp.status_code == 422
 
 
@@ -143,15 +152,21 @@ class TestLoginAPI:
 
     async def test_login_missing_fields(self, client):
         # Missing email
-        resp = await client.post("/auth/login", json={
-            "password": "AnyPass1!",
-        })
+        resp = await client.post(
+            "/auth/login",
+            json={
+                "password": "AnyPass1!",
+            },
+        )
         assert resp.status_code == 422
 
         # Missing password
-        resp = await client.post("/auth/login", json={
-            "email": "some@example.com",
-        })
+        resp = await client.post(
+            "/auth/login",
+            json={
+                "email": "some@example.com",
+            },
+        )
         assert resp.status_code == 422
 
 
@@ -175,9 +190,7 @@ class TestTokenVerificationAPI:
         )
         token = login_resp.json()["access_token"]
 
-        resp = await client.get(
-            "/auth/me", headers={"Authorization": f"Bearer {token}"}
-        )
+        resp = await client.get("/auth/me", headers={"Authorization": f"Bearer {token}"})
         assert resp.status_code == 200
         data = resp.json()
         assert data["username"] == "meuser"
@@ -188,14 +201,14 @@ class TestTokenVerificationAPI:
         assert resp.status_code == 401 or resp.status_code == 403
 
     async def test_me_with_invalid_token(self, client):
-        resp = await client.get(
-            "/auth/me", headers={"Authorization": "Bearer invalid.token.here"}
-        )
+        resp = await client.get("/auth/me", headers={"Authorization": "Bearer invalid.token.here"})
         assert resp.status_code == 401
 
     async def test_me_with_expired_token(self, client):
-        import jwt
         from datetime import datetime, timedelta, timezone
+
+        import jwt
+
         from app.core.config import settings
 
         expired_payload = {
@@ -204,10 +217,6 @@ class TestTokenVerificationAPI:
             "role": "user",
             "exp": datetime.now(timezone.utc) - timedelta(hours=1),
         }
-        expired_token = jwt.encode(
-            expired_payload, settings.JWT_SECRET_KEY, algorithm=settings.JWT_ALGORITHM
-        )
-        resp = await client.get(
-            "/auth/me", headers={"Authorization": f"Bearer {expired_token}"}
-        )
+        expired_token = jwt.encode(expired_payload, settings.JWT_SECRET_KEY, algorithm=settings.JWT_ALGORITHM)
+        resp = await client.get("/auth/me", headers={"Authorization": f"Bearer {expired_token}"})
         assert resp.status_code == 401

--- a/backend/tests/api/test_story_api.py
+++ b/backend/tests/api/test_story_api.py
@@ -1,6 +1,7 @@
-import pytest
 import uuid
 from datetime import date
+
+import pytest
 
 from app.db.enums import DatePrecision, MediaType, StoryStatus, StoryVisibility
 from app.db.media_file import MediaFile
@@ -122,9 +123,7 @@ class TestStoryListingAPI:
         db_session.add_all([in_bounds_story, out_bounds_story, null_coord_story])
         await db_session.commit()
 
-        resp = await client.get(
-            "/stories?min_lat=40.9&max_lat=41.1&min_lng=28.9&max_lng=29.1"
-        )
+        resp = await client.get("/stories?min_lat=40.9&max_lat=41.1&min_lng=28.9&max_lng=29.1")
 
         assert resp.status_code == 200
         data = resp.json()
@@ -172,9 +171,7 @@ class TestStoryListingAPI:
         db_session.add_all([in_range_story, out_range_story])
         await db_session.commit()
 
-        resp = await client.get(
-            "/stories?query_start=2025-08-01&query_end=2025-08-31&query_precision=date"
-        )
+        resp = await client.get("/stories?query_start=2025-08-01&query_end=2025-08-31&query_precision=date")
 
         assert resp.status_code == 200
         data = resp.json()
@@ -187,9 +184,7 @@ class TestStoryListingAPI:
         assert resp.status_code == 422
 
     async def test_list_stories_with_invalid_bounds_order_returns_422(self, client):
-        resp = await client.get(
-            "/stories?min_lat=41.1&max_lat=40.9&min_lng=28.9&max_lng=29.1"
-        )
+        resp = await client.get("/stories?min_lat=41.1&max_lat=40.9&min_lng=28.9&max_lng=29.1")
 
         assert resp.status_code == 422
 
@@ -264,7 +259,7 @@ class TestStoryMediaUploadAPI:
         assert "id" in media
         assert "storage_key" in media
         assert "bucket_name" in media
-        assert media["media_url"].endswith(f'/{media["bucket_name"]}/{media["storage_key"]}')
+        assert media["media_url"].endswith(f"/{media['bucket_name']}/{media['storage_key']}")
         assert "created_at" in media
 
     async def test_upload_media_invalid_mime_type(self, client, db_session, monkeypatch):

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -6,13 +6,12 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 
 from app.core.config import settings
 from app.db.base import Base
+from app.db.media_file import MediaFile  # noqa: F401
 from app.db.session import get_db
+from app.db.story import Story  # noqa: F401
 
 # Import all models so Base.metadata knows about them
 from app.db.user import User  # noqa: F401
-from app.db.story import Story  # noqa: F401
-from app.db.media_file import MediaFile  # noqa: F401
-
 
 # Build the async DB URL
 _url = settings.DATABASE_URL
@@ -33,9 +32,7 @@ async def db_session():
         await conn.run_sync(Base.metadata.drop_all)
         await conn.run_sync(Base.metadata.create_all)
 
-    session_factory = async_sessionmaker(
-        bind=engine, class_=AsyncSession, expire_on_commit=False
-    )
+    session_factory = async_sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
     session = session_factory()
 
     yield session
@@ -54,6 +51,7 @@ async def client(db_session):
 
     # Override storage check so tests don't need MinIO
     from app.services import storage
+
     original_check = storage.check_connection
     storage.check_connection = MagicMock()
 

--- a/backend/tests/factories/user_factory.py
+++ b/backend/tests/factories/user_factory.py
@@ -2,7 +2,6 @@ from app.db.enums import UserRole
 from app.db.user import User
 from app.services.auth_service import hash_password
 
-
 DEFAULT_USERNAME = "testuser"
 DEFAULT_EMAIL = "test@example.com"
 DEFAULT_PASSWORD = "ValidPass1!"

--- a/backend/tests/integration/test_auth_flow.py
+++ b/backend/tests/integration/test_auth_flow.py
@@ -1,5 +1,4 @@
 import pytest
-import pytest_asyncio
 from sqlalchemy import select
 
 from app.db.user import User
@@ -23,17 +22,13 @@ class TestRegisterAndLoginFlow:
         assert user_resp.email == "flow@example.com"
 
         # Verify password stored as hash
-        result = await db_session.execute(
-            select(User).where(User.email == "flow@example.com")
-        )
+        result = await db_session.execute(select(User).where(User.email == "flow@example.com"))
         db_user = result.scalar_one()
         assert db_user.password_hash != "FlowPass1!"
         assert verify_password("FlowPass1!", db_user.password_hash) is True
 
         # Login
-        login_payload = UserLoginRequest(
-            email="flow@example.com", password="FlowPass1!"
-        )
+        login_payload = UserLoginRequest(email="flow@example.com", password="FlowPass1!")
         token_resp = await login_user(db_session, login_payload)
         assert token_resp.access_token is not None
         assert token_resp.token_type == "bearer"
@@ -66,9 +61,7 @@ class TestDuplicateEmailRejection:
         # Confirm no duplicate user record was created
         from sqlalchemy import func
 
-        count = await db_session.execute(
-            select(func.count()).where(User.email == "dupe@example.com")
-        )
+        count = await db_session.execute(select(func.count()).where(User.email == "dupe@example.com"))
         assert count.scalar_one() == 1
 
 
@@ -87,9 +80,7 @@ class TestInvalidCredentialsRejection:
         from fastapi import HTTPException
 
         with pytest.raises(HTTPException) as exc_info:
-            login_payload = UserLoginRequest(
-                email="cred@example.com", password="WrongPass1!"
-            )
+            login_payload = UserLoginRequest(email="cred@example.com", password="WrongPass1!")
             await login_user(db_session, login_payload)
         assert exc_info.value.status_code == 401
 
@@ -97,8 +88,6 @@ class TestInvalidCredentialsRejection:
         from fastapi import HTTPException
 
         with pytest.raises(HTTPException) as exc_info:
-            login_payload = UserLoginRequest(
-                email="nobody@example.com", password="AnyPass1!"
-            )
+            login_payload = UserLoginRequest(email="nobody@example.com", password="AnyPass1!")
             await login_user(db_session, login_payload)
         assert exc_info.value.status_code == 401

--- a/backend/tests/integration/test_story_time_filter_flow.py
+++ b/backend/tests/integration/test_story_time_filter_flow.py
@@ -40,9 +40,7 @@ class TestStoryTimeOverlapFlow:
         )
         assert create_resp.status_code == 201
 
-        list_resp = await client.get(
-            "/stories?query_start=2025-08-01&query_end=2025-08-31&query_precision=date"
-        )
+        list_resp = await client.get("/stories?query_start=2025-08-01&query_end=2025-08-31&query_precision=date")
 
         assert list_resp.status_code == 200
         payload = list_resp.json()

--- a/backend/tests/unit/test_jwt.py
+++ b/backend/tests/unit/test_jwt.py
@@ -37,9 +37,7 @@ class TestJWTTokenCreation:
     def test_token_contains_correct_claims(self):
         user = self._make_mock_user()
         token = create_access_token(user)
-        payload = jwt.decode(
-            token, settings.JWT_SECRET_KEY, algorithms=[settings.JWT_ALGORITHM]
-        )
+        payload = jwt.decode(token, settings.JWT_SECRET_KEY, algorithms=[settings.JWT_ALGORITHM])
         assert payload["sub"] == str(user.id)
         assert payload["email"] == "test@example.com"
         assert payload["role"] == "user"
@@ -48,9 +46,7 @@ class TestJWTTokenCreation:
     def test_token_has_expiration(self):
         user = self._make_mock_user()
         token = create_access_token(user)
-        payload = jwt.decode(
-            token, settings.JWT_SECRET_KEY, algorithms=[settings.JWT_ALGORITHM]
-        )
+        payload = jwt.decode(token, settings.JWT_SECRET_KEY, algorithms=[settings.JWT_ALGORITHM])
         exp = datetime.fromtimestamp(payload["exp"], tz=timezone.utc)
         now = datetime.now(timezone.utc)
         assert exp > now
@@ -60,9 +56,7 @@ class TestJWTTokenCreation:
         user = self._make_mock_user()
         token = create_access_token(user)
         # Should not raise
-        jwt.decode(
-            token, settings.JWT_SECRET_KEY, algorithms=[settings.JWT_ALGORITHM]
-        )
+        jwt.decode(token, settings.JWT_SECRET_KEY, algorithms=[settings.JWT_ALGORITHM])
 
     def test_token_fails_with_wrong_secret(self):
         user = self._make_mock_user()
@@ -73,8 +67,6 @@ class TestJWTTokenCreation:
     def test_token_does_not_contain_password(self):
         user = self._make_mock_user()
         token = create_access_token(user)
-        payload = jwt.decode(
-            token, settings.JWT_SECRET_KEY, algorithms=[settings.JWT_ALGORITHM]
-        )
+        payload = jwt.decode(token, settings.JWT_SECRET_KEY, algorithms=[settings.JWT_ALGORITHM])
         assert "password" not in payload
         assert "password_hash" not in payload

--- a/backend/tests/unit/test_schemas.py
+++ b/backend/tests/unit/test_schemas.py
@@ -1,42 +1,33 @@
-import pytest
 from datetime import date
+
+import pytest
 from pydantic import ValidationError
 
 from app.db.enums import DatePrecision
 from app.models.story import StoryCreateRequest, StoryDateRangeFilter, StoryUpdateRequest
-from app.models.user import UserRegisterRequest, UserLoginRequest
+from app.models.user import UserLoginRequest, UserRegisterRequest
 
 
 class TestUserRegisterRequestSchema:
     def test_valid_payload(self):
-        req = UserRegisterRequest(
-            username="john", email="john@example.com", password="MyPass1!"
-        )
+        req = UserRegisterRequest(username="john", email="john@example.com", password="MyPass1!")
         assert req.username == "john"
         assert req.email == "john@example.com"
 
     def test_username_too_short(self):
         with pytest.raises(ValidationError):
-            UserRegisterRequest(
-                username="ab", email="a@b.com", password="MyPass1!"
-            )
+            UserRegisterRequest(username="ab", email="a@b.com", password="MyPass1!")
 
     def test_username_too_long(self):
         with pytest.raises(ValidationError):
-            UserRegisterRequest(
-                username="a" * 51, email="a@b.com", password="MyPass1!"
-            )
+            UserRegisterRequest(username="a" * 51, email="a@b.com", password="MyPass1!")
 
     def test_invalid_email(self):
         with pytest.raises(ValidationError):
-            UserRegisterRequest(
-                username="john", email="not-an-email", password="MyPass1!"
-            )
+            UserRegisterRequest(username="john", email="not-an-email", password="MyPass1!")
 
     def test_display_name_optional(self):
-        req = UserRegisterRequest(
-            username="john", email="john@example.com", password="MyPass1!"
-        )
+        req = UserRegisterRequest(username="john", email="john@example.com", password="MyPass1!")
         assert req.display_name is None
 
     def test_display_name_provided(self):

--- a/backend/tests/unit/test_story_factory.py
+++ b/backend/tests/unit/test_story_factory.py
@@ -1,8 +1,6 @@
 import uuid
 from datetime import date
 
-import pytest
-
 from app.db.enums import DatePrecision, StoryStatus, StoryVisibility
 from app.db.story import Story
 from tests.factories.story_factory import (

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,0 +1,87 @@
+const js = require("@eslint/js");
+
+module.exports = [
+    js.configs.recommended,
+    {
+        ignores: ["android/**", "node_modules/**"],
+    },
+    {
+        languageOptions: {
+            ecmaVersion: 2022,
+            sourceType: "script",
+            globals: {
+                // Browser globals
+                window: "readonly",
+                document: "readonly",
+                localStorage: "readonly",
+                Storage: "readonly",
+                fetch: "readonly",
+                console: "readonly",
+                alert: "readonly",
+                FormData: "readonly",
+                URLSearchParams: "readonly",
+                location: "readonly",
+                navigator: "readonly",
+                FileReader: "readonly",
+                Image: "readonly",
+                HTMLElement: "readonly",
+                Event: "readonly",
+                URL: "readonly",
+                // CommonJS exports used by some source files for testing
+                module: "readonly",
+                // Libraries loaded via <script>
+                L: "readonly",
+                // Cross-file globals (defined in one file, used in others via <script> tags)
+                API_BASE: "writable",
+                getToken: "writable",
+                saveToken: "writable",
+                isLoggedIn: "writable",
+                logout: "writable",
+                authFetch: "writable",
+                requireAuth: "writable",
+            },
+        },
+        rules: {
+            "no-unused-vars": ["warn", { args: "none" }],
+            "no-undef": "error",
+            "no-redeclare": ["error", { builtinGlobals: false }],
+        },
+    },
+    {
+        files: ["**/*.test.js", "jest.config.js"],
+        languageOptions: {
+            sourceType: "commonjs",
+            globals: {
+                module: "readonly",
+                require: "readonly",
+                exports: "readonly",
+                describe: "readonly",
+                test: "readonly",
+                expect: "readonly",
+                beforeEach: "readonly",
+                afterEach: "readonly",
+                jest: "readonly",
+                global: "readonly",
+            },
+        },
+    },
+    {
+        files: ["eslint.config.js"],
+        languageOptions: {
+            sourceType: "commonjs",
+            globals: {
+                module: "readonly",
+                require: "readonly",
+            },
+        },
+    },
+    {
+        files: ["**/*.mjs"],
+        languageOptions: {
+            sourceType: "module",
+            globals: {
+                process: "readonly",
+            },
+        },
+    },
+];

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,8 @@
       },
       "devDependencies": {
         "@capacitor/cli": "^8.3.0",
+        "@eslint/js": "^9.0.0",
+        "eslint": "^9.0.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "jest-html-reporter": "^3.10.2",
@@ -587,6 +589,206 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@ionic/cli-framework-output": {
@@ -1211,6 +1413,12 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
     "node_modules/@types/fs-extra": {
       "version": "8.1.5",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.5.tgz",
@@ -1269,6 +1477,12 @@
         "@types/tough-cookie": "*",
         "parse5": "^7.0.0"
       }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "25.5.0",
@@ -1360,6 +1574,15 @@
         "acorn-walk": "^8.0.2"
       }
     },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/acorn-walk": {
       "version": "8.3.5",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
@@ -1384,6 +1607,22 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-escapes": {
@@ -2077,6 +2316,12 @@
         }
       }
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -2320,6 +2565,168 @@
         "source-map": "~0.6.1"
       }
     },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -2332,6 +2739,30 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/estraverse": {
@@ -2404,12 +2835,24 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -2429,6 +2872,18 @@
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/fill-range": {
@@ -2457,6 +2912,25 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true
     },
     "node_modules/form-data": {
       "version": "4.0.5",
@@ -2636,6 +3110,30 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -2780,6 +3278,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/import-local": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
@@ -2878,6 +3410,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -2896,6 +3437,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-number": {
@@ -3781,12 +4334,30 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -3824,6 +4395,15 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -3842,6 +4422,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lines-and-columns": {
@@ -3863,6 +4456,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -4153,6 +4752,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -4214,6 +4830,18 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
@@ -4374,6 +5002,15 @@
       },
       "engines": {
         "node": ">=10.4.0"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/pretty-format": {
@@ -5044,6 +5681,18 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -5137,6 +5786,15 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/url-parse": {
@@ -5266,6 +5924,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wrap-ansi": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,11 +4,14 @@
   "private": true,
   "scripts": {
     "test": "jest",
+    "lint": "eslint .",
     "capacitor:prepare": "node scripts/prepare-capacitor-web.mjs",
     "capacitor:sync": "node scripts/prepare-capacitor-web.mjs && npx cap sync android"
   },
   "devDependencies": {
     "@capacitor/cli": "^8.3.0",
+    "@eslint/js": "^9.0.0",
+    "eslint": "^9.0.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "jest-html-reporter": "^3.10.2",


### PR DESCRIPTION
## Description
Add lint and format check steps to the CI pipeline for both backend (Python) and frontend (JavaScript). This ensures code style consistency is enforced automatically on every push and pull request.

- **Backend:** Uses [Ruff](https://docs.astral.sh/ruff/) for linting (pycodestyle, pyflakes, isort) and format checking.
- **Frontend:** Uses [ESLint 9](https://eslint.org/) with flat config for vanilla JS linting.

Both lint jobs run early in the pipeline (no DB/MinIO needed) and gate their respective test jobs.

## Related Issue(s)
- Closes #103

## Changes

| File | Change |
|------|--------|
| `backend/ruff.toml` | Added ruff configuration (Python 3.11, 120 char lines, E/W/F/I rules) |
| `backend/requirements.txt` | Added `ruff` dependency |
| `backend/**/*.py` (20 files) | Auto-fixed import sorting, formatting, and removed unused imports via `ruff check --fix` and `ruff format` |
| `frontend/eslint.config.js` | Added ESLint flat config with browser/cross-file globals, Jest overrides |
| `frontend/package.json` | Added `eslint`, `@eslint/js` to devDependencies and `lint` script |
| `.github/workflows/ci.yml` | Added `backend-lint` and `frontend-lint` CI jobs gating test stages |

## Checklist
- [x] All tests passed
- [x] I have self-reviewed my own code
- [x] I have requested at least 1 reviewer
