### PR TITLE
feat: add notification triggers for story interactions

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -8,6 +8,7 @@ from alembic import context
 from app.core.config import settings
 from app.db.base import Base  # noqa: F401 — import all models here so autogenerate sees them
 from app.db.media_file import MediaFile  # noqa: F401
+from app.db.notification import Notification  # noqa: F401
 from app.db.story import Story  # noqa: F401
 from app.db.story_comment import StoryComment  # noqa: F401
 from app.db.story_like import StoryLike  # noqa: F401

--- a/backend/alembic/versions/20260424_0008_add_notifications.py
+++ b/backend/alembic/versions/20260424_0008_add_notifications.py
@@ -42,7 +42,7 @@ def upgrade() -> None:
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
         sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
         sa.ForeignKeyConstraint(["actor_user_id"], ["users.id"], ondelete="CASCADE"),
-        sa.ForeignKeyConstraint(["comment_id"], ["story_comments.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["comment_id"], ["story_comments.id"], ondelete="SET NULL"),
         sa.ForeignKeyConstraint(["recipient_user_id"], ["users.id"], ondelete="CASCADE"),
         sa.ForeignKeyConstraint(["story_id"], ["stories.id"], ondelete="CASCADE"),
         sa.PrimaryKeyConstraint("id"),

--- a/backend/alembic/versions/20260424_0008_add_notifications.py
+++ b/backend/alembic/versions/20260424_0008_add_notifications.py
@@ -1,0 +1,66 @@
+"""Add notifications table.
+
+Revision ID: 20260424_0008
+Revises: 20260419_0007
+Create Date: 2026-04-24 00:00:00
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260424_0008"
+down_revision: Union[str, Sequence[str], None] = "20260419_0007"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "notifications",
+        sa.Column("recipient_user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("actor_user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("story_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("comment_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column(
+            "event_type",
+            sa.Enum(
+                "story_liked",
+                "story_commented",
+                "story_bookmarked",
+                name="notification_event_type",
+                native_enum=False,
+            ),
+            nullable=False,
+        ),
+        sa.Column("read_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.ForeignKeyConstraint(["actor_user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["comment_id"], ["story_comments.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["recipient_user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["story_id"], ["stories.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_notifications_recipient_created_at",
+        "notifications",
+        ["recipient_user_id", "created_at"],
+        unique=False,
+    )
+    op.create_index("ix_notifications_actor_user_id", "notifications", ["actor_user_id"], unique=False)
+    op.create_index("ix_notifications_story_id", "notifications", ["story_id"], unique=False)
+    op.create_index("ix_notifications_comment_id", "notifications", ["comment_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_notifications_comment_id", table_name="notifications")
+    op.drop_index("ix_notifications_story_id", table_name="notifications")
+    op.drop_index("ix_notifications_actor_user_id", table_name="notifications")
+    op.drop_index("ix_notifications_recipient_created_at", table_name="notifications")
+    op.drop_table("notifications")

--- a/backend/app/db/README.md
+++ b/backend/app/db/README.md
@@ -22,4 +22,5 @@ SQLAlchemy table models live in this package.
 - `media_files` stores storage location as `bucket_name + storage_key`, which keeps the schema compatible with MinIO locally and S3-compatible storage in production.
 - `media_files.alt_text` and `media_files.caption` are optional initial metadata fields for accessibility and presentation.
 - `notifications` records story interaction events with `recipient_user_id`, `actor_user_id`, `story_id`, and an optional `comment_id` for comment-triggered notifications.
+- If a comment is deleted later, notification history is preserved and `notifications.comment_id` is set to `NULL`.
 - Deduplication behavior is currently interaction-driven: repeated idempotent like/save requests do not create extra notifications while the underlying like/save row already exists, but a new notification is created if the user unlikes/unsaves and later performs the interaction again. Each new comment creates its own notification. Self-interactions never create notifications.

--- a/backend/app/db/README.md
+++ b/backend/app/db/README.md
@@ -7,6 +7,7 @@ SQLAlchemy table models live in this package.
 - `users`: authentication and profile fields
 - `stories`: story content plus publication metadata
 - `media_files`: object-storage-backed media linked to stories
+- `notifications`: persisted interaction events for future notification list/read APIs
 
 ## Design notes
 
@@ -20,3 +21,5 @@ SQLAlchemy table models live in this package.
 - `media_files` belongs to `stories` through `story_id`.
 - `media_files` stores storage location as `bucket_name + storage_key`, which keeps the schema compatible with MinIO locally and S3-compatible storage in production.
 - `media_files.alt_text` and `media_files.caption` are optional initial metadata fields for accessibility and presentation.
+- `notifications` records story interaction events with `recipient_user_id`, `actor_user_id`, `story_id`, and an optional `comment_id` for comment-triggered notifications.
+- Deduplication behavior is currently interaction-driven: repeated idempotent like/save requests do not create extra notifications while the underlying like/save row already exists, but a new notification is created if the user unlikes/unsaves and later performs the interaction again. Each new comment creates its own notification. Self-interactions never create notifications.

--- a/backend/app/db/enums.py
+++ b/backend/app/db/enums.py
@@ -28,3 +28,9 @@ class MediaType(str, Enum):
 class DatePrecision(str, Enum):
     YEAR = "year"
     DATE = "date"
+
+
+class NotificationEventType(str, Enum):
+    STORY_LIKED = "story_liked"
+    STORY_COMMENTED = "story_commented"
+    STORY_BOOKMARKED = "story_bookmarked"

--- a/backend/app/db/notification.py
+++ b/backend/app/db/notification.py
@@ -42,7 +42,7 @@ class Notification(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     )
     comment_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
-        ForeignKey("story_comments.id", ondelete="CASCADE"),
+        ForeignKey("story_comments.id", ondelete="SET NULL"),
         nullable=True,
     )
     event_type: Mapped[NotificationEventType] = mapped_column(

--- a/backend/app/db/notification.py
+++ b/backend/app/db/notification.py
@@ -1,0 +1,66 @@
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import DateTime, Enum, ForeignKey, Index
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+from app.db.enums import NotificationEventType
+from app.db.mixins import TimestampMixin, UUIDPrimaryKeyMixin
+
+if TYPE_CHECKING:
+    from app.db.story import Story
+    from app.db.story_comment import StoryComment
+    from app.db.user import User
+
+
+class Notification(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "notifications"
+    __table_args__ = (
+        Index("ix_notifications_recipient_created_at", "recipient_user_id", "created_at"),
+        Index("ix_notifications_actor_user_id", "actor_user_id"),
+        Index("ix_notifications_story_id", "story_id"),
+        Index("ix_notifications_comment_id", "comment_id"),
+    )
+
+    recipient_user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    actor_user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    story_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("stories.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    comment_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("story_comments.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    event_type: Mapped[NotificationEventType] = mapped_column(
+        Enum(NotificationEventType, name="notification_event_type", native_enum=False),
+        nullable=False,
+    )
+    read_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+
+    recipient_user: Mapped["User"] = relationship(
+        back_populates="received_notifications",
+        foreign_keys=[recipient_user_id],
+    )
+    actor_user: Mapped["User"] = relationship(
+        back_populates="triggered_notifications",
+        foreign_keys=[actor_user_id],
+    )
+    story: Mapped["Story"] = relationship(back_populates="notifications")
+    comment: Mapped["StoryComment | None"] = relationship(back_populates="notifications")

--- a/backend/app/db/story.py
+++ b/backend/app/db/story.py
@@ -12,6 +12,7 @@ from app.db.mixins import TimestampMixin, UUIDPrimaryKeyMixin
 
 if TYPE_CHECKING:
     from app.db.media_file import MediaFile
+    from app.db.notification import Notification
     from app.db.story_comment import StoryComment
     from app.db.story_like import StoryLike
     from app.db.story_save import StorySave
@@ -79,3 +80,4 @@ class Story(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         back_populates="story",
         cascade="all, delete-orphan",
     )
+    notifications: Mapped[list["Notification"]] = relationship(back_populates="story")

--- a/backend/app/db/story_comment.py
+++ b/backend/app/db/story_comment.py
@@ -9,6 +9,7 @@ from app.db.base import Base
 from app.db.mixins import TimestampMixin, UUIDPrimaryKeyMixin
 
 if TYPE_CHECKING:
+    from app.db.notification import Notification
     from app.db.story import Story
     from app.db.user import User
 
@@ -34,3 +35,4 @@ class StoryComment(UUIDPrimaryKeyMixin, TimestampMixin, Base):
 
     story: Mapped["Story"] = relationship(back_populates="comments")
     user: Mapped["User"] = relationship(back_populates="comments")
+    notifications: Mapped[list["Notification"]] = relationship(back_populates="comment")

--- a/backend/app/db/user.py
+++ b/backend/app/db/user.py
@@ -8,6 +8,7 @@ from app.db.enums import UserRole
 from app.db.mixins import TimestampMixin, UUIDPrimaryKeyMixin
 
 if TYPE_CHECKING:
+    from app.db.notification import Notification
     from app.db.story import Story
     from app.db.story_comment import StoryComment
     from app.db.story_like import StoryLike
@@ -55,4 +56,12 @@ class User(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     story_likes: Mapped[list["StoryLike"]] = relationship(
         back_populates="user",
         cascade="all, delete-orphan",
+    )
+    received_notifications: Mapped[list["Notification"]] = relationship(
+        back_populates="recipient_user",
+        foreign_keys="Notification.recipient_user_id",
+    )
+    triggered_notifications: Mapped[list["Notification"]] = relationship(
+        back_populates="actor_user",
+        foreign_keys="Notification.actor_user_id",
     )

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -8,8 +8,9 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.db.enums import StoryStatus, StoryVisibility
+from app.db.enums import NotificationEventType, StoryStatus, StoryVisibility
 from app.db.media_file import MediaFile
+from app.db.notification import Notification
 from app.db.story import Story
 from app.db.story_comment import StoryComment
 from app.db.story_like import StoryLike
@@ -137,6 +138,44 @@ def _build_media_storage_key(story_id: uuid.UUID, filename: str) -> str:
     return f"stories/{story_id}/media/{uuid.uuid4()}{ext}"
 
 
+async def _get_story_or_404(
+    db: AsyncSession,
+    story_id: uuid.UUID,
+) -> Story:
+    story_result = await db.execute(select(Story).where(Story.id == story_id))
+    story = story_result.scalar_one_or_none()
+    if story is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Story not found",
+        )
+    return story
+
+
+def _queue_story_interaction_notification(
+    db: AsyncSession,
+    *,
+    story: Story,
+    actor: User,
+    event_type: NotificationEventType,
+    comment_id: uuid.UUID | None = None,
+) -> None:
+    # Duplicate likes/saves are ignored at the interaction-table level; notifications
+    # are only queued when a new interaction row is actually being created.
+    if story.user_id == actor.id:
+        return
+
+    db.add(
+        Notification(
+            recipient_user_id=story.user_id,
+            actor_user_id=actor.id,
+            story_id=story.id,
+            comment_id=comment_id,
+            event_type=event_type,
+        )
+    )
+
+
 async def list_available_stories(
     db: AsyncSession,
     min_lat: float | None = None,
@@ -240,13 +279,7 @@ async def list_comments_for_story(
     db: AsyncSession,
     story_id: uuid.UUID,
 ) -> CommentListResponse:
-    story_result = await db.execute(select(Story.id).where(Story.id == story_id))
-    story_exists = story_result.scalar_one_or_none()
-    if story_exists is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Story not found",
-        )
+    await _get_story_or_404(db, story_id)
 
     stmt = (
         select(StoryComment, User)
@@ -266,13 +299,7 @@ async def create_comment_for_story(
     current_user: User,
     payload: CommentCreateRequest,
 ) -> CommentResponse:
-    story_result = await db.execute(select(Story.id).where(Story.id == story_id))
-    story_exists = story_result.scalar_one_or_none()
-    if story_exists is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Story not found",
-        )
+    story = await _get_story_or_404(db, story_id)
 
     comment = StoryComment(
         story_id=story_id,
@@ -280,6 +307,14 @@ async def create_comment_for_story(
         content=payload.content,
     )
     db.add(comment)
+    await db.flush()
+    _queue_story_interaction_notification(
+        db,
+        story=story,
+        actor=current_user,
+        event_type=NotificationEventType.STORY_COMMENTED,
+        comment_id=comment.id,
+    )
     await db.commit()
     await db.refresh(comment)
 
@@ -292,13 +327,7 @@ async def delete_comment_for_story(
     comment_id: uuid.UUID,
     current_user: User,
 ) -> None:
-    story_result = await db.execute(select(Story.id).where(Story.id == story_id))
-    story_exists = story_result.scalar_one_or_none()
-    if story_exists is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Story not found",
-        )
+    await _get_story_or_404(db, story_id)
 
     comment_result = await db.execute(
         select(StoryComment).where(
@@ -328,13 +357,7 @@ async def save_story_for_user(
     story_id: uuid.UUID,
     current_user: User,
 ) -> StorySaveResponse:
-    story_result = await db.execute(select(Story.id).where(Story.id == story_id))
-    story_exists = story_result.scalar_one_or_none()
-    if story_exists is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Story not found",
-        )
+    story = await _get_story_or_404(db, story_id)
 
     existing_save_result = await db.execute(
         select(StorySave).where(
@@ -346,6 +369,12 @@ async def save_story_for_user(
 
     if existing_save is None:
         db.add(StorySave(story_id=story_id, user_id=current_user.id))
+        _queue_story_interaction_notification(
+            db,
+            story=story,
+            actor=current_user,
+            event_type=NotificationEventType.STORY_BOOKMARKED,
+        )
         try:
             await db.commit()
         except IntegrityError:
@@ -359,13 +388,7 @@ async def unsave_story_for_user(
     story_id: uuid.UUID,
     current_user: User,
 ) -> StorySaveResponse:
-    story_result = await db.execute(select(Story.id).where(Story.id == story_id))
-    story_exists = story_result.scalar_one_or_none()
-    if story_exists is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Story not found",
-        )
+    await _get_story_or_404(db, story_id)
 
     existing_save_result = await db.execute(
         select(StorySave).where(
@@ -487,13 +510,7 @@ async def like_story(
     story_id: uuid.UUID,
     current_user: User,
 ) -> StoryLikeResponse:
-    story_result = await db.execute(select(Story.id).where(Story.id == story_id))
-    story_exists = story_result.scalar_one_or_none()
-    if story_exists is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Story not found",
-        )
+    story = await _get_story_or_404(db, story_id)
 
     existing_like_result = await db.execute(
         select(StoryLike).where(
@@ -509,6 +526,12 @@ async def like_story(
                 story_id=story_id,
                 user_id=current_user.id,
             )
+        )
+        _queue_story_interaction_notification(
+            db,
+            story=story,
+            actor=current_user,
+            event_type=NotificationEventType.STORY_LIKED,
         )
         try:
             await db.commit()
@@ -528,13 +551,7 @@ async def unlike_story(
     story_id: uuid.UUID,
     current_user: User,
 ) -> StoryLikeResponse:
-    story_result = await db.execute(select(Story.id).where(Story.id == story_id))
-    story_exists = story_result.scalar_one_or_none()
-    if story_exists is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Story not found",
-        )
+    await _get_story_or_404(db, story_id)
 
     existing_like_result = await db.execute(
         select(StoryLike).where(

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from app.core.config import settings
 from app.db.base import Base
 from app.db.media_file import MediaFile  # noqa: F401
+from app.db.notification import Notification  # noqa: F401
 from app.db.session import get_db
 from app.db.story import Story  # noqa: F401
 from app.db.story_comment import StoryComment  # noqa: F401

--- a/backend/tests/integration/test_story_notification_flow.py
+++ b/backend/tests/integration/test_story_notification_flow.py
@@ -1,0 +1,203 @@
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from app.db.enums import NotificationEventType
+from app.db.notification import Notification
+from app.db.story import Story
+from app.db.user import User
+
+
+@pytest.mark.asyncio
+class TestStoryNotificationFlow:
+    async def _register_and_login(self, client, username, email, password):
+        await client.post(
+            "/auth/register",
+            json={"username": username, "email": email, "password": password},
+        )
+        login_resp = await client.post(
+            "/auth/login",
+            json={"email": email, "password": password},
+        )
+        return login_resp.json()["access_token"]
+
+    async def _create_story(self, client, token, title="Story for notifications"):
+        create_resp = await client.post(
+            "/stories",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "title": title,
+                "content": "Story content",
+                "summary": "Story summary",
+                "place_name": "Istanbul",
+                "latitude": 41.0082,
+                "longitude": 28.9784,
+                "date_start": 1453,
+                "date_end": 1453,
+            },
+        )
+        assert create_resp.status_code == 201
+        return create_resp.json()["id"]
+
+    async def _get_notifications(self, db_session):
+        result = await db_session.execute(select(Notification).order_by(Notification.created_at.asc(), Notification.id.asc()))
+        return result.scalars().all()
+
+    async def test_like_comment_and_save_create_notifications_for_story_author(self, client, db_session):
+        author_token = await self._register_and_login(client, "notifauthor", "notifauthor@example.com", "NotifPass1!")
+        actor_token = await self._register_and_login(client, "notifactor", "notifactor@example.com", "NotifPass2!")
+        story_id = await self._create_story(client, author_token)
+
+        like_resp = await client.post(
+            f"/stories/{story_id}/like",
+            headers={"Authorization": f"Bearer {actor_token}"},
+        )
+        comment_resp = await client.post(
+            f"/stories/{story_id}/comments",
+            headers={"Authorization": f"Bearer {actor_token}"},
+            json={"content": "Great story"},
+        )
+        save_resp = await client.post(
+            f"/stories/{story_id}/save",
+            headers={"Authorization": f"Bearer {actor_token}"},
+        )
+
+        story = await db_session.get(Story, uuid.UUID(story_id))
+        author = (
+            await db_session.execute(select(User).where(User.username == "notifauthor"))
+        ).scalar_one()
+        actor = (
+            await db_session.execute(select(User).where(User.username == "notifactor"))
+        ).scalar_one()
+        notifications = await self._get_notifications(db_session)
+
+        assert like_resp.status_code == 200
+        assert comment_resp.status_code == 201
+        assert save_resp.status_code == 200
+        assert len(notifications) == 3
+
+        notifications_by_type = {notification.event_type: notification for notification in notifications}
+        like_notification = notifications_by_type[NotificationEventType.STORY_LIKED]
+        comment_notification = notifications_by_type[NotificationEventType.STORY_COMMENTED]
+        save_notification = notifications_by_type[NotificationEventType.STORY_BOOKMARKED]
+
+        assert like_notification.recipient_user_id == author.id
+        assert like_notification.actor_user_id == actor.id
+        assert like_notification.story_id == story.id
+        assert like_notification.event_type == NotificationEventType.STORY_LIKED
+        assert like_notification.comment_id is None
+
+        assert comment_notification.recipient_user_id == author.id
+        assert comment_notification.actor_user_id == actor.id
+        assert comment_notification.story_id == story.id
+        assert comment_notification.event_type == NotificationEventType.STORY_COMMENTED
+        assert comment_notification.comment_id == uuid.UUID(comment_resp.json()["id"])
+
+        assert save_notification.recipient_user_id == author.id
+        assert save_notification.actor_user_id == actor.id
+        assert save_notification.story_id == story.id
+        assert save_notification.event_type == NotificationEventType.STORY_BOOKMARKED
+        assert save_notification.comment_id is None
+
+    async def test_self_interactions_do_not_create_notifications(self, client, db_session):
+        author_token = await self._register_and_login(
+            client, "notifselfauthor", "notifselfauthor@example.com", "NotifPass3!"
+        )
+        story_id = await self._create_story(client, author_token, title="Self notification story")
+
+        like_resp = await client.post(
+            f"/stories/{story_id}/like",
+            headers={"Authorization": f"Bearer {author_token}"},
+        )
+        comment_resp = await client.post(
+            f"/stories/{story_id}/comments",
+            headers={"Authorization": f"Bearer {author_token}"},
+            json={"content": "Talking to myself"},
+        )
+        save_resp = await client.post(
+            f"/stories/{story_id}/save",
+            headers={"Authorization": f"Bearer {author_token}"},
+        )
+
+        notifications = await self._get_notifications(db_session)
+
+        assert like_resp.status_code == 200
+        assert comment_resp.status_code == 201
+        assert save_resp.status_code == 200
+        assert notifications == []
+
+    async def test_duplicate_requests_do_not_duplicate_active_interaction_notifications(self, client, db_session):
+        author_token = await self._register_and_login(
+            client, "notifdedupeauthor", "notifdedupeauthor@example.com", "NotifPass4!"
+        )
+        actor_token = await self._register_and_login(client, "notifdedupeactor", "notifdedupeactor@example.com", "NotifPass5!")
+        story_id = await self._create_story(client, author_token, title="Dedupe story")
+
+        first_like = await client.post(
+            f"/stories/{story_id}/like",
+            headers={"Authorization": f"Bearer {actor_token}"},
+        )
+        second_like = await client.post(
+            f"/stories/{story_id}/like",
+            headers={"Authorization": f"Bearer {actor_token}"},
+        )
+        first_save = await client.post(
+            f"/stories/{story_id}/save",
+            headers={"Authorization": f"Bearer {actor_token}"},
+        )
+        second_save = await client.post(
+            f"/stories/{story_id}/save",
+            headers={"Authorization": f"Bearer {actor_token}"},
+        )
+
+        notifications = await self._get_notifications(db_session)
+        event_types = [notification.event_type for notification in notifications]
+
+        assert first_like.status_code == 200
+        assert second_like.status_code == 200
+        assert first_save.status_code == 200
+        assert second_save.status_code == 200
+        assert event_types.count(NotificationEventType.STORY_LIKED) == 1
+        assert event_types.count(NotificationEventType.STORY_BOOKMARKED) == 1
+
+    async def test_reliking_and_resaving_after_removal_create_fresh_notifications(self, client, db_session):
+        author_token = await self._register_and_login(
+            client, "notifrepeatauthor", "notifrepeatauthor@example.com", "NotifPass6!"
+        )
+        actor_token = await self._register_and_login(client, "notifrepeatactor", "notifrepeatactor@example.com", "NotifPass7!")
+        story_id = await self._create_story(client, author_token, title="Repeat story")
+
+        await client.post(
+            f"/stories/{story_id}/like",
+            headers={"Authorization": f"Bearer {actor_token}"},
+        )
+        await client.delete(
+            f"/stories/{story_id}/like",
+            headers={"Authorization": f"Bearer {actor_token}"},
+        )
+        relike_resp = await client.post(
+            f"/stories/{story_id}/like",
+            headers={"Authorization": f"Bearer {actor_token}"},
+        )
+
+        await client.post(
+            f"/stories/{story_id}/save",
+            headers={"Authorization": f"Bearer {actor_token}"},
+        )
+        await client.delete(
+            f"/stories/{story_id}/save",
+            headers={"Authorization": f"Bearer {actor_token}"},
+        )
+        resave_resp = await client.post(
+            f"/stories/{story_id}/save",
+            headers={"Authorization": f"Bearer {actor_token}"},
+        )
+
+        notifications = await self._get_notifications(db_session)
+        event_types = [notification.event_type for notification in notifications]
+
+        assert relike_resp.status_code == 200
+        assert resave_resp.status_code == 200
+        assert event_types.count(NotificationEventType.STORY_LIKED) == 2
+        assert event_types.count(NotificationEventType.STORY_BOOKMARKED) == 2

--- a/backend/tests/integration/test_story_notification_flow.py
+++ b/backend/tests/integration/test_story_notification_flow.py
@@ -203,3 +203,30 @@ class TestStoryNotificationFlow:
         assert resave_resp.status_code == 200
         assert event_types.count(NotificationEventType.STORY_LIKED) == 2
         assert event_types.count(NotificationEventType.STORY_BOOKMARKED) == 2
+
+    async def test_deleting_comment_preserves_notification_history(self, client, db_session):
+        author_token = await self._register_and_login(
+            client, "notifdeleteauthor", "notifdeleteauthor@example.com", "NotifPass8!"
+        )
+        actor_token = await self._register_and_login(
+            client, "notifdeleteactor", "notifdeleteactor@example.com", "NotifPass9!"
+        )
+        story_id = await self._create_story(client, author_token, title="Delete comment history story")
+
+        comment_resp = await client.post(
+            f"/stories/{story_id}/comments",
+            headers={"Authorization": f"Bearer {actor_token}"},
+            json={"content": "Temporary comment"},
+        )
+        assert comment_resp.status_code == 201
+
+        delete_resp = await client.delete(
+            f"/stories/{story_id}/comments/{comment_resp.json()['id']}",
+            headers={"Authorization": f"Bearer {actor_token}"},
+        )
+        notifications = await self._get_notifications(db_session)
+
+        assert delete_resp.status_code == 204
+        assert len(notifications) == 1
+        assert notifications[0].event_type == NotificationEventType.STORY_COMMENTED
+        assert notifications[0].comment_id is None

--- a/backend/tests/integration/test_story_notification_flow.py
+++ b/backend/tests/integration/test_story_notification_flow.py
@@ -41,7 +41,9 @@ class TestStoryNotificationFlow:
         return create_resp.json()["id"]
 
     async def _get_notifications(self, db_session):
-        result = await db_session.execute(select(Notification).order_by(Notification.created_at.asc(), Notification.id.asc()))
+        result = await db_session.execute(
+            select(Notification).order_by(Notification.created_at.asc(), Notification.id.asc())
+        )
         return result.scalars().all()
 
     async def test_like_comment_and_save_create_notifications_for_story_author(self, client, db_session):
@@ -64,12 +66,8 @@ class TestStoryNotificationFlow:
         )
 
         story = await db_session.get(Story, uuid.UUID(story_id))
-        author = (
-            await db_session.execute(select(User).where(User.username == "notifauthor"))
-        ).scalar_one()
-        actor = (
-            await db_session.execute(select(User).where(User.username == "notifactor"))
-        ).scalar_one()
+        author = (await db_session.execute(select(User).where(User.username == "notifauthor"))).scalar_one()
+        actor = (await db_session.execute(select(User).where(User.username == "notifactor"))).scalar_one()
         notifications = await self._get_notifications(db_session)
 
         assert like_resp.status_code == 200
@@ -131,7 +129,9 @@ class TestStoryNotificationFlow:
         author_token = await self._register_and_login(
             client, "notifdedupeauthor", "notifdedupeauthor@example.com", "NotifPass4!"
         )
-        actor_token = await self._register_and_login(client, "notifdedupeactor", "notifdedupeactor@example.com", "NotifPass5!")
+        actor_token = await self._register_and_login(
+            client, "notifdedupeactor", "notifdedupeactor@example.com", "NotifPass5!"
+        )
         story_id = await self._create_story(client, author_token, title="Dedupe story")
 
         first_like = await client.post(
@@ -165,7 +165,9 @@ class TestStoryNotificationFlow:
         author_token = await self._register_and_login(
             client, "notifrepeatauthor", "notifrepeatauthor@example.com", "NotifPass6!"
         )
-        actor_token = await self._register_and_login(client, "notifrepeatactor", "notifrepeatactor@example.com", "NotifPass7!")
+        actor_token = await self._register_and_login(
+            client, "notifrepeatactor", "notifrepeatactor@example.com", "NotifPass7!"
+        )
         story_id = await self._create_story(client, author_token, title="Repeat story")
 
         await client.post(

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -8,7 +8,8 @@ import pytest
 from fastapi import HTTPException
 from starlette.datastructures import Headers, UploadFile
 
-from app.db.enums import DatePrecision, MediaType, StoryStatus, StoryVisibility
+from app.db.enums import DatePrecision, MediaType, NotificationEventType, StoryStatus, StoryVisibility
+from app.db.notification import Notification
 from app.models.comment import CommentCreateRequest
 from app.models.story import MediaUploadRequest, StoryCreateRequest, StoryUpdateRequest
 from app.services.story_service import (
@@ -416,10 +417,11 @@ class TestStorySaveService:
     async def test_save_story_creates_save_and_returns_saved_true(self):
         story_id = uuid.uuid4()
         current_user = _make_user()
+        story = _make_story(id=story_id, user_id=uuid.uuid4())
         db = AsyncMock()
         db.add = MagicMock()
         db.execute.side_effect = [
-            SimpleNamespace(scalar_one_or_none=lambda: story_id),
+            SimpleNamespace(scalar_one_or_none=lambda: story),
             SimpleNamespace(scalar_one_or_none=lambda: None),
         ]
 
@@ -427,20 +429,27 @@ class TestStorySaveService:
 
         assert result.story_id == story_id
         assert result.saved is True
-        db.add.assert_called_once()
-        added_save = db.add.call_args.args[0]
+        assert db.add.call_count == 2
+        added_save = db.add.call_args_list[0].args[0]
         assert added_save.story_id == story_id
         assert added_save.user_id == current_user.id
+        added_notification = db.add.call_args_list[1].args[0]
+        assert isinstance(added_notification, Notification)
+        assert added_notification.recipient_user_id == story.user_id
+        assert added_notification.actor_user_id == current_user.id
+        assert added_notification.story_id == story_id
+        assert added_notification.event_type == NotificationEventType.STORY_BOOKMARKED
         db.commit.assert_awaited_once()
 
     async def test_save_story_is_idempotent_when_already_saved(self):
         story_id = uuid.uuid4()
         current_user = _make_user()
+        story = _make_story(id=story_id, user_id=uuid.uuid4())
         existing_save = SimpleNamespace(id=uuid.uuid4(), story_id=story_id, user_id=current_user.id)
         db = AsyncMock()
         db.add = MagicMock()
         db.execute.side_effect = [
-            SimpleNamespace(scalar_one_or_none=lambda: story_id),
+            SimpleNamespace(scalar_one_or_none=lambda: story),
             SimpleNamespace(scalar_one_or_none=lambda: existing_save),
         ]
 
@@ -463,10 +472,11 @@ class TestStorySaveService:
     async def test_unsave_story_deletes_save_when_present(self):
         story_id = uuid.uuid4()
         current_user = _make_user()
+        story = _make_story(id=story_id)
         existing_save = SimpleNamespace(id=uuid.uuid4(), story_id=story_id, user_id=current_user.id)
         db = AsyncMock()
         db.execute.side_effect = [
-            SimpleNamespace(scalar_one_or_none=lambda: story_id),
+            SimpleNamespace(scalar_one_or_none=lambda: story),
             SimpleNamespace(scalar_one_or_none=lambda: existing_save),
         ]
 
@@ -480,9 +490,10 @@ class TestStorySaveService:
     async def test_unsave_story_is_idempotent_when_not_saved(self):
         story_id = uuid.uuid4()
         current_user = _make_user()
+        story = _make_story(id=story_id)
         db = AsyncMock()
         db.execute.side_effect = [
-            SimpleNamespace(scalar_one_or_none=lambda: story_id),
+            SimpleNamespace(scalar_one_or_none=lambda: story),
             SimpleNamespace(scalar_one_or_none=lambda: None),
         ]
 
@@ -530,7 +541,7 @@ class TestStoryCommentService:
 
         db = AsyncMock()
         db.execute.side_effect = [
-            SimpleNamespace(scalar_one_or_none=lambda: story_id),
+            SimpleNamespace(scalar_one_or_none=lambda: _make_story(id=story_id)),
             SimpleNamespace(all=lambda: [(first_comment, first_author), (second_comment, second_author)]),
         ]
 
@@ -555,16 +566,22 @@ class TestStoryCommentService:
         story_id = uuid.uuid4()
         current_user = _make_user()
         payload = CommentCreateRequest(content="  New comment  ")
+        story = _make_story(id=story_id, user_id=uuid.uuid4())
 
         db = AsyncMock()
         db.add = MagicMock()
-        db.execute.return_value.scalar_one_or_none = lambda: story_id
+        db.execute.return_value.scalar_one_or_none = lambda: story
 
         async def _refresh_side_effect(comment_obj):
             comment_obj.id = uuid.uuid4()
             comment_obj.created_at = datetime.now(timezone.utc)
             comment_obj.updated_at = datetime.now(timezone.utc)
 
+        async def _flush_side_effect():
+            comment_obj = db.add.call_args_list[0].args[0]
+            comment_obj.id = uuid.uuid4()
+
+        db.flush.side_effect = _flush_side_effect
         db.refresh.side_effect = _refresh_side_effect
 
         result = await create_comment_for_story(db, story_id, current_user, payload)
@@ -572,7 +589,15 @@ class TestStoryCommentService:
         assert result.story_id == story_id
         assert result.content == "New comment"
         assert result.author.username == "storyauthor"
-        db.add.assert_called_once()
+        assert db.add.call_count == 2
+        added_notification = db.add.call_args_list[1].args[0]
+        assert isinstance(added_notification, Notification)
+        assert added_notification.recipient_user_id == story.user_id
+        assert added_notification.actor_user_id == current_user.id
+        assert added_notification.story_id == story_id
+        assert added_notification.event_type == NotificationEventType.STORY_COMMENTED
+        assert added_notification.comment_id is not None
+        db.flush.assert_awaited_once()
         db.commit.assert_awaited_once()
         db.refresh.assert_awaited_once()
 
@@ -593,9 +618,10 @@ class TestStoryCommentService:
         comment_id = uuid.uuid4()
         current_user = _make_user()
         comment = _make_comment(id=comment_id, story_id=story_id, user_id=current_user.id)
+        story = _make_story(id=story_id)
         db = AsyncMock()
         db.execute.side_effect = [
-            SimpleNamespace(scalar_one_or_none=lambda: story_id),
+            SimpleNamespace(scalar_one_or_none=lambda: story),
             SimpleNamespace(scalar_one_or_none=lambda: comment),
         ]
 
@@ -609,9 +635,10 @@ class TestStoryCommentService:
         comment_id = uuid.uuid4()
         current_user = _make_user()
         comment = _make_comment(id=comment_id, story_id=story_id, user_id=uuid.uuid4())
+        story = _make_story(id=story_id)
         db = AsyncMock()
         db.execute.side_effect = [
-            SimpleNamespace(scalar_one_or_none=lambda: story_id),
+            SimpleNamespace(scalar_one_or_none=lambda: story),
             SimpleNamespace(scalar_one_or_none=lambda: comment),
         ]
 
@@ -624,9 +651,10 @@ class TestStoryCommentService:
 
     async def test_delete_comment_raises_404_when_comment_missing(self):
         story_id = uuid.uuid4()
+        story = _make_story(id=story_id)
         db = AsyncMock()
         db.execute.side_effect = [
-            SimpleNamespace(scalar_one_or_none=lambda: story_id),
+            SimpleNamespace(scalar_one_or_none=lambda: story),
             SimpleNamespace(scalar_one_or_none=lambda: None),
         ]
 
@@ -652,10 +680,11 @@ class TestStoryLikeService:
     async def test_like_story_creates_like_and_returns_count(self):
         story_id = uuid.uuid4()
         current_user = SimpleNamespace(id=uuid.uuid4())
+        story = _make_story(id=story_id, user_id=uuid.uuid4())
         db = AsyncMock()
         db.add = MagicMock()
         db.execute.side_effect = [
-            SimpleNamespace(scalar_one_or_none=lambda: story_id),
+            SimpleNamespace(scalar_one_or_none=lambda: story),
             SimpleNamespace(scalar_one_or_none=lambda: None),
             SimpleNamespace(scalar_one=lambda: 1),
         ]
@@ -666,18 +695,26 @@ class TestStoryLikeService:
         assert result.liked is True
         assert result.like_count == 1
         db.commit.assert_awaited_once()
-        added_like = db.add.call_args.args[0]
+        assert db.add.call_count == 2
+        added_like = db.add.call_args_list[0].args[0]
         assert added_like.story_id == story_id
         assert added_like.user_id == current_user.id
+        added_notification = db.add.call_args_list[1].args[0]
+        assert isinstance(added_notification, Notification)
+        assert added_notification.recipient_user_id == story.user_id
+        assert added_notification.actor_user_id == current_user.id
+        assert added_notification.story_id == story_id
+        assert added_notification.event_type == NotificationEventType.STORY_LIKED
 
     async def test_like_story_is_idempotent_when_like_exists(self):
         story_id = uuid.uuid4()
         current_user = SimpleNamespace(id=uuid.uuid4())
+        story = _make_story(id=story_id, user_id=uuid.uuid4())
         existing_like = SimpleNamespace(id=uuid.uuid4(), story_id=story_id, user_id=current_user.id)
         db = AsyncMock()
         db.add = MagicMock()
         db.execute.side_effect = [
-            SimpleNamespace(scalar_one_or_none=lambda: story_id),
+            SimpleNamespace(scalar_one_or_none=lambda: story),
             SimpleNamespace(scalar_one_or_none=lambda: existing_like),
             SimpleNamespace(scalar_one=lambda: 1),
         ]
@@ -703,9 +740,10 @@ class TestStoryLikeService:
         story_id = uuid.uuid4()
         current_user = SimpleNamespace(id=uuid.uuid4())
         existing_like = SimpleNamespace(id=uuid.uuid4(), story_id=story_id, user_id=current_user.id)
+        story = _make_story(id=story_id)
         db = AsyncMock()
         db.execute.side_effect = [
-            SimpleNamespace(scalar_one_or_none=lambda: story_id),
+            SimpleNamespace(scalar_one_or_none=lambda: story),
             SimpleNamespace(scalar_one_or_none=lambda: existing_like),
             SimpleNamespace(scalar_one=lambda: 0),
         ]
@@ -721,9 +759,10 @@ class TestStoryLikeService:
     async def test_unlike_story_is_idempotent_when_like_missing(self):
         story_id = uuid.uuid4()
         current_user = SimpleNamespace(id=uuid.uuid4())
+        story = _make_story(id=story_id)
         db = AsyncMock()
         db.execute.side_effect = [
-            SimpleNamespace(scalar_one_or_none=lambda: story_id),
+            SimpleNamespace(scalar_one_or_none=lambda: story),
             SimpleNamespace(scalar_one_or_none=lambda: None),
             SimpleNamespace(scalar_one=lambda: 0),
         ]


### PR DESCRIPTION
## Description
Adds backend notification trigger support for story interactions so story authors can be notified when another user likes, comments on, or bookmarks their story.

This PR introduces the notification persistence foundation, wires notification creation into the existing like/comment/save flows, prevents self-notifications, and defines deduplication behavior for repeated interactions. It does not add a notification listing/read API or frontend notification UI.

## Related Issue(s)
- Closes #207

## Changes

| File | Change |
|------|--------|
| `backend/app/db/notification.py` | Added the new notification persistence model for interaction-based events. |
| `backend/app/db/enums.py` | Added notification event type enums for like, comment, and bookmark notifications. |
| `backend/app/db/story.py` | Added the story-to-notifications relationship. |
| `backend/app/db/story_comment.py` | Added the comment-to-notifications relationship for comment-triggered notifications. |
| `backend/app/db/user.py` | Added user relationships for received and triggered notifications. |
| `backend/app/services/story_service.py` | Added notification creation logic to the existing like, comment, and save flows, including self-notification prevention and deduplication behavior. |
| `backend/alembic/env.py` | Imported the notification model so Alembic can detect it. |
| `backend/alembic/versions/20260424_0008_add_notifications.py` | Added the migration for the new `notifications` table. |
| `backend/tests/conftest.py` | Registered the notification model in test metadata setup. |
| `backend/tests/unit/test_story_service.py` | Updated service tests to cover notification side effects. |
| `backend/tests/integration/test_story_notification_flow.py` | Added integration tests for notification creation, self-notification prevention, and duplicate-trigger behavior. |
| `backend/app/db/README.md` | Documented the new notification table and the deduplication rules. |

## Checklist
- [x] All tests passed 
- [x] I have self-reviewed my own code
- [x] I have requested at least 1 reviewer
