### PR TITLE
feat: implement Haversine geospatial query for nearby stories

### DIFF
--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -650,9 +650,7 @@ async def get_nearby_stories(
     dlat = lat2 - lat1
     dlon = lon2 - lon1
 
-    a = func.pow(func.sin(dlat / 2), 2) + func.cos(lat1) * func.cos(lat2) * func.pow(
-        func.sin(dlon / 2), 2
-    )
+    a = func.pow(func.sin(dlat / 2), 2) + func.cos(lat1) * func.cos(lat2) * func.pow(func.sin(dlon / 2), 2)
     distance_km = func.asin(func.sqrt(a)) * (_EARTH_RADIUS_KM * 2)
 
     stmt = (

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -631,3 +631,44 @@ async def upload_media_for_story(
         )
 
     return MediaUploadResponse(media=_map_media_file(media))
+
+
+_EARTH_RADIUS_KM = 6371.0
+
+
+async def get_nearby_stories(
+    db: AsyncSession,
+    center_lat: float,
+    center_lng: float,
+    radius_km: float = 10.0,
+) -> StoryListResponse:
+    lat1 = func.radians(center_lat)
+    lat2 = func.radians(Story.latitude)
+    lon1 = func.radians(center_lng)
+    lon2 = func.radians(Story.longitude)
+
+    dlat = lat2 - lat1
+    dlon = lon2 - lon1
+
+    a = func.pow(func.sin(dlat / 2), 2) + func.cos(lat1) * func.cos(lat2) * func.pow(
+        func.sin(dlon / 2), 2
+    )
+    distance_km = func.asin(func.sqrt(a)) * (_EARTH_RADIUS_KM * 2)
+
+    stmt = (
+        select(Story, User.username)
+        .join(User, Story.user_id == User.id)
+        .where(
+            Story.status == StoryStatus.PUBLISHED,
+            Story.visibility == StoryVisibility.PUBLIC,
+            Story.latitude.is_not(None),
+            Story.longitude.is_not(None),
+            distance_km <= radius_km,
+        )
+        .order_by(distance_km)
+    )
+
+    result = await db.execute(stmt)
+    rows = result.all()
+
+    return _map_story_rows(rows)

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -15,6 +15,7 @@ from app.services.story_service import (
     create_comment_for_story,
     create_story_with_location,
     delete_comment_for_story,
+    get_nearby_stories,
     get_story_detail_by_id,
     like_story,
     list_available_stories,
@@ -889,3 +890,85 @@ class TestUpdateStoryWithLocationAndDatesService:
         assert exc_info.value.status_code == 422
         assert "place_name is required" in exc_info.value.detail
         db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+class TestGetNearbyStoriesService:
+    async def test_returns_nearby_stories_and_total(self):
+        story = _make_story()
+
+        db = AsyncMock()
+        db.execute.return_value.all = lambda: [(story, "storyauthor")]
+
+        result = await get_nearby_stories(db, center_lat=41.0082, center_lng=28.9784)
+
+        assert result.total == 1
+        assert len(result.stories) == 1
+        item = result.stories[0]
+        assert item.id == story.id
+        assert item.title == "Story Title"
+        assert item.author == "storyauthor"
+        assert item.latitude == 41.0082
+        assert item.longitude == 28.9784
+        db.execute.assert_awaited_once()
+
+    async def test_returns_empty_response_when_no_stories_in_radius(self):
+        db = AsyncMock()
+        db.execute.return_value.all = lambda: []
+
+        result = await get_nearby_stories(db, center_lat=0.0, center_lng=0.0, radius_km=1.0)
+
+        assert result.total == 0
+        assert result.stories == []
+        db.execute.assert_awaited_once()
+
+    async def test_query_uses_haversine_formula(self):
+        db = AsyncMock()
+        db.execute.return_value.all = lambda: []
+
+        await get_nearby_stories(db, center_lat=41.0082, center_lng=28.9784)
+
+        stmt = db.execute.await_args.args[0]
+        sql = str(stmt)
+
+        assert "asin" in sql
+        assert "sqrt" in sql
+        assert "sin" in sql
+        assert "cos" in sql
+        assert "radians" in sql
+
+    async def test_query_filters_null_coordinates(self):
+        db = AsyncMock()
+        db.execute.return_value.all = lambda: []
+
+        await get_nearby_stories(db, center_lat=41.0082, center_lng=28.9784)
+
+        stmt = db.execute.await_args.args[0]
+        sql = str(stmt)
+
+        assert "stories.latitude IS NOT NULL" in sql
+        assert "stories.longitude IS NOT NULL" in sql
+
+    async def test_query_filters_published_public_stories_only(self):
+        db = AsyncMock()
+        db.execute.return_value.all = lambda: []
+
+        await get_nearby_stories(db, center_lat=41.0082, center_lng=28.9784)
+
+        stmt = db.execute.await_args.args[0]
+        sql = str(stmt)
+
+        assert "stories.status" in sql
+        assert "stories.visibility" in sql
+
+    async def test_query_orders_by_distance_ascending(self):
+        db = AsyncMock()
+        db.execute.return_value.all = lambda: []
+
+        await get_nearby_stories(db, center_lat=41.0082, center_lng=28.9784)
+
+        stmt = db.execute.await_args.args[0]
+        sql = str(stmt)
+
+        assert "ORDER BY" in sql
+        assert "DESC" not in sql


### PR DESCRIPTION
## Description

Implements the geospatial radius query for nearby stories as required by #198.

Uses the **Haversine formula** expressed entirely as standard PostgreSQL math via SQLAlchemy `func` — no PostGIS extension or new migration needed. The `latitude` and `longitude` columns already exist on the `stories` table from a previous migration.

### New service function: `get_nearby_stories(db, center_lat, center_lng, radius_km=10.0)`
- Filters `PUBLISHED` + `PUBLIC` stories with non-null coordinates
- Computes great-circle distance using the Haversine formula
- Filters to stories within `radius_km` of the given centre point
- Orders results by distance ascending (nearest first)
- Returns `StoryListResponse` — consistent with all other story list endpoints

### This PR covers the service/query layer only. The HTTP endpoint (`GET /stories/nearby`) is addressed in the follow-up issue #199.

## Related Issue(s)
- Closes #198

## Testing
- 6 new unit tests added to `TestGetNearbyStoriesService` in `tests/unit/test_story_service.py`
- All 24 tests in the file pass (18 pre-existing + 6 new)
- Tests verify: correct result mapping, empty response, Haversine SQL presence, null-coordinate filter, status/visibility filter, ascending distance ordering

## Checklist
- [x] `latitude`/`longitude` fields on story model — already existed
- [x] Location stored on story creation — already existed  
- [x] Radius-based query logic implemented
- [x] Results sorted by distance (nearest first)
- [x] Unit tests added