### PR TITLE
add backend unit tests

### DIFF
--- a/backend/tests/unit/test_auth_service.py
+++ b/backend/tests/unit/test_auth_service.py
@@ -1,0 +1,186 @@
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.db.enums import UserRole
+from app.models.user import UserLoginRequest, UserRegisterRequest
+from app.services.auth_service import login_user, register_user
+
+
+def _make_user_entity(**overrides):
+    base = {
+        "id": uuid.uuid4(),
+        "username": "testuser",
+        "email": "test@example.com",
+        "password_hash": "hashed_password",
+        "display_name": None,
+        "role": UserRole.USER,
+        "is_active": True,
+        "created_at": datetime.now(timezone.utc),
+        "updated_at": datetime.now(timezone.utc),
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+@pytest.mark.asyncio
+class TestRegisterUser:
+    async def test_register_success(self):
+        payload = UserRegisterRequest(
+            username="newuser",
+            email="new@example.com",
+            password="StrongPass1!",
+            display_name="New User",
+        )
+
+        db = AsyncMock()
+        # First execute: email check returns None
+        # Second execute: username check returns None
+        db.execute.side_effect = [
+            MagicMock(scalar_one_or_none=lambda: None),
+            MagicMock(scalar_one_or_none=lambda: None),
+        ]
+
+        async def _refresh_side_effect(user_obj):
+            user_obj.id = uuid.uuid4()
+            user_obj.role = UserRole.USER
+            user_obj.created_at = datetime.now(timezone.utc)
+
+        db.refresh.side_effect = _refresh_side_effect
+
+        result = await register_user(db, payload)
+
+        assert result.username == "newuser"
+        assert result.email == "new@example.com"
+        assert result.display_name == "New User"
+        assert result.role == UserRole.USER
+        db.add.assert_called_once()
+        db.commit.assert_awaited_once()
+        db.refresh.assert_awaited_once()
+
+    async def test_register_normalizes_email_to_lowercase(self):
+        payload = UserRegisterRequest(
+            username="newuser",
+            email="Test@Example.COM",
+            password="StrongPass1!",
+        )
+
+        db = AsyncMock()
+        db.execute.side_effect = [
+            MagicMock(scalar_one_or_none=lambda: None),
+            MagicMock(scalar_one_or_none=lambda: None),
+        ]
+
+        async def _refresh_side_effect(user_obj):
+            user_obj.id = uuid.uuid4()
+            user_obj.role = UserRole.USER
+            user_obj.created_at = datetime.now(timezone.utc)
+
+        db.refresh.side_effect = _refresh_side_effect
+
+        result = await register_user(db, payload)
+
+        assert result.email == "test@example.com"
+
+    async def test_register_rejects_duplicate_email(self):
+        payload = UserRegisterRequest(
+            username="newuser",
+            email="existing@example.com",
+            password="StrongPass1!",
+        )
+
+        existing_user = _make_user_entity(email="existing@example.com")
+        db = AsyncMock()
+        db.execute.return_value.scalar_one_or_none = lambda: existing_user
+
+        with pytest.raises(HTTPException) as exc_info:
+            await register_user(db, payload)
+
+        assert exc_info.value.status_code == 409
+        assert "Email already registered" in exc_info.value.detail
+        db.add.assert_not_called()
+
+    async def test_register_rejects_duplicate_username(self):
+        payload = UserRegisterRequest(
+            username="takenuser",
+            email="new@example.com",
+            password="StrongPass1!",
+        )
+
+        existing_user = _make_user_entity(username="takenuser")
+        db = AsyncMock()
+        # First execute: email check returns None
+        # Second execute: username check returns existing user
+        db.execute.side_effect = [
+            MagicMock(scalar_one_or_none=lambda: None),
+            MagicMock(scalar_one_or_none=lambda: existing_user),
+        ]
+
+        with pytest.raises(HTTPException) as exc_info:
+            await register_user(db, payload)
+
+        assert exc_info.value.status_code == 409
+        assert "Username already taken" in exc_info.value.detail
+        db.add.assert_not_called()
+
+
+@pytest.mark.asyncio
+class TestLoginUser:
+    @patch("app.services.auth_service.verify_password", return_value=True)
+    @patch("app.services.auth_service.create_access_token", return_value="fake-jwt-token")
+    async def test_login_success(self, mock_token, mock_verify):
+        payload = UserLoginRequest(email="test@example.com", password="StrongPass1!")
+        user = _make_user_entity()
+
+        db = AsyncMock()
+        db.execute.return_value.scalar_one_or_none = lambda: user
+
+        result = await login_user(db, payload)
+
+        assert result.access_token == "fake-jwt-token"
+        assert result.token_type == "bearer"
+        mock_verify.assert_called_once_with("StrongPass1!", user.password_hash)
+        mock_token.assert_called_once_with(user)
+
+    async def test_login_rejects_nonexistent_email(self):
+        payload = UserLoginRequest(email="nobody@example.com", password="StrongPass1!")
+
+        db = AsyncMock()
+        db.execute.return_value.scalar_one_or_none = lambda: None
+
+        with pytest.raises(HTTPException) as exc_info:
+            await login_user(db, payload)
+
+        assert exc_info.value.status_code == 401
+        assert "Invalid email or password" in exc_info.value.detail
+
+    @patch("app.services.auth_service.verify_password", return_value=False)
+    async def test_login_rejects_wrong_password(self, mock_verify):
+        payload = UserLoginRequest(email="test@example.com", password="WrongPass1!")
+        user = _make_user_entity()
+
+        db = AsyncMock()
+        db.execute.return_value.scalar_one_or_none = lambda: user
+
+        with pytest.raises(HTTPException) as exc_info:
+            await login_user(db, payload)
+
+        assert exc_info.value.status_code == 401
+        assert "Invalid email or password" in exc_info.value.detail
+
+    @patch("app.services.auth_service.verify_password", return_value=True)
+    @patch("app.services.auth_service.create_access_token", return_value="fake-jwt-token")
+    async def test_login_normalizes_email_to_lowercase(self, mock_token, mock_verify):
+        payload = UserLoginRequest(email="Test@Example.COM", password="StrongPass1!")
+        user = _make_user_entity(email="test@example.com")
+
+        db = AsyncMock()
+        db.execute.return_value.scalar_one_or_none = lambda: user
+
+        result = await login_user(db, payload)
+
+        assert result.access_token == "fake-jwt-token"

--- a/backend/tests/unit/test_deps.py
+++ b/backend/tests/unit/test_deps.py
@@ -1,0 +1,123 @@
+import uuid
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import jwt
+import pytest
+from fastapi import HTTPException
+
+from app.core.config import settings
+from app.core.deps import get_current_user
+from app.db.enums import UserRole
+
+
+def _make_token(sub: str, expired: bool = False, **extra_claims) -> str:
+    if expired:
+        exp = datetime.now(timezone.utc) - timedelta(minutes=5)
+    else:
+        exp = datetime.now(timezone.utc) + timedelta(minutes=30)
+
+    payload = {"sub": sub, "email": "test@example.com", "role": "user", "exp": exp}
+    payload.update(extra_claims)
+    return jwt.encode(payload, settings.JWT_SECRET_KEY, algorithm=settings.JWT_ALGORITHM)
+
+
+def _make_credentials(token: str):
+    return SimpleNamespace(credentials=token)
+
+
+def _make_user(user_id: uuid.UUID):
+    return SimpleNamespace(
+        id=user_id,
+        username="testuser",
+        email="test@example.com",
+        role=UserRole.USER,
+        is_active=True,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+@pytest.mark.asyncio
+class TestGetCurrentUser:
+    async def test_returns_user_for_valid_token(self):
+        user_id = uuid.uuid4()
+        token = _make_token(sub=str(user_id))
+        credentials = _make_credentials(token)
+        user = _make_user(user_id)
+
+        db = AsyncMock()
+        db.execute.return_value.scalar_one_or_none = lambda: user
+
+        result = await get_current_user(credentials=credentials, db=db)
+
+        assert result.id == user_id
+        assert result.username == "testuser"
+        db.execute.assert_awaited_once()
+
+    async def test_rejects_expired_token(self):
+        token = _make_token(sub=str(uuid.uuid4()), expired=True)
+        credentials = _make_credentials(token)
+        db = AsyncMock()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(credentials=credentials, db=db)
+
+        assert exc_info.value.status_code == 401
+        assert "expired" in exc_info.value.detail.lower()
+        db.execute.assert_not_awaited()
+
+    async def test_rejects_invalid_token(self):
+        credentials = _make_credentials("not-a-valid-jwt-token")
+        db = AsyncMock()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(credentials=credentials, db=db)
+
+        assert exc_info.value.status_code == 401
+        assert "Invalid token" in exc_info.value.detail
+        db.execute.assert_not_awaited()
+
+    async def test_rejects_token_with_wrong_secret(self):
+        payload = {
+            "sub": str(uuid.uuid4()),
+            "email": "test@example.com",
+            "role": "user",
+            "exp": datetime.now(timezone.utc) + timedelta(minutes=30),
+        }
+        token = jwt.encode(payload, "wrong-secret-key", algorithm="HS256")
+        credentials = _make_credentials(token)
+        db = AsyncMock()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(credentials=credentials, db=db)
+
+        assert exc_info.value.status_code == 401
+        db.execute.assert_not_awaited()
+
+    async def test_rejects_token_without_sub_claim(self):
+        exp = datetime.now(timezone.utc) + timedelta(minutes=30)
+        payload = {"email": "test@example.com", "role": "user", "exp": exp}
+        token = jwt.encode(payload, settings.JWT_SECRET_KEY, algorithm=settings.JWT_ALGORITHM)
+        credentials = _make_credentials(token)
+        db = AsyncMock()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(credentials=credentials, db=db)
+
+        assert exc_info.value.status_code == 401
+        assert "Invalid token payload" in exc_info.value.detail
+
+    async def test_rejects_token_for_nonexistent_user(self):
+        user_id = uuid.uuid4()
+        token = _make_token(sub=str(user_id))
+        credentials = _make_credentials(token)
+
+        db = AsyncMock()
+        db.execute.return_value.scalar_one_or_none = lambda: None
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(credentials=credentials, db=db)
+
+        assert exc_info.value.status_code == 401
+        assert "User not found" in exc_info.value.detail

--- a/backend/tests/unit/test_deps.py
+++ b/backend/tests/unit/test_deps.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import jwt
 import pytest

--- a/backend/tests/unit/test_health.py
+++ b/backend/tests/unit/test_health.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 

--- a/backend/tests/unit/test_health.py
+++ b/backend/tests/unit/test_health.py
@@ -25,9 +25,7 @@ class TestHealthEndpoint:
     async def test_returns_degraded_when_db_unreachable(self, mock_engine, mock_check):
         from app.main import health
 
-        mock_engine.connect.return_value.__aenter__ = AsyncMock(
-            side_effect=Exception("DB connection refused")
-        )
+        mock_engine.connect.return_value.__aenter__ = AsyncMock(side_effect=Exception("DB connection refused"))
         mock_engine.connect.return_value.__aexit__ = AsyncMock(return_value=False)
 
         result = await health()
@@ -56,9 +54,7 @@ class TestHealthEndpoint:
     async def test_returns_degraded_when_both_unreachable(self, mock_engine, mock_check):
         from app.main import health
 
-        mock_engine.connect.return_value.__aenter__ = AsyncMock(
-            side_effect=Exception("DB down")
-        )
+        mock_engine.connect.return_value.__aenter__ = AsyncMock(side_effect=Exception("DB down"))
         mock_engine.connect.return_value.__aexit__ = AsyncMock(return_value=False)
 
         result = await health()

--- a/backend/tests/unit/test_health.py
+++ b/backend/tests/unit/test_health.py
@@ -1,0 +1,68 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+class TestHealthEndpoint:
+    @patch("app.main.check_connection")
+    @patch("app.main.engine")
+    async def test_returns_ok_when_all_healthy(self, mock_engine, mock_check):
+        from app.main import health
+
+        mock_conn = AsyncMock()
+        mock_engine.connect.return_value.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_engine.connect.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await health()
+
+        assert result["status"] == "ok"
+        assert result["db"] == "ok"
+        assert result["storage"] == "ok"
+
+    @patch("app.main.check_connection")
+    @patch("app.main.engine")
+    async def test_returns_degraded_when_db_unreachable(self, mock_engine, mock_check):
+        from app.main import health
+
+        mock_engine.connect.return_value.__aenter__ = AsyncMock(
+            side_effect=Exception("DB connection refused")
+        )
+        mock_engine.connect.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await health()
+
+        assert result["status"] == "degraded"
+        assert "unreachable" in result["db"]
+        assert result["storage"] == "ok"
+
+    @patch("app.main.check_connection", side_effect=Exception("Storage down"))
+    @patch("app.main.engine")
+    async def test_returns_degraded_when_storage_unreachable(self, mock_engine, mock_check):
+        from app.main import health
+
+        mock_conn = AsyncMock()
+        mock_engine.connect.return_value.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_engine.connect.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await health()
+
+        assert result["status"] == "degraded"
+        assert result["db"] == "ok"
+        assert "unreachable" in result["storage"]
+
+    @patch("app.main.check_connection", side_effect=Exception("Storage down"))
+    @patch("app.main.engine")
+    async def test_returns_degraded_when_both_unreachable(self, mock_engine, mock_check):
+        from app.main import health
+
+        mock_engine.connect.return_value.__aenter__ = AsyncMock(
+            side_effect=Exception("DB down")
+        )
+        mock_engine.connect.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await health()
+
+        assert result["status"] == "degraded"
+        assert "unreachable" in result["db"]
+        assert "unreachable" in result["storage"]

--- a/backend/tests/unit/test_schemas.py
+++ b/backend/tests/unit/test_schemas.py
@@ -1,10 +1,19 @@
-from datetime import date
+import uuid
+from datetime import date, datetime, timezone
+from types import SimpleNamespace
 
 import pytest
 from pydantic import ValidationError
 
-from app.db.enums import DatePrecision
-from app.models.story import StoryCreateRequest, StoryDateRangeFilter, StoryUpdateRequest
+from app.db.enums import DatePrecision, MediaType, StoryStatus, StoryVisibility
+from app.models.story import (
+    MediaUploadRequest,
+    StoryBoundsFilter,
+    StoryCreateRequest,
+    StoryDateRangeFilter,
+    StoryResponse,
+    StoryUpdateRequest,
+)
 from app.models.user import UserLoginRequest, UserRegisterRequest
 
 
@@ -153,3 +162,224 @@ class TestStoryDateRangeFilter:
         assert normalized_start == date(2025, 8, 1)
         assert normalized_end == date(2025, 8, 31)
         assert precision == DatePrecision.DATE
+
+
+class TestStoryCreateRequestSchema:
+    def test_valid_minimal_payload(self):
+        req = StoryCreateRequest(
+            title="A Story",
+            content="Story content here",
+            latitude=41.0,
+            longitude=28.9,
+        )
+        assert req.title == "A Story"
+        assert req.summary is None
+        assert req.place_name is None
+
+    def test_rejects_empty_title(self):
+        with pytest.raises(ValidationError):
+            StoryCreateRequest(title="", content="content", latitude=0, longitude=0)
+
+    def test_rejects_title_too_long(self):
+        with pytest.raises(ValidationError):
+            StoryCreateRequest(title="x" * 256, content="content", latitude=0, longitude=0)
+
+    def test_rejects_empty_content(self):
+        with pytest.raises(ValidationError):
+            StoryCreateRequest(title="Title", content="", latitude=0, longitude=0)
+
+    def test_rejects_latitude_out_of_range(self):
+        with pytest.raises(ValidationError):
+            StoryCreateRequest(title="Title", content="content", latitude=91.0, longitude=0)
+
+    def test_rejects_longitude_out_of_range(self):
+        with pytest.raises(ValidationError):
+            StoryCreateRequest(title="Title", content="content", latitude=0, longitude=181.0)
+
+    def test_accepts_boundary_coordinates(self):
+        req = StoryCreateRequest(title="Title", content="content", latitude=-90.0, longitude=-180.0)
+        assert req.latitude == -90.0
+        assert req.longitude == -180.0
+
+
+class TestStoryUpdateRequestSchema:
+    def test_valid_payload(self):
+        req = StoryUpdateRequest(
+            title="Updated",
+            content="Updated content",
+            latitude=39.9,
+            longitude=32.8,
+            place_name="Ankara",
+        )
+        assert req.title == "Updated"
+        assert req.place_name == "Ankara"
+
+    def test_rejects_empty_title(self):
+        with pytest.raises(ValidationError):
+            StoryUpdateRequest(title="", content="content", latitude=0, longitude=0)
+
+    def test_rejects_latitude_out_of_range(self):
+        with pytest.raises(ValidationError):
+            StoryUpdateRequest(title="Title", content="content", latitude=-91.0, longitude=0)
+
+
+class TestStoryBoundsFilterSchema:
+    def test_valid_complete_bounds(self):
+        bounds = StoryBoundsFilter(min_lat=40.0, max_lat=42.0, min_lng=28.0, max_lng=30.0)
+        assert bounds.min_lat == 40.0
+        assert bounds.max_lat == 42.0
+
+    def test_accepts_all_none(self):
+        bounds = StoryBoundsFilter()
+        assert bounds.min_lat is None
+        assert bounds.max_lat is None
+        assert bounds.min_lng is None
+        assert bounds.max_lng is None
+
+    def test_rejects_partial_bounds(self):
+        with pytest.raises(ValidationError, match="must be provided together"):
+            StoryBoundsFilter(min_lat=40.0, max_lat=42.0)
+
+    def test_rejects_min_lat_greater_than_max_lat(self):
+        with pytest.raises(ValidationError, match="min_lat must be less than or equal to max_lat"):
+            StoryBoundsFilter(min_lat=42.0, max_lat=40.0, min_lng=28.0, max_lng=30.0)
+
+    def test_rejects_min_lng_greater_than_max_lng(self):
+        with pytest.raises(ValidationError, match="min_lng must be less than or equal to max_lng"):
+            StoryBoundsFilter(min_lat=40.0, max_lat=42.0, min_lng=30.0, max_lng=28.0)
+
+    def test_rejects_out_of_range_latitude(self):
+        with pytest.raises(ValidationError):
+            StoryBoundsFilter(min_lat=-91.0, max_lat=42.0, min_lng=28.0, max_lng=30.0)
+
+    def test_rejects_out_of_range_longitude(self):
+        with pytest.raises(ValidationError):
+            StoryBoundsFilter(min_lat=40.0, max_lat=42.0, min_lng=28.0, max_lng=181.0)
+
+
+class TestMediaUploadRequestSchema:
+    def test_valid_image_upload(self):
+        req = MediaUploadRequest(media_type=MediaType.IMAGE)
+        assert req.media_type == MediaType.IMAGE
+        assert req.alt_text is None
+        assert req.caption is None
+        assert req.sort_order == 0
+
+    def test_valid_with_all_fields(self):
+        req = MediaUploadRequest(
+            media_type=MediaType.AUDIO,
+            alt_text="A sound clip",
+            caption="Recording from 1920",
+            sort_order=3,
+        )
+        assert req.alt_text == "A sound clip"
+        assert req.caption == "Recording from 1920"
+        assert req.sort_order == 3
+
+    def test_rejects_negative_sort_order(self):
+        with pytest.raises(ValidationError):
+            MediaUploadRequest(media_type=MediaType.IMAGE, sort_order=-1)
+
+    def test_rejects_alt_text_too_long(self):
+        with pytest.raises(ValidationError):
+            MediaUploadRequest(media_type=MediaType.IMAGE, alt_text="x" * 501)
+
+    def test_rejects_caption_too_long(self):
+        with pytest.raises(ValidationError):
+            MediaUploadRequest(media_type=MediaType.IMAGE, caption="x" * 501)
+
+
+def _make_story_obj(**overrides):
+    base = {
+        "id": uuid.uuid4(),
+        "title": "Test Story",
+        "summary": "Summary",
+        "content": "Content",
+        "place_name": "Istanbul",
+        "latitude": 41.0,
+        "longitude": 28.9,
+        "date_start": date(1453, 1, 1),
+        "date_end": date(1453, 12, 31),
+        "date_precision": DatePrecision.YEAR,
+        "status": StoryStatus.PUBLISHED,
+        "visibility": StoryVisibility.PUBLIC,
+        "created_at": datetime.now(timezone.utc),
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+class TestStoryResponseFromOrmWithAuthor:
+    def test_maps_all_fields(self):
+        story = _make_story_obj()
+        resp = StoryResponse.from_orm_with_author(story, "authorname")
+
+        assert resp.id == story.id
+        assert resp.title == "Test Story"
+        assert resp.author == "authorname"
+        assert resp.place_name == "Istanbul"
+        assert resp.latitude == 41.0
+        assert resp.status == StoryStatus.PUBLISHED
+
+    def test_year_precision_single_year_label(self):
+        story = _make_story_obj(
+            date_start=date(1453, 1, 1),
+            date_end=date(1453, 12, 31),
+            date_precision=DatePrecision.YEAR,
+        )
+        resp = StoryResponse.from_orm_with_author(story, "author")
+        assert resp.date_label == "1453"
+
+    def test_year_precision_range_label(self):
+        story = _make_story_obj(
+            date_start=date(1920, 1, 1),
+            date_end=date(1923, 12, 31),
+            date_precision=DatePrecision.YEAR,
+        )
+        resp = StoryResponse.from_orm_with_author(story, "author")
+        assert resp.date_label == "1920 - 1923"
+
+    def test_date_precision_single_date_label(self):
+        story = _make_story_obj(
+            date_start=date(1453, 5, 29),
+            date_end=date(1453, 5, 29),
+            date_precision=DatePrecision.DATE,
+        )
+        resp = StoryResponse.from_orm_with_author(story, "author")
+        assert resp.date_label == "1453-05-29"
+
+    def test_date_precision_range_label(self):
+        story = _make_story_obj(
+            date_start=date(1453, 5, 29),
+            date_end=date(1453, 6, 15),
+            date_precision=DatePrecision.DATE,
+        )
+        resp = StoryResponse.from_orm_with_author(story, "author")
+        assert resp.date_label == "1453-05-29 - 1453-06-15"
+
+    def test_no_dates_returns_none_label(self):
+        story = _make_story_obj(
+            date_start=None,
+            date_end=None,
+            date_precision=None,
+        )
+        resp = StoryResponse.from_orm_with_author(story, "author")
+        assert resp.date_label is None
+
+    def test_start_only_with_year_precision(self):
+        story = _make_story_obj(
+            date_start=date(1920, 1, 1),
+            date_end=None,
+            date_precision=DatePrecision.YEAR,
+        )
+        resp = StoryResponse.from_orm_with_author(story, "author")
+        assert resp.date_label == "1920"
+
+    def test_start_only_with_date_precision(self):
+        story = _make_story_obj(
+            date_start=date(1920, 3, 15),
+            date_end=None,
+            date_precision=DatePrecision.DATE,
+        )
+        resp = StoryResponse.from_orm_with_author(story, "author")
+        assert resp.date_label == "1920-03-15"

--- a/backend/tests/unit/test_storage_service.py
+++ b/backend/tests/unit/test_storage_service.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 

--- a/backend/tests/unit/test_storage_service.py
+++ b/backend/tests/unit/test_storage_service.py
@@ -1,0 +1,152 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.db.enums import MediaType
+
+
+class TestCheckConnection:
+    @patch("app.services.storage.storage_client")
+    def test_calls_list_buckets(self, mock_client):
+        from app.services.storage import check_connection
+
+        check_connection()
+
+        mock_client.list_buckets.assert_called_once()
+
+    @patch("app.services.storage.storage_client")
+    def test_raises_when_storage_unreachable(self, mock_client):
+        from app.services.storage import check_connection
+
+        mock_client.list_buckets.side_effect = Exception("Connection refused")
+
+        with pytest.raises(Exception, match="Connection refused"):
+            check_connection()
+
+
+class TestGetBucketForMediaType:
+    @patch("app.services.storage.settings")
+    def test_image_returns_images_bucket(self, mock_settings):
+        from app.services.storage import get_bucket_for_media_type
+
+        mock_settings.STORAGE_BUCKET_IMAGES = "images"
+        assert get_bucket_for_media_type(MediaType.IMAGE) == "images"
+
+    @patch("app.services.storage.settings")
+    def test_audio_returns_audio_bucket(self, mock_settings):
+        from app.services.storage import get_bucket_for_media_type
+
+        mock_settings.STORAGE_BUCKET_AUDIO = "audio"
+        assert get_bucket_for_media_type(MediaType.AUDIO) == "audio"
+
+    @patch("app.services.storage.settings")
+    def test_video_returns_videos_bucket(self, mock_settings):
+        from app.services.storage import get_bucket_for_media_type
+
+        mock_settings.STORAGE_BUCKET_VIDEOS = "videos"
+        assert get_bucket_for_media_type(MediaType.VIDEO) == "videos"
+
+    @patch("app.services.storage.settings")
+    def test_document_falls_back_to_images_bucket(self, mock_settings):
+        from app.services.storage import get_bucket_for_media_type
+
+        mock_settings.STORAGE_BUCKET_IMAGES = "images"
+        assert get_bucket_for_media_type(MediaType.DOCUMENT) == "images"
+
+
+class TestUploadBytes:
+    @patch("app.services.storage.storage_client")
+    def test_calls_put_object_with_correct_args(self, mock_client):
+        from app.services.storage import upload_bytes
+
+        upload_bytes(
+            bucket_name="images",
+            storage_key="stories/abc/media/photo.png",
+            content=b"fake-image-bytes",
+            content_type="image/png",
+        )
+
+        mock_client.put_object.assert_called_once_with(
+            Bucket="images",
+            Key="stories/abc/media/photo.png",
+            Body=b"fake-image-bytes",
+            ContentType="image/png",
+        )
+
+    @patch("app.services.storage.storage_client")
+    def test_raises_when_upload_fails(self, mock_client):
+        from app.services.storage import upload_bytes
+
+        mock_client.put_object.side_effect = Exception("Upload failed")
+
+        with pytest.raises(Exception, match="Upload failed"):
+            upload_bytes(
+                bucket_name="images",
+                storage_key="key.png",
+                content=b"data",
+                content_type="image/png",
+            )
+
+
+class TestDeleteObject:
+    @patch("app.services.storage.storage_client")
+    def test_calls_delete_object_with_correct_args(self, mock_client):
+        from app.services.storage import delete_object
+
+        delete_object(bucket_name="images", storage_key="stories/abc/photo.png")
+
+        mock_client.delete_object.assert_called_once_with(
+            Bucket="images",
+            Key="stories/abc/photo.png",
+        )
+
+    @patch("app.services.storage.storage_client")
+    def test_raises_when_delete_fails(self, mock_client):
+        from app.services.storage import delete_object
+
+        mock_client.delete_object.side_effect = Exception("Delete failed")
+
+        with pytest.raises(Exception, match="Delete failed"):
+            delete_object(bucket_name="images", storage_key="key.png")
+
+
+class TestBuildPublicObjectUrl:
+    @patch("app.services.storage.settings")
+    def test_builds_correct_url(self, mock_settings):
+        from app.services.storage import build_public_object_url
+
+        mock_settings.STORAGE_PUBLIC_URL = "http://localhost:9000"
+
+        url = build_public_object_url(bucket_name="images", storage_key="stories/abc/photo.png")
+
+        assert url == "http://localhost:9000/images/stories/abc/photo.png"
+
+    @patch("app.services.storage.settings")
+    def test_strips_trailing_slash_from_base_url(self, mock_settings):
+        from app.services.storage import build_public_object_url
+
+        mock_settings.STORAGE_PUBLIC_URL = "http://localhost:9000/"
+
+        url = build_public_object_url(bucket_name="images", storage_key="stories/abc/photo.png")
+
+        assert url == "http://localhost:9000/images/stories/abc/photo.png"
+
+    @patch("app.services.storage.settings")
+    def test_encodes_special_characters_in_key(self, mock_settings):
+        from app.services.storage import build_public_object_url
+
+        mock_settings.STORAGE_PUBLIC_URL = "http://localhost:9000"
+
+        url = build_public_object_url(bucket_name="images", storage_key="stories/abc/photo with spaces.png")
+
+        assert "photo%20with%20spaces.png" in url
+
+    @patch("app.services.storage.settings")
+    def test_strips_leading_slash_from_storage_key(self, mock_settings):
+        from app.services.storage import build_public_object_url
+
+        mock_settings.STORAGE_PUBLIC_URL = "http://localhost:9000"
+
+        url = build_public_object_url(bucket_name="images", storage_key="/stories/abc/photo.png")
+
+        assert url == "http://localhost:9000/images/stories/abc/photo.png"


### PR DESCRIPTION
## Description
Add unit tests for backend modules that had no unit-level coverage: storage service, auth service (register/login), `get_current_user` JWT dependency, remaining story Pydantic schemas, and `/health` endpoint degraded paths. ~58 new tests total, all mocked (no DB or MinIO needed).

## Related Issue(s)
- Closes #214
- Closes #215
- Closes #216
- Closes #217
- Closes #218

## Changes

| File | Change |
|------|--------|
| `backend/tests/unit/test_storage_service.py` | Added 13 tests for `check_connection`, `get_bucket_for_media_type`, `upload_bytes`, `delete_object`, `build_public_object_url` |
| `backend/tests/unit/test_auth_service.py` | Added 8 tests for `register_user` and `login_user` service functions |
| `backend/tests/unit/test_deps.py` | Added 6 tests for `get_current_user` JWT dependency |
| `backend/tests/unit/test_schemas.py` | Extended with ~27 tests for `StoryCreateRequest`, `StoryUpdateRequest`, `StoryBoundsFilter`, `MediaUploadRequest`, `StoryResponse.from_orm_with_author` |
| `backend/tests/unit/test_health.py` | Added 4 tests for `/health` endpoint ok and degraded paths |

## Checklist
- [x] All tests passed
- [x] I have self-reviewed my own code
- [x] I have requested at least 1 reviewer