### PR TITLE
docs: add OpenAPI metadata and endpoint summaries/descriptions

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -23,7 +23,16 @@ async def lifespan(app: FastAPI):
     await engine.dispose()
 
 
-app = FastAPI(lifespan=lifespan)
+app = FastAPI(
+    title="Local History Story Map API",
+    description=(
+        "API for creating, discovering, and exploring stories tied to geographic locations "
+        "and historical dates. Supports authentication, story CRUD, geographic/date filtering, "
+        "full-text search, and media uploads."
+    ),
+    version="1.0.0",
+    lifespan=lifespan,
+)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=[o.strip() for o in settings.CORS_ORIGINS.split(",")],

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -14,6 +14,8 @@ router = APIRouter(prefix="/auth", tags=["auth"])
     "/register",
     response_model=UserResponse,
     status_code=status.HTTP_201_CREATED,
+    summary="Register a new user",
+    description="Create a new user account. Returns the created user profile on success.",
     responses={
         409: {"description": "Email or username already taken"},
         422: {"description": "Validation error (weak password, invalid email, etc.)"},
@@ -29,8 +31,11 @@ async def register(
 @router.post(
     "/login",
     response_model=TokenResponse,
+    summary="Login and obtain a JWT",
+    description="Authenticate with email and password. Returns a Bearer JWT valid for 30 minutes.",
     responses={
         401: {"description": "Invalid email or password"},
+        422: {"description": "Validation error (missing or malformed fields)"},
     },
 )
 async def login(
@@ -43,6 +48,8 @@ async def login(
 @router.get(
     "/me",
     response_model=UserResponse,
+    summary="Get current user profile",
+    description="Return the profile of the authenticated user. Requires a valid Bearer token.",
     responses={
         401: {"description": "Missing, invalid, or expired token"},
     },

--- a/backend/app/routers/story.py
+++ b/backend/app/routers/story.py
@@ -185,8 +185,7 @@ async def get_story_by_id(
     status_code=status.HTTP_201_CREATED,
     summary="Upload media for a story",
     description=(
-        "Attach an image, audio, or video file to a story. "
-        "Maximum file size is 20 MB. Requires authentication."
+        "Attach an image, audio, or video file to a story. Maximum file size is 20 MB. Requires authentication."
     ),
     responses={
         401: {"description": "Missing or invalid authentication token"},

--- a/backend/app/routers/story.py
+++ b/backend/app/routers/story.py
@@ -34,6 +34,8 @@ router = APIRouter(prefix="/stories", tags=["stories"])
     "",
     response_model=StoryDetailResponse,
     status_code=status.HTTP_201_CREATED,
+    summary="Create a story",
+    description="Create a new story tied to a geographic location and historical date range. Requires authentication.",
     responses={
         401: {"description": "Missing or invalid authentication token"},
         422: {"description": "Validation error for story/location input"},
@@ -50,8 +52,11 @@ async def create_story(
 @router.put(
     "/{story_id}",
     response_model=StoryDetailResponse,
+    summary="Update a story",
+    description="Update an existing story. Only the story owner may update it. Requires authentication.",
     responses={
         401: {"description": "Missing or invalid authentication token"},
+        403: {"description": "Authenticated user is not the story owner"},
         404: {"description": "Story not found"},
         422: {"description": "Validation error for story/location input"},
     },
@@ -65,7 +70,19 @@ async def update_story(
     return await update_story_with_location_and_dates(db, story_id, current_user, payload)
 
 
-@router.get("", response_model=StoryListResponse)
+@router.get(
+    "",
+    response_model=StoryListResponse,
+    summary="List public stories",
+    description=(
+        "Return all published public stories. Optionally filter by geographic bounding box "
+        "(min_lat/max_lat/min_lng/max_lng) and/or date range (query_start/query_end/query_precision). "
+        "query_precision accepts 'year' or 'date'."
+    ),
+    responses={
+        422: {"description": "Validation error for bounds or date filter parameters"},
+    },
+)
 async def list_stories(
     min_lat: float | None = Query(default=None),
     max_lat: float | None = Query(default=None),
@@ -106,7 +123,18 @@ async def list_stories(
     )
 
 
-@router.get("/search", response_model=StoryListResponse)
+@router.get(
+    "/search",
+    response_model=StoryListResponse,
+    summary="Search stories by place name",
+    description=(
+        "Search published public stories by place name (case-insensitive substring match). "
+        "Optionally filter by date range using query_start/query_end/query_precision."
+    ),
+    responses={
+        422: {"description": "Validation error for place_name or date filter parameters"},
+    },
+)
 async def search_stories(
     place_name: str = Query(min_length=1, max_length=255),
     query_start: int | str | None = Query(default=None),
@@ -138,7 +166,11 @@ async def search_stories(
 @router.get(
     "/{story_id}",
     response_model=StoryDetailResponse,
-    responses={404: {"description": "Story not found"}},
+    summary="Get story by ID",
+    description="Return the full detail of a single story including its media files.",
+    responses={
+        404: {"description": "Story not found"},
+    },
 )
 async def get_story_by_id(
     story_id: uuid.UUID,
@@ -151,6 +183,17 @@ async def get_story_by_id(
     "/{story_id}/media",
     response_model=MediaUploadResponse,
     status_code=status.HTTP_201_CREATED,
+    summary="Upload media for a story",
+    description=(
+        "Attach an image, audio, or video file to a story. "
+        "Maximum file size is 20 MB. Requires authentication."
+    ),
+    responses={
+        401: {"description": "Missing or invalid authentication token"},
+        404: {"description": "Story not found"},
+        413: {"description": "File exceeds the 20 MB size limit"},
+        502: {"description": "Object storage backend unavailable"},
+    },
 )
 async def upload_story_media(
     story_id: uuid.UUID,


### PR DESCRIPTION
## Description
Fully documents all MVP API endpoints for Swagger UI (`/docs`) and OpenAPI spec (`/openapi.json`). Adds app-level metadata to `FastAPI()` and adds `summary`, `description`, and complete `responses` to every endpoint in the auth and story routers.

## Related Issue(s)
- Closes #136

## Changes

| File | Change |
|------|--------|
| `backend/app/main.py` | Added `title`, `description`, and `version` to `FastAPI()` constructor |
| `backend/app/routers/auth.py` | Added `summary` and `description` to all 3 endpoints; added explicit 422 to `/login` |
| `backend/app/routers/story.py` | Added `summary` and `description` to all 6 endpoints; filled missing `responses` (422 on list/search, 401/404/413/502 on media upload, 403 on update) |

## Checklist
- [x] All tests passed 
- [x] I have self-reviewed my own code
- [x] I have requested at least 1 reviewer