### PR TITLE
Add seeded_db fixture and seed DB integration tests

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -68,3 +68,113 @@ async def client(db_session):
 
     app.dependency_overrides.clear()
     storage.check_connection = original_check
+
+
+@pytest_asyncio.fixture
+async def seeded_db(db_session):
+    """Insert a canonical set of sample data for tests that need a pre-populated DB.
+
+    Creates 3 users and 5 stories (3 public/published, 1 draft, 1 private).
+    All users share the password 'ValidPass1!' for login tests.
+
+    Returns a dict:
+        users   -> {key: User ORM object}
+        stories -> {title: Story ORM object}
+        public  -> list of published+public Story ORM objects
+    """
+    from datetime import date
+
+    from app.db.enums import DatePrecision, StoryStatus, StoryVisibility, UserRole
+    from tests.factories.story_factory import make_story_entity
+    from tests.factories.user_factory import make_user_entity
+
+    admin = make_user_entity(username="seed_admin", email="seed_admin@example.com", role=UserRole.ADMIN)
+    alice = make_user_entity(username="seed_alice", email="seed_alice@example.com", display_name="Alice")
+    bob = make_user_entity(username="seed_bob", email="seed_bob@example.com", display_name="Bob")
+    db_session.add_all([admin, alice, bob])
+    await db_session.flush()
+
+    stories_data = [
+        make_story_entity(
+            user_id=alice.id,
+            title="Fall of Constantinople",
+            content="The Ottoman siege of 1453 ended the Byzantine Empire.",
+            summary="Ottoman conquest of Constantinople in 1453.",
+            place_name="Istanbul",
+            latitude=41.0082,
+            longitude=28.9784,
+            date_start=date(1453, 1, 1),
+            date_end=date(1453, 12, 31),
+            date_precision=DatePrecision.YEAR,
+            status=StoryStatus.PUBLISHED,
+            visibility=StoryVisibility.PUBLIC,
+        ),
+        make_story_entity(
+            user_id=alice.id,
+            title="Atatürk's Ankara",
+            content="The founding of the Turkish Republic and its new capital.",
+            summary="How Ankara became the capital of modern Turkey.",
+            place_name="Ankara",
+            latitude=39.9334,
+            longitude=32.8597,
+            date_start=date(1923, 1, 1),
+            date_end=date(1938, 12, 31),
+            date_precision=DatePrecision.YEAR,
+            status=StoryStatus.PUBLISHED,
+            visibility=StoryVisibility.PUBLIC,
+        ),
+        make_story_entity(
+            user_id=bob.id,
+            title="Ancient Ephesus",
+            content="One of the greatest cities of the ancient world, located near modern Selçuk.",
+            summary="The rise and fall of the ancient city of Ephesus.",
+            place_name="Izmir",
+            latitude=37.9395,
+            longitude=27.3417,
+            date_start=date(100, 1, 1),
+            date_end=date(400, 12, 31),
+            date_precision=DatePrecision.YEAR,
+            status=StoryStatus.PUBLISHED,
+            visibility=StoryVisibility.PUBLIC,
+        ),
+        make_story_entity(
+            user_id=bob.id,
+            title="Draft Story",
+            content="A story not yet ready for publication.",
+            summary="Unpublished draft.",
+            place_name="Istanbul",
+            latitude=41.0082,
+            longitude=28.9784,
+            date_start=date(1900, 1, 1),
+            date_end=date(1900, 12, 31),
+            date_precision=DatePrecision.YEAR,
+            status=StoryStatus.DRAFT,
+            visibility=StoryVisibility.PUBLIC,
+        ),
+        make_story_entity(
+            user_id=alice.id,
+            title="Private Story",
+            content="A story the author keeps private.",
+            summary="Not visible to the public.",
+            place_name="Bursa",
+            latitude=40.1826,
+            longitude=29.0665,
+            date_start=date(1326, 1, 1),
+            date_end=date(1326, 12, 31),
+            date_precision=DatePrecision.YEAR,
+            status=StoryStatus.PUBLISHED,
+            visibility=StoryVisibility.PRIVATE,
+        ),
+    ]
+
+    db_session.add_all(stories_data)
+    await db_session.commit()
+
+    stories_by_title = {s.title: s for s in stories_data}
+    public = [s for s in stories_data if s.status == StoryStatus.PUBLISHED and s.visibility == StoryVisibility.PUBLIC]
+
+    return {
+        "users": {"admin": admin, "alice": alice, "bob": bob},
+        "stories": stories_by_title,
+        "public": public,
+    }

