### PR TITLE
feat: add story like and unlike endpoints

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -9,6 +9,7 @@ from app.core.config import settings
 from app.db.base import Base  # noqa: F401 — import all models here so autogenerate sees them
 from app.db.media_file import MediaFile  # noqa: F401
 from app.db.story import Story  # noqa: F401
+from app.db.story_like import StoryLike  # noqa: F401
 from app.db.user import User  # noqa: F401
 
 config = context.config

--- a/backend/alembic/versions/20260419_0004_add_story_likes.py
+++ b/backend/alembic/versions/20260419_0004_add_story_likes.py
@@ -1,0 +1,52 @@
+"""Add story likes table.
+
+Revision ID: 20260419_0004
+Revises: 20260407_0003
+Create Date: 2026-04-19 00:00:00
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260419_0004"
+down_revision: Union[str, Sequence[str], None] = "20260407_0003"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "story_likes",
+        sa.Column("story_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(["story_id"], ["stories.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("story_id", "user_id", name="uq_story_likes_story_user"),
+    )
+    op.create_index("ix_story_likes_story_id", "story_likes", ["story_id"], unique=False)
+    op.create_index("ix_story_likes_user_id", "story_likes", ["user_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_story_likes_user_id", table_name="story_likes")
+    op.drop_index("ix_story_likes_story_id", table_name="story_likes")
+    op.drop_table("story_likes")

--- a/backend/alembic/versions/20260419_0005_add_story_likes.py
+++ b/backend/alembic/versions/20260419_0005_add_story_likes.py
@@ -1,6 +1,6 @@
 """Add story likes table.
 
