### PR TITLE
feature: accept audio/webm MIME type for live recorded audio

### DIFF
--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -35,7 +35,7 @@ MAX_MEDIA_UPLOAD_BYTES = 20 * 1024 * 1024  # 20 MB
 
 ALLOWED_MIME_TYPES = {
     "image": {"image/jpeg", "image/png", "image/webp", "image/gif"},
-    "audio": {"audio/mpeg", "audio/wav", "audio/ogg", "audio/mp4"},
+    "audio": {"audio/mpeg", "audio/wav", "audio/ogg", "audio/mp4", "audio/webm"},
     "video": {"video/mp4", "video/webm", "video/quicktime"},
     "document": {
         "application/pdf",
@@ -105,10 +105,11 @@ def _validate_media_upload(file: UploadFile, payload: MediaUploadRequest) -> Non
         )
 
     allowed_for_type = ALLOWED_MIME_TYPES[payload.media_type.value]
-    if file.content_type not in allowed_for_type:
+    base_content_type = (file.content_type or "").split(";")[0].strip()
+    if base_content_type not in allowed_for_type:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=(f"Unsupported mime type '{file.content_type}' for media type '{payload.media_type.value}'"),
+            detail=(f"Unsupported mime type '{base_content_type}' for media type '{payload.media_type.value}'"),
         )
 
 

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -105,7 +105,7 @@ def _validate_media_upload(file: UploadFile, payload: MediaUploadRequest) -> Non
         )
 
     allowed_for_type = ALLOWED_MIME_TYPES[payload.media_type.value]
-    base_content_type = (file.content_type or "").split(";")[0].strip()
+    base_content_type = (file.content_type or "").split(";")[0].strip().lower()
     if base_content_type not in allowed_for_type:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -265,15 +265,20 @@ class TestUploadMediaForStoryService:
         payload = MediaUploadRequest(media_type=MediaType.AUDIO)
         file = _make_upload_file("recording.webm", b"audio-bytes", "audio/webm;codecs=opus")
         db = AsyncMock()
+        db.add = MagicMock()
         db.execute.return_value.scalar_one_or_none = lambda: story
 
-        with patch("app.services.story_service.upload_bytes") as mock_upload:
-            mock_upload.return_value = None
-            with patch("app.services.story_service.build_public_object_url", return_value="http://minio/audio.webm"):
-                result = await upload_media_for_story(db, story_id, file, payload)
+        async def _refresh_side_effect(media_obj):
+            media_obj.id = uuid.uuid4()
+            media_obj.created_at = datetime.now(timezone.utc)
+
+        db.refresh.side_effect = _refresh_side_effect
+
+        with patch("app.services.story_service.upload_bytes"):
+            result = await upload_media_for_story(db, story_id, file, payload)
 
         assert result.media.mime_type == "audio/webm;codecs=opus"
-        mock_upload.assert_called_once()
+        assert result.media.media_type == MediaType.AUDIO
 
     async def test_upload_strips_mime_params_for_validation(self):
         payload = MediaUploadRequest(media_type=MediaType.IMAGE)

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -259,6 +259,35 @@ class TestUploadMediaForStoryService:
         db.commit.assert_awaited_once()
         db.refresh.assert_awaited_once()
 
+    async def test_upload_accepts_audio_webm(self):
+        story_id = uuid.uuid4()
+        story = _make_story(id=story_id)
+        payload = MediaUploadRequest(media_type=MediaType.AUDIO)
+        file = _make_upload_file("recording.webm", b"audio-bytes", "audio/webm;codecs=opus")
+        db = AsyncMock()
+        db.execute.return_value.scalar_one_or_none = lambda: story
+
+        with patch("app.services.story_service.upload_bytes") as mock_upload:
+            mock_upload.return_value = None
+            with patch("app.services.story_service.build_public_object_url", return_value="http://minio/audio.webm"):
+                result = await upload_media_for_story(db, story_id, file, payload)
+
+        assert result.media.mime_type == "audio/webm;codecs=opus"
+        mock_upload.assert_called_once()
+
+    async def test_upload_strips_mime_params_for_validation(self):
+        payload = MediaUploadRequest(media_type=MediaType.IMAGE)
+        file = _make_upload_file("clip.webm", b"audio-bytes", "audio/webm;codecs=opus")
+        db = AsyncMock()
+
+        with patch("app.services.story_service.upload_bytes") as mock_upload:
+            with pytest.raises(HTTPException) as exc_info:
+                await upload_media_for_story(db, uuid.uuid4(), file, payload)
+
+        assert exc_info.value.status_code == 422
+        assert "audio/webm" in exc_info.value.detail
+        mock_upload.assert_not_called()
+
     async def test_upload_rejects_unsupported_mime_type(self):
         payload = MediaUploadRequest(media_type=MediaType.IMAGE)
         file = _make_upload_file("clip.mp4", b"video-bytes", "video/mp4")

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -280,6 +280,26 @@ class TestUploadMediaForStoryService:
         assert result.media.mime_type == "audio/webm;codecs=opus"
         assert result.media.media_type == MediaType.AUDIO
 
+    async def test_upload_accepts_audio_webm_mixed_case(self):
+        story_id = uuid.uuid4()
+        story = _make_story(id=story_id)
+        payload = MediaUploadRequest(media_type=MediaType.AUDIO)
+        file = _make_upload_file("recording.webm", b"audio-bytes", "Audio/WebM;codecs=opus")
+        db = AsyncMock()
+        db.add = MagicMock()
+        db.execute.return_value.scalar_one_or_none = lambda: story
+
+        async def _refresh_side_effect(media_obj):
+            media_obj.id = uuid.uuid4()
+            media_obj.created_at = datetime.now(timezone.utc)
+
+        db.refresh.side_effect = _refresh_side_effect
+
+        with patch("app.services.story_service.upload_bytes"):
+            result = await upload_media_for_story(db, story_id, file, payload)
+
+        assert result.media.media_type == MediaType.AUDIO
+
     async def test_upload_strips_mime_params_for_validation(self):
         payload = MediaUploadRequest(media_type=MediaType.IMAGE)
         file = _make_upload_file("clip.webm", b"audio-bytes", "audio/webm;codecs=opus")


### PR DESCRIPTION
## Description
Browser `MediaRecorder` API outputs `audio/webm;codecs=opus` by default. The existing MIME allowlist did not include `audio/webm`, causing uploads of live-recorded audio to fail with 422. This PR adds `audio/webm` to the allowed audio MIME types and strips codec parameters before validation so any `audio/webm;codecs=*` variant is accepted.

## Related Issue(s)
- Closes #209

## Changes

| File | Change |
|------|--------|
| `backend/app/services/story_service.py` | Added `audio/webm` to allowed audio MIME types; strip `;codecs=...` params before allowlist check |
| `backend/tests/unit/test_story_service.py` | Added tests for `audio/webm;codecs=opus` upload acceptance and MIME param stripping on rejection |

## Checklist
- [x] All tests passed 
- [x] I have self-reviewed my own code
- [x] I have requested at least 1 reviewer