--- a/backend/tests/integration/test_seed_db.py
+++ b/backend/tests/integration/test_seed_db.py
@@ -1,0 +1,79 @@
+import pytest
+
+# Shared credentials for seeded users (set by make_user_entity default password)
+ALICE_EMAIL = "seed_alice@example.com"
+BOB_EMAIL = "seed_bob@example.com"
+SEED_PASSWORD = "ValidPass1!"
+
+
+@pytest.mark.asyncio
+class TestSeededDatabaseContent:
+    """Integration tests that verify the seeded_db fixture populates the DB
+    correctly and that the data is reachable through the API. Covers #110."""
+
+    async def test_seeded_users_can_log_in(self, client, seeded_db):
+        for email in (ALICE_EMAIL, BOB_EMAIL):
+            resp = await client.post("/auth/login", json={"email": email, "password": SEED_PASSWORD})
+            assert resp.status_code == 200, f"Login failed for {email}: {resp.json()}"
+            assert "access_token" in resp.json()
+
+    async def test_three_public_stories_in_listing(self, client, seeded_db):
+        resp = await client.get("/stories")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 3
+
+    async def test_public_story_titles_in_listing(self, client, seeded_db):
+        resp = await client.get("/stories")
+        assert resp.status_code == 200
+        titles = {s["title"] for s in resp.json()["stories"]}
+        assert titles == {"Fall of Constantinople", "Atatürk's Ankara", "Ancient Ephesus"}
+
+    async def test_draft_story_excluded_from_listing(self, client, seeded_db):
+        resp = await client.get("/stories")
+        assert resp.status_code == 200
+        titles = [s["title"] for s in resp.json()["stories"]]
+        assert "Draft Story" not in titles
+
+    async def test_private_story_excluded_from_listing(self, client, seeded_db):
+        resp = await client.get("/stories")
+        assert resp.status_code == 200
+        titles = [s["title"] for s in resp.json()["stories"]]
+        assert "Private Story" not in titles
+
+    async def test_search_by_place_name_returns_correct_story(self, client, seeded_db):
+        resp = await client.get("/stories/search?place_name=Ankara")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["stories"][0]["title"] == "Atatürk's Ankara"
+
+    async def test_bounds_filter_returns_istanbul_story(self, client, seeded_db):
+        # Tight bounding box around Istanbul (41.0082, 28.9784)
+        resp = await client.get(
+            "/stories",
+            params={
+                "min_lat": 40.5,
+                "max_lat": 41.5,
+                "min_lng": 28.5,
+                "max_lng": 29.5,
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        titles = [s["title"] for s in data["stories"]]
+        assert "Fall of Constantinople" in titles
+        assert "Atatürk's Ankara" not in titles
+        assert "Ancient Ephesus" not in titles
+
+    async def test_date_filter_returns_stories_in_range(self, client, seeded_db):
+        # query 1900–1950 should only return Atatürk's Ankara (1923–1938)
+        resp = await client.get(
+            "/stories",
+            params={"query_start": 1900, "query_end": 1950, "query_precision": "year"},
+        )
+        assert resp.status_code == 200
+        titles = [s["title"] for s in resp.json()["stories"]]
+        assert "Atatürk's Ankara" in titles
+        assert "Fall of Constantinople" not in titles
+        assert "Ancient Ephesus" not in titles


### PR DESCRIPTION
## Description
Adds a reusable `seeded_db` pytest fixture that populates the test database with a canonical set of sample data (3 users, 5 stories), and an integration test suite that verifies the seeded data is correct and queryable through the API.

The fixture inserts data directly via the ORM (not through the API), making it fast and independent of auth being functional. It is available to all test files via `conftest.py`.

## Related Issue(s)
- Closes #110

## Changes

| File | Change |
|------|--------|
| `backend/tests/conftest.py` | Added `seeded_db` fixture: 3 users (admin, alice, bob) + 5 stories (3 public/published, 1 draft, 1 private) |
| `backend/tests/integration/test_seed_db.py` | Added 8 integration tests: login, listing count, title set, draft/private exclusion, place search, bounds filter, date filter |

## Checklist
- [x] All tests passed 
- [x] I have self-reviewed my own code
- [ ] I have requested at least 1 reviewer