-Revision ID: 20260419_0004
+Revision ID: 20260419_0005
 Revises: 20260407_0003
 Create Date: 2026-04-19 00:00:00
 """
@@ -13,7 +13,7 @@ from sqlalchemy.dialects import postgresql
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "20260419_0004"
+revision: str = "20260419_0005"
 down_revision: Union[str, Sequence[str], None] = "20260407_0003"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/backend/app/db/story.py
+++ b/backend/app/db/story.py
@@ -12,6 +12,7 @@ from app.db.mixins import TimestampMixin, UUIDPrimaryKeyMixin
 
 if TYPE_CHECKING:
     from app.db.media_file import MediaFile
+    from app.db.story_like import StoryLike
     from app.db.user import User
 
 
@@ -60,6 +61,10 @@ class Story(UUIDPrimaryKeyMixin, TimestampMixin, Base):
 
     user: Mapped["User"] = relationship(back_populates="stories")
     media_files: Mapped[list["MediaFile"]] = relationship(
+        back_populates="story",
+        cascade="all, delete-orphan",
+    )
+    story_likes: Mapped[list["StoryLike"]] = relationship(
         back_populates="story",
         cascade="all, delete-orphan",
     )

--- a/backend/app/db/story_like.py
+++ b/backend/app/db/story_like.py
@@ -1,0 +1,36 @@
+import uuid
+from typing import TYPE_CHECKING
+
+from sqlalchemy import ForeignKey, Index, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+from app.db.mixins import TimestampMixin, UUIDPrimaryKeyMixin
+
+if TYPE_CHECKING:
+    from app.db.story import Story
+    from app.db.user import User
+
+
+class StoryLike(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "story_likes"
+    __table_args__ = (
+        UniqueConstraint("story_id", "user_id", name="uq_story_likes_story_user"),
+        Index("ix_story_likes_story_id", "story_id"),
+        Index("ix_story_likes_user_id", "user_id"),
+    )
+
+    story_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("stories.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    story: Mapped["Story"] = relationship(back_populates="story_likes")
+    user: Mapped["User"] = relationship(back_populates="story_likes")

--- a/backend/app/db/user.py
+++ b/backend/app/db/user.py
@@ -9,6 +9,7 @@ from app.db.mixins import TimestampMixin, UUIDPrimaryKeyMixin
 
 if TYPE_CHECKING:
     from app.db.story import Story
+    from app.db.story_like import StoryLike
 
 
 class User(UUIDPrimaryKeyMixin, TimestampMixin, Base):
@@ -37,6 +38,10 @@ class User(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     )
 
     stories: Mapped[list["Story"]] = relationship(
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
+    story_likes: Mapped[list["StoryLike"]] = relationship(
         back_populates="user",
         cascade="all, delete-orphan",
     )

--- a/backend/app/models/story.py
+++ b/backend/app/models/story.py
@@ -222,5 +222,12 @@ class MediaUploadResponse(BaseModel):
     media: MediaFileResponse
 
 
+class StoryLikeResponse(BaseModel):
+    story_id: uuid.UUID
+    liked: bool
+    like_count: int = Field(default=0, ge=0)
+
+
 class StoryDetailResponse(StoryResponse):
     media_files: list[MediaFileResponse] = Field(default_factory=list)
+    like_count: int = Field(default=0, ge=0)

--- a/backend/app/routers/story.py
+++ b/backend/app/routers/story.py
@@ -15,14 +15,17 @@ from app.models.story import (
     StoryCreateRequest,
     StoryDateRangeFilter,
     StoryDetailResponse,
+    StoryLikeResponse,
     StoryListResponse,
     StoryUpdateRequest,
 )
 from app.services.story_service import (
     create_story_with_location,
     get_story_detail_by_id,
+    like_story,
     list_available_stories,
     search_available_stories_by_place,
+    unlike_story,
     update_story_with_location_and_dates,
     upload_media_for_story,
 )
@@ -177,6 +180,42 @@ async def get_story_by_id(
     db: AsyncSession = Depends(get_db),
 ):
     return await get_story_detail_by_id(db, story_id)
+
+
+@router.post(
+    "/{story_id}/like",
+    response_model=StoryLikeResponse,
+    summary="Like a story",
+    description="Like a story as the authenticated user. Repeating the request keeps the story liked.",
+    responses={
+        401: {"description": "Missing or invalid authentication token"},
+        404: {"description": "Story not found"},
+    },
+)
+async def like_story_by_id(
+    story_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await like_story(db, story_id, current_user)
+
+
+@router.delete(
+    "/{story_id}/like",
+    response_model=StoryLikeResponse,
+    summary="Unlike a story",
+    description="Remove the authenticated user's like from a story. Repeating the request keeps the story unliked.",
+    responses={
+        401: {"description": "Missing or invalid authentication token"},
+        404: {"description": "Story not found"},
+    },
+)
+async def unlike_story_by_id(
+    story_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await unlike_story(db, story_id, current_user)
 
 
 @router.post(

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -72,10 +72,13 @@ def _map_media_file(media: MediaFile) -> MediaFileResponse:
     )
 
 
-def _map_story_detail(story: Story, author_username: str) -> StoryDetailResponse:
+def _map_story_detail(
+    story: Story,
+    author_username: str,
+    like_count: int,
+) -> StoryDetailResponse:
     story_response = StoryResponse.from_orm_with_author(story, author_username)
     media_files = [_map_media_file(media) for media in story.media_files]
-    like_count = len(getattr(story, "story_likes", []))
     return StoryDetailResponse(
         **story_response.model_dump(),
         media_files=media_files,
@@ -196,7 +199,7 @@ async def get_story_detail_by_id(
         select(Story, User.username)
         .join(User, Story.user_id == User.id)
         .where(Story.id == story_id)
-        .options(selectinload(Story.media_files), selectinload(Story.story_likes))
+        .options(selectinload(Story.media_files))
     )
 
     result = await db.execute(stmt)
@@ -209,7 +212,8 @@ async def get_story_detail_by_id(
         )
 
     story, author_username = row
-    return _map_story_detail(story, author_username)
+    like_count = await _get_story_like_count(db, story.id)
+    return _map_story_detail(story, author_username, like_count)
 
 
 async def create_story_with_location(
@@ -246,7 +250,8 @@ async def create_story_with_location(
     await db.refresh(story)
 
     story_response = StoryResponse.from_orm_with_author(story, current_user.username)
-    return StoryDetailResponse(**story_response.model_dump(), media_files=[], like_count=0)
+    like_count = await _get_story_like_count(db, story.id)
+    return StoryDetailResponse(**story_response.model_dump(), media_files=[], like_count=like_count)
 
 
 async def update_story_with_location_and_dates(
@@ -286,7 +291,8 @@ async def update_story_with_location_and_dates(
     await db.refresh(story)
 
     story_response = StoryResponse.from_orm_with_author(story, current_user.username)
-    return StoryDetailResponse(**story_response.model_dump(), media_files=[], like_count=0)
+    like_count = await _get_story_like_count(db, story.id)
+    return StoryDetailResponse(**story_response.model_dump(), media_files=[], like_count=like_count)
 
 
 async def like_story(

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -3,13 +3,15 @@ from datetime import date
 from pathlib import Path
 
 from fastapi import HTTPException, UploadFile, status
-from sqlalchemy import select
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.db.enums import StoryStatus, StoryVisibility
 from app.db.media_file import MediaFile
 from app.db.story import Story
+from app.db.story_like import StoryLike
 from app.db.user import User
 from app.models.story import (
     MediaFileResponse,
@@ -17,6 +19,7 @@ from app.models.story import (
     MediaUploadResponse,
     StoryCreateRequest,
     StoryDetailResponse,
+    StoryLikeResponse,
     StoryListResponse,
     StoryResponse,
     StoryUpdateRequest,
@@ -72,7 +75,17 @@ def _map_media_file(media: MediaFile) -> MediaFileResponse:
 def _map_story_detail(story: Story, author_username: str) -> StoryDetailResponse:
     story_response = StoryResponse.from_orm_with_author(story, author_username)
     media_files = [_map_media_file(media) for media in story.media_files]
-    return StoryDetailResponse(**story_response.model_dump(), media_files=media_files)
+    like_count = len(getattr(story, "story_likes", []))
+    return StoryDetailResponse(
+        **story_response.model_dump(),
+        media_files=media_files,
+        like_count=like_count,
+    )
+
+
+async def _get_story_like_count(db: AsyncSession, story_id: uuid.UUID) -> int:
+    result = await db.execute(select(func.count(StoryLike.id)).where(StoryLike.story_id == story_id))
+    return result.scalar_one()
 
 
 def _validate_media_upload(file: UploadFile, payload: MediaUploadRequest) -> None:
@@ -183,7 +196,7 @@ async def get_story_detail_by_id(
         select(Story, User.username)
         .join(User, Story.user_id == User.id)
         .where(Story.id == story_id)
-        .options(selectinload(Story.media_files))
+        .options(selectinload(Story.media_files), selectinload(Story.story_likes))
     )
 
     result = await db.execute(stmt)
@@ -233,7 +246,7 @@ async def create_story_with_location(
     await db.refresh(story)
 
     story_response = StoryResponse.from_orm_with_author(story, current_user.username)
-    return StoryDetailResponse(**story_response.model_dump(), media_files=[])
+    return StoryDetailResponse(**story_response.model_dump(), media_files=[], like_count=0)
 
 
 async def update_story_with_location_and_dates(
@@ -273,7 +286,81 @@ async def update_story_with_location_and_dates(
     await db.refresh(story)
 
     story_response = StoryResponse.from_orm_with_author(story, current_user.username)
-    return StoryDetailResponse(**story_response.model_dump(), media_files=[])
+    return StoryDetailResponse(**story_response.model_dump(), media_files=[], like_count=0)
+
+
+async def like_story(
+    db: AsyncSession,
+    story_id: uuid.UUID,
+    current_user: User,
+) -> StoryLikeResponse:
+    story_result = await db.execute(select(Story.id).where(Story.id == story_id))
+    story_exists = story_result.scalar_one_or_none()
+    if story_exists is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Story not found",
+        )
+
+    existing_like_result = await db.execute(
+        select(StoryLike).where(
+            StoryLike.story_id == story_id,
+            StoryLike.user_id == current_user.id,
+        )
+    )
+    existing_like = existing_like_result.scalar_one_or_none()
+
+    if existing_like is None:
+        db.add(
+            StoryLike(
+                story_id=story_id,
+                user_id=current_user.id,
+            )
+        )
+        try:
+            await db.commit()
+        except IntegrityError:
+            await db.rollback()
+
+    like_count = await _get_story_like_count(db, story_id)
+    return StoryLikeResponse(
+        story_id=story_id,
+        liked=True,
+        like_count=like_count,
+    )
+
+
+async def unlike_story(
+    db: AsyncSession,
+    story_id: uuid.UUID,
+    current_user: User,
+) -> StoryLikeResponse:
+    story_result = await db.execute(select(Story.id).where(Story.id == story_id))
+    story_exists = story_result.scalar_one_or_none()
+    if story_exists is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Story not found",
+        )
+
+    existing_like_result = await db.execute(
+        select(StoryLike).where(
+            StoryLike.story_id == story_id,
+            StoryLike.user_id == current_user.id,
+        )
+    )
+    existing_like = existing_like_result.scalar_one_or_none()
+
+    if existing_like is not None:
+        await db.delete(existing_like)
+        await db.commit()
+
+    like_count = await _get_story_like_count(db, story_id)
+    return StoryLikeResponse(
+        story_id=story_id,
+        liked=False,
+        like_count=like_count,
+    )
 
 
 async def upload_media_for_story(

--- a/backend/tests/api/test_story_api.py
+++ b/backend/tests/api/test_story_api.py
@@ -2,10 +2,12 @@ import uuid
 from datetime import date
 
 import pytest
+from sqlalchemy import func, select
 
 from app.db.enums import DatePrecision, MediaType, StoryStatus, StoryVisibility
 from app.db.media_file import MediaFile
 from app.db.story import Story
+from app.db.story_like import StoryLike
 from app.db.user import User
 from app.services.auth_service import hash_password
 
@@ -356,6 +358,7 @@ class TestStoryDetailAPI:
         assert data["date_label"] == "1923"
         assert data["status"] == "published"
         assert data["visibility"] == "public"
+        assert data["like_count"] == 0
         assert "created_at" in data
 
         assert len(data["media_files"]) == 1
@@ -373,6 +376,162 @@ class TestStoryDetailAPI:
         assert resp.status_code == 404
         data = resp.json()
         assert data["detail"] == "Story not found"
+
+
+@pytest.mark.asyncio
+class TestStoryLikeAPI:
+    async def _create_user_and_token(self, client, username, email):
+        await client.post(
+            "/auth/register",
+            json={
+                "username": username,
+                "email": email,
+                "password": "StoryLike1!",
+            },
+        )
+        login_resp = await client.post(
+            "/auth/login",
+            json={
+                "email": email,
+                "password": "StoryLike1!",
+            },
+        )
+        return login_resp.json()["access_token"]
+
+    async def test_like_story_success(self, client):
+        author_token = await self._create_user_and_token(client, "likeauthorapi", "likeauthorapi@example.com")
+        liker_token = await self._create_user_and_token(client, "likerapi", "likerapi@example.com")
+
+        create_resp = await client.post(
+            "/stories",
+            headers={"Authorization": f"Bearer {author_token}"},
+            json={
+                "title": "API Like Story",
+                "content": "Story content",
+                "summary": "Story summary",
+                "place_name": "Istanbul",
+                "latitude": 41.0082,
+                "longitude": 28.9784,
+            },
+        )
+        story_id = create_resp.json()["id"]
+
+        resp = await client.post(
+            f"/stories/{story_id}/like",
+            headers={"Authorization": f"Bearer {liker_token}"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "story_id": story_id,
+            "liked": True,
+            "like_count": 1,
+        }
+
+    async def test_duplicate_like_is_idempotent_and_persists_once(self, client, db_session):
+        author_token = await self._create_user_and_token(client, "likeauthorapi2", "likeauthorapi2@example.com")
+        liker_token = await self._create_user_and_token(client, "likerapi2", "likerapi2@example.com")
+
+        create_resp = await client.post(
+            "/stories",
+            headers={"Authorization": f"Bearer {author_token}"},
+            json={
+                "title": "Duplicate Like Story",
+                "content": "Story content",
+                "summary": "Story summary",
+                "place_name": "Ankara",
+                "latitude": 39.9334,
+                "longitude": 32.8597,
+            },
+        )
+        story_id = create_resp.json()["id"]
+
+        first_resp = await client.post(
+            f"/stories/{story_id}/like",
+            headers={"Authorization": f"Bearer {liker_token}"},
+        )
+        second_resp = await client.post(
+            f"/stories/{story_id}/like",
+            headers={"Authorization": f"Bearer {liker_token}"},
+        )
+
+        like_count_result = await db_session.execute(
+            select(func.count(StoryLike.id)).where(StoryLike.story_id == uuid.UUID(story_id))
+        )
+
+        assert first_resp.status_code == 200
+        assert second_resp.status_code == 200
+        assert first_resp.json()["like_count"] == 1
+        assert second_resp.json()["like_count"] == 1
+        assert like_count_result.scalar_one() == 1
+
+    async def test_unlike_story_success_and_repeat_is_idempotent(self, client):
+        author_token = await self._create_user_and_token(client, "likeauthorapi3", "likeauthorapi3@example.com")
+        liker_token = await self._create_user_and_token(client, "likerapi3", "likerapi3@example.com")
+
+        create_resp = await client.post(
+            "/stories",
+            headers={"Authorization": f"Bearer {author_token}"},
+            json={
+                "title": "Unlike Story",
+                "content": "Story content",
+                "summary": "Story summary",
+                "place_name": "Izmir",
+                "latitude": 38.4237,
+                "longitude": 27.1428,
+            },
+        )
+        story_id = create_resp.json()["id"]
+
+        await client.post(
+            f"/stories/{story_id}/like",
+            headers={"Authorization": f"Bearer {liker_token}"},
+        )
+
+        first_unlike = await client.delete(
+            f"/stories/{story_id}/like",
+            headers={"Authorization": f"Bearer {liker_token}"},
+        )
+        second_unlike = await client.delete(
+            f"/stories/{story_id}/like",
+            headers={"Authorization": f"Bearer {liker_token}"},
+        )
+        detail_resp = await client.get(f"/stories/{story_id}")
+
+        assert first_unlike.status_code == 200
+        assert second_unlike.status_code == 200
+        assert first_unlike.json()["liked"] is False
+        assert second_unlike.json()["liked"] is False
+        assert first_unlike.json()["like_count"] == 0
+        assert second_unlike.json()["like_count"] == 0
+        assert detail_resp.json()["like_count"] == 0
+
+    async def test_like_story_missing_story_returns_404(self, client):
+        liker_token = await self._create_user_and_token(client, "likerapi4", "likerapi4@example.com")
+
+        resp = await client.post(
+            f"/stories/{uuid.uuid4()}/like",
+            headers={"Authorization": f"Bearer {liker_token}"},
+        )
+
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Story not found"
+
+    async def test_unlike_story_missing_story_returns_404(self, client):
+        liker_token = await self._create_user_and_token(client, "likerapi5", "likerapi5@example.com")
+
+        resp = await client.delete(
+            f"/stories/{uuid.uuid4()}/like",
+            headers={"Authorization": f"Bearer {liker_token}"},
+        )
+
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Story not found"
+
+    async def test_like_story_requires_authentication(self, client):
+        resp = await client.post(f"/stories/{uuid.uuid4()}/like")
+
+        assert resp.status_code == 401
 
 
 @pytest.mark.asyncio

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -9,6 +9,7 @@ from app.db.base import Base
 from app.db.media_file import MediaFile  # noqa: F401
 from app.db.session import get_db
 from app.db.story import Story  # noqa: F401
+from app.db.story_like import StoryLike  # noqa: F401
 
 # Import all models so Base.metadata knows about them
 from app.db.user import User  # noqa: F401

--- a/backend/tests/integration/test_story_like_flow.py
+++ b/backend/tests/integration/test_story_like_flow.py
@@ -1,0 +1,102 @@
+import uuid
+
+import pytest
+
+
+@pytest.mark.asyncio
+class TestStoryLikeFlow:
+    async def _register_and_login(self, client, username, email, password):
+        await client.post(
+            "/auth/register",
+            json={"username": username, "email": email, "password": password},
+        )
+        login_resp = await client.post(
+            "/auth/login",
+            json={"email": email, "password": password},
+        )
+        return login_resp.json()["access_token"]
+
+    async def _create_story(self, client, token):
+        create_resp = await client.post(
+            "/stories",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "title": "Likable Story",
+                "content": "Content for likes",
+                "summary": "Summary for likes",
+                "place_name": "Istanbul",
+                "latitude": 41.0082,
+                "longitude": 28.9784,
+                "date_start": 1453,
+                "date_end": 1453,
+            },
+        )
+        assert create_resp.status_code == 201
+        return create_resp.json()["id"]
+
+    async def test_authenticated_user_can_like_story_and_see_detail_count(self, client):
+        author_token = await self._register_and_login(client, "likeauthor", "likeauthor@example.com", "LikeAuth1!")
+        liker_token = await self._register_and_login(client, "likeruser", "liker@example.com", "LikeUser1!")
+        story_id = await self._create_story(client, author_token)
+
+        like_resp = await client.post(
+            f"/stories/{story_id}/like",
+            headers={"Authorization": f"Bearer {liker_token}"},
+        )
+
+        assert like_resp.status_code == 200
+        assert like_resp.json() == {
+            "story_id": story_id,
+            "liked": True,
+            "like_count": 1,
+        }
+
+        detail_resp = await client.get(f"/stories/{story_id}")
+        assert detail_resp.status_code == 200
+        assert detail_resp.json()["like_count"] == 1
+
+    async def test_duplicate_like_and_duplicate_unlike_are_idempotent(self, client):
+        author_token = await self._register_and_login(client, "likeauthor2", "likeauthor2@example.com", "LikeAuth2!")
+        liker_token = await self._register_and_login(client, "likeruser2", "liker2@example.com", "LikeUser2!")
+        story_id = await self._create_story(client, author_token)
+
+        first_like = await client.post(
+            f"/stories/{story_id}/like",
+            headers={"Authorization": f"Bearer {liker_token}"},
+        )
+        second_like = await client.post(
+            f"/stories/{story_id}/like",
+            headers={"Authorization": f"Bearer {liker_token}"},
+        )
+        first_unlike = await client.delete(
+            f"/stories/{story_id}/like",
+            headers={"Authorization": f"Bearer {liker_token}"},
+        )
+        second_unlike = await client.delete(
+            f"/stories/{story_id}/like",
+            headers={"Authorization": f"Bearer {liker_token}"},
+        )
+
+        assert first_like.status_code == 200
+        assert second_like.status_code == 200
+        assert first_like.json()["like_count"] == 1
+        assert second_like.json()["like_count"] == 1
+        assert first_unlike.status_code == 200
+        assert second_unlike.status_code == 200
+        assert first_unlike.json()["like_count"] == 0
+        assert second_unlike.json()["like_count"] == 0
+
+        detail_resp = await client.get(f"/stories/{story_id}")
+        assert detail_resp.status_code == 200
+        assert detail_resp.json()["like_count"] == 0
+
+    async def test_like_missing_story_returns_404(self, client):
+        liker_token = await self._register_and_login(client, "likeruser3", "liker3@example.com", "LikeUser3!")
+
+        resp = await client.post(
+            f"/stories/{uuid.uuid4()}/like",
+            headers={"Authorization": f"Bearer {liker_token}"},
+        )
+
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Story not found"

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -13,8 +13,10 @@ from app.models.story import MediaUploadRequest, StoryCreateRequest, StoryUpdate
 from app.services.story_service import (
     create_story_with_location,
     get_story_detail_by_id,
+    like_story,
     list_available_stories,
     search_available_stories_by_place,
+    unlike_story,
     update_story_with_location_and_dates,
     upload_media_for_story,
 )
@@ -35,6 +37,7 @@ def _make_story(**overrides):
         "status": StoryStatus.PUBLISHED,
         "visibility": StoryVisibility.PUBLIC,
         "created_at": datetime.now(timezone.utc),
+        "story_likes": [],
     }
     base.update(overrides)
     return SimpleNamespace(**base)
@@ -292,7 +295,11 @@ class TestGetStoryDetailByIdService:
         story_id = uuid.uuid4()
         media_1 = _make_media_file(story_id=story_id, original_filename="photo1.png")
         media_2 = _make_media_file(story_id=story_id, original_filename="photo2.png")
-        story = _make_story(id=story_id, media_files=[media_1, media_2])
+        story = _make_story(
+            id=story_id,
+            media_files=[media_1, media_2],
+            story_likes=[SimpleNamespace(), SimpleNamespace()],
+        )
 
         db = AsyncMock()
         db.execute.return_value.one_or_none = lambda: (story, "storyauthor")
@@ -307,6 +314,7 @@ class TestGetStoryDetailByIdService:
         assert result.media_files[1].original_filename == "photo2.png"
         assert result.media_files[0].media_url.endswith("/images/stories/key.png")
         assert result.media_files[1].media_url.endswith("/images/stories/key.png")
+        assert result.like_count == 2
         db.execute.assert_awaited_once()
 
     async def test_raises_404_when_story_not_found(self):
@@ -318,6 +326,95 @@ class TestGetStoryDetailByIdService:
 
         assert exc_info.value.status_code == 404
         assert exc_info.value.detail == "Story not found"
+
+
+@pytest.mark.asyncio
+class TestStoryLikeService:
+    async def test_like_story_creates_like_and_returns_count(self):
+        story_id = uuid.uuid4()
+        current_user = SimpleNamespace(id=uuid.uuid4())
+        db = AsyncMock()
+        db.add = MagicMock()
+        db.execute.side_effect = [
+            SimpleNamespace(scalar_one_or_none=lambda: story_id),
+            SimpleNamespace(scalar_one_or_none=lambda: None),
+            SimpleNamespace(scalar_one=lambda: 1),
+        ]
+
+        result = await like_story(db, story_id, current_user)
+
+        assert result.story_id == story_id
+        assert result.liked is True
+        assert result.like_count == 1
+        db.commit.assert_awaited_once()
+        added_like = db.add.call_args.args[0]
+        assert added_like.story_id == story_id
+        assert added_like.user_id == current_user.id
+
+    async def test_like_story_is_idempotent_when_like_exists(self):
+        story_id = uuid.uuid4()
+        current_user = SimpleNamespace(id=uuid.uuid4())
+        existing_like = SimpleNamespace(id=uuid.uuid4(), story_id=story_id, user_id=current_user.id)
+        db = AsyncMock()
+        db.add = MagicMock()
+        db.execute.side_effect = [
+            SimpleNamespace(scalar_one_or_none=lambda: story_id),
+            SimpleNamespace(scalar_one_or_none=lambda: existing_like),
+            SimpleNamespace(scalar_one=lambda: 1),
+        ]
+
+        result = await like_story(db, story_id, current_user)
+
+        assert result.liked is True
+        assert result.like_count == 1
+        db.add.assert_not_called()
+        db.commit.assert_not_awaited()
+
+    async def test_like_story_raises_404_when_story_missing(self):
+        db = AsyncMock()
+        db.execute.return_value.scalar_one_or_none = lambda: None
+
+        with pytest.raises(HTTPException) as exc_info:
+            await like_story(db, uuid.uuid4(), SimpleNamespace(id=uuid.uuid4()))
+
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "Story not found"
+
+    async def test_unlike_story_deletes_like_and_returns_zero_count(self):
+        story_id = uuid.uuid4()
+        current_user = SimpleNamespace(id=uuid.uuid4())
+        existing_like = SimpleNamespace(id=uuid.uuid4(), story_id=story_id, user_id=current_user.id)
+        db = AsyncMock()
+        db.execute.side_effect = [
+            SimpleNamespace(scalar_one_or_none=lambda: story_id),
+            SimpleNamespace(scalar_one_or_none=lambda: existing_like),
+            SimpleNamespace(scalar_one=lambda: 0),
+        ]
+
+        result = await unlike_story(db, story_id, current_user)
+
+        assert result.story_id == story_id
+        assert result.liked is False
+        assert result.like_count == 0
+        db.delete.assert_awaited_once_with(existing_like)
+        db.commit.assert_awaited_once()
+
+    async def test_unlike_story_is_idempotent_when_like_missing(self):
+        story_id = uuid.uuid4()
+        current_user = SimpleNamespace(id=uuid.uuid4())
+        db = AsyncMock()
+        db.execute.side_effect = [
+            SimpleNamespace(scalar_one_or_none=lambda: story_id),
+            SimpleNamespace(scalar_one_or_none=lambda: None),
+            SimpleNamespace(scalar_one=lambda: 0),
+        ]
+
+        result = await unlike_story(db, story_id, current_user)
+
+        assert result.liked is False
+        assert result.like_count == 0
+        db.delete.assert_not_awaited()
+        db.commit.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -295,14 +295,13 @@ class TestGetStoryDetailByIdService:
         story_id = uuid.uuid4()
         media_1 = _make_media_file(story_id=story_id, original_filename="photo1.png")
         media_2 = _make_media_file(story_id=story_id, original_filename="photo2.png")
-        story = _make_story(
-            id=story_id,
-            media_files=[media_1, media_2],
-            story_likes=[SimpleNamespace(), SimpleNamespace()],
-        )
+        story = _make_story(id=story_id, media_files=[media_1, media_2])
 
         db = AsyncMock()
-        db.execute.return_value.one_or_none = lambda: (story, "storyauthor")
+        db.execute.side_effect = [
+            SimpleNamespace(one_or_none=lambda: (story, "storyauthor")),
+            SimpleNamespace(scalar_one=lambda: 2),
+        ]
 
         result = await get_story_detail_by_id(db, story_id)
 
@@ -315,7 +314,7 @@ class TestGetStoryDetailByIdService:
         assert result.media_files[0].media_url.endswith("/images/stories/key.png")
         assert result.media_files[1].media_url.endswith("/images/stories/key.png")
         assert result.like_count == 2
-        db.execute.assert_awaited_once()
+        assert db.execute.await_count == 2
 
     async def test_raises_404_when_story_not_found(self):
         db = AsyncMock()
@@ -442,6 +441,7 @@ class TestCreateStoryWithLocationService:
             story_obj.visibility = StoryVisibility.PUBLIC
 
         db.refresh.side_effect = _refresh_side_effect
+        db.execute.return_value.scalar_one = lambda: 0
 
         result = await create_story_with_location(db, current_user, payload)
 
@@ -456,6 +456,7 @@ class TestCreateStoryWithLocationService:
         assert result.status == StoryStatus.PUBLISHED
         assert result.visibility == StoryVisibility.PUBLIC
         assert result.media_files == []
+        assert result.like_count == 0
         db.add.assert_called_once()
         db.commit.assert_awaited_once()
         db.refresh.assert_awaited_once()
@@ -499,7 +500,10 @@ class TestUpdateStoryWithLocationAndDatesService:
         current_user = SimpleNamespace(id=story.user_id, username="authoruser")
 
         db = AsyncMock()
-        db.execute.return_value.scalar_one_or_none = lambda: story
+        db.execute.side_effect = [
+            SimpleNamespace(scalar_one_or_none=lambda: story),
+            SimpleNamespace(scalar_one=lambda: 4),
+        ]
 
         result = await update_story_with_location_and_dates(db, story_id, current_user, payload)
 
@@ -514,6 +518,7 @@ class TestUpdateStoryWithLocationAndDatesService:
         assert result.date_end == date(1923, 12, 31)
         assert result.date_precision == DatePrecision.YEAR
         assert result.date_label == "1920 - 1923"
+        assert result.like_count == 4
         assert result.media_files == []
         db.commit.assert_awaited_once()
         db.refresh.assert_awaited_once_with(story)


### PR DESCRIPTION
## Description
Implements story like functionality in the FastAPI backend. Authenticated users can now like and unlike stories, duplicate like/unlike actions are handled idempotently, and story detail responses now include the current `like_count`. This follows the existing backend structure for DB models, service logic, routers, migrations, and tests.

## Related Issue(s)
- Closes #202

## Changes

| File | Change |
|------|--------|
| `backend/app/db/story_like.py` | Added new `StoryLike` persistence model with foreign keys to `stories` and `users`, plus a uniqueness rule preventing duplicate likes per user/story pair. |
| `backend/app/db/story.py` | Modified to add relationship mapping for story likes. |
| `backend/app/db/user.py` | Modified to add relationship mapping for user likes. |
| `backend/app/models/story.py` | Added `StoryLikeResponse` and extended story detail responses with `like_count`. |
| `backend/app/services/story_service.py` | Added like/unlike service logic, idempotent duplicate handling, and story detail like count mapping. |
| `backend/app/routers/story.py` | Added authenticated `POST /stories/{story_id}/like` and `DELETE /stories/{story_id}/like` endpoints. |
| `backend/alembic/env.py` | Updated imports so Alembic recognizes the new `StoryLike` model. |
| `backend/alembic/versions/20260419_0004_add_story_likes.py` | Added migration creating the `story_likes` table and related indexes/constraints. |
| `backend/tests/conftest.py` | Updated test metadata imports so the new model is included during test schema setup. |
| `backend/tests/unit/test_story_service.py` | Added unit tests for like/unlike service behavior and story detail like count mapping. |
| `backend/tests/api/test_story_api.py` | Added API tests covering like success, duplicate-like idempotency, unlike behavior, authentication, and story-not-found cases. |
| `backend/tests/integration/test_story_like_flow.py` | Added integration tests covering end-to-end story like/unlike flows. |

## Checklist
- [x] All tests passed
- [x] I have self-reviewed my own code
- [x] I have requested at least 1 reviewer
