### PR TITLE
feat: add GET /stories/nearby endpoint

### DIFF
--- a/backend/app/routers/story.py
+++ b/backend/app/routers/story.py
@@ -25,6 +25,7 @@ from app.services.story_service import (
     create_comment_for_story,
     create_story_with_location,
     delete_comment_for_story,
+    get_nearby_stories,
     get_story_detail_by_id,
     like_story,
     list_available_stories,
@@ -188,6 +189,28 @@ async def list_saved_stories(
     db: AsyncSession = Depends(get_db),
 ):
     return await list_saved_stories_for_user(db, current_user)
+
+
+@router.get(
+    "/nearby",
+    response_model=StoryListResponse,
+    summary="List stories near a location",
+    description=(
+        "Return published public stories within a given radius of a coordinate point, "
+        "ordered by distance ascending (nearest first). "
+        "lat and lng are required. radius_km defaults to 10 km (max 500 km)."
+    ),
+    responses={
+        422: {"description": "Validation error for lat, lng, or radius_km"},
+    },
+)
+async def list_nearby_stories(
+    lat: float = Query(ge=-90.0, le=90.0),
+    lng: float = Query(ge=-180.0, le=180.0),
+    radius_km: float = Query(default=10.0, gt=0.0, le=500.0),
+    db: AsyncSession = Depends(get_db),
+):
+    return await get_nearby_stories(db, center_lat=lat, center_lng=lng, radius_km=radius_km)
 
 
 @router.get(

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -650,9 +650,7 @@ async def get_nearby_stories(
     dlat = lat2 - lat1
     dlon = lon2 - lon1
 
-    a = func.pow(func.sin(dlat / 2), 2) + func.cos(lat1) * func.cos(lat2) * func.pow(
-        func.sin(dlon / 2), 2
-    )
+    a = func.pow(func.sin(dlat / 2), 2) + func.cos(lat1) * func.cos(lat2) * func.pow(func.sin(dlon / 2), 2)
     distance_km = func.asin(func.sqrt(a)) * (_EARTH_RADIUS_KM * 2)
 
     stmt = (

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -631,3 +631,44 @@ async def upload_media_for_story(
         )
 
     return MediaUploadResponse(media=_map_media_file(media))
+
+
+_EARTH_RADIUS_KM = 6371.0
+
+
+async def get_nearby_stories(
+    db: AsyncSession,
+    center_lat: float,
+    center_lng: float,
+    radius_km: float = 10.0,
+) -> StoryListResponse:
+    lat1 = func.radians(center_lat)
+    lat2 = func.radians(Story.latitude)
+    lon1 = func.radians(center_lng)
+    lon2 = func.radians(Story.longitude)
+
+    dlat = lat2 - lat1
+    dlon = lon2 - lon1
+
+    a = func.pow(func.sin(dlat / 2), 2) + func.cos(lat1) * func.cos(lat2) * func.pow(
+        func.sin(dlon / 2), 2
+    )
+    distance_km = func.asin(func.sqrt(a)) * (_EARTH_RADIUS_KM * 2)
+
+    stmt = (
+        select(Story, User.username)
+        .join(User, Story.user_id == User.id)
+        .where(
+            Story.status == StoryStatus.PUBLISHED,
+            Story.visibility == StoryVisibility.PUBLIC,
+            Story.latitude.is_not(None),
+            Story.longitude.is_not(None),
+            distance_km <= radius_km,
+        )
+        .order_by(distance_km)
+    )
+
+    result = await db.execute(stmt)
+    rows = result.all()
+
+    return _map_story_rows(rows)

--- a/backend/tests/api/test_story_api.py
+++ b/backend/tests/api/test_story_api.py
@@ -1499,3 +1499,90 @@ class TestStorySaveAPI:
 
         assert save_resp.status_code == 401
         assert list_resp.status_code == 401
+
+
+@pytest.mark.asyncio
+class TestNearbyStoriesAPI:
+    def _make_user(self, username: str, email: str) -> User:
+        return User(
+            username=username,
+            email=email,
+            password_hash=hash_password("TestPass1!"),
+        )
+
+    def _make_story(self, user_id, title, lat, lng, place_name="Istanbul") -> Story:
+        return Story(
+            user_id=user_id,
+            title=title,
+            content="content",
+            summary="summary",
+            status=StoryStatus.PUBLISHED,
+            visibility=StoryVisibility.PUBLIC,
+            place_name=place_name,
+            latitude=lat,
+            longitude=lng,
+        )
+
+    async def test_returns_story_within_radius(self, client, db_session):
+        user = self._make_user("nearbyauthor1", "nearby1@example.com")
+        db_session.add(user)
+        await db_session.flush()
+
+        # Çeliktepe, Istanbul — ~0.4 km from query centre
+        story = self._make_story(user.id, "Nearby Story", lat=41.0739, lng=28.9606)
+        db_session.add(story)
+        await db_session.commit()
+
+        resp = await client.get("/stories/nearby?lat=41.0770&lng=28.9620&radius_km=5")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["stories"][0]["title"] == "Nearby Story"
+
+    async def test_excludes_story_outside_radius(self, client, db_session):
+        user = self._make_user("nearbyauthor2", "nearby2@example.com")
+        db_session.add(user)
+        await db_session.flush()
+
+        # Ankara — ~350 km from Istanbul
+        story = self._make_story(user.id, "Far Away Story", lat=39.9334, lng=32.8597, place_name="Ankara")
+        db_session.add(story)
+        await db_session.commit()
+
+        resp = await client.get("/stories/nearby?lat=41.0082&lng=28.9784&radius_km=10")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 0
+
+    async def test_returns_empty_when_no_stories_exist(self, client):
+        resp = await client.get("/stories/nearby?lat=41.0082&lng=28.9784")
+
+        assert resp.status_code == 200
+        assert resp.json() == {"stories": [], "total": 0}
+
+    async def test_invalid_lat_returns_422(self, client):
+        resp = await client.get("/stories/nearby?lat=999&lng=28.9784")
+
+        assert resp.status_code == 422
+
+    async def test_invalid_lng_returns_422(self, client):
+        resp = await client.get("/stories/nearby?lat=41.0082&lng=999")
+
+        assert resp.status_code == 422
+
+    async def test_non_positive_radius_returns_422(self, client):
+        resp = await client.get("/stories/nearby?lat=41.0082&lng=28.9784&radius_km=0")
+
+        assert resp.status_code == 422
+
+    async def test_missing_lat_returns_422(self, client):
+        resp = await client.get("/stories/nearby?lng=28.9784")
+
+        assert resp.status_code == 422
+
+    async def test_missing_lng_returns_422(self, client):
+        resp = await client.get("/stories/nearby?lat=41.0082")
+
+        assert resp.status_code == 422

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -15,6 +15,7 @@ from app.services.story_service import (
     create_comment_for_story,
     create_story_with_location,
     delete_comment_for_story,
+    get_nearby_stories,
     get_story_detail_by_id,
     like_story,
     list_available_stories,
@@ -889,3 +890,85 @@ class TestUpdateStoryWithLocationAndDatesService:
         assert exc_info.value.status_code == 422
         assert "place_name is required" in exc_info.value.detail
         db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+class TestGetNearbyStoriesService:
+    async def test_returns_nearby_stories_and_total(self):
+        story = _make_story()
+
+        db = AsyncMock()
+        db.execute.return_value.all = lambda: [(story, "storyauthor")]
+
+        result = await get_nearby_stories(db, center_lat=41.0082, center_lng=28.9784)
+
+        assert result.total == 1
+        assert len(result.stories) == 1
+        item = result.stories[0]
+        assert item.id == story.id
+        assert item.title == "Story Title"
+        assert item.author == "storyauthor"
+        assert item.latitude == 41.0082
+        assert item.longitude == 28.9784
+        db.execute.assert_awaited_once()
+
+    async def test_returns_empty_response_when_no_stories_in_radius(self):
+        db = AsyncMock()
+        db.execute.return_value.all = lambda: []
+
+        result = await get_nearby_stories(db, center_lat=0.0, center_lng=0.0, radius_km=1.0)
+
+        assert result.total == 0
+        assert result.stories == []
+        db.execute.assert_awaited_once()
+
+    async def test_query_uses_haversine_formula(self):
+        db = AsyncMock()
+        db.execute.return_value.all = lambda: []
+
+        await get_nearby_stories(db, center_lat=41.0082, center_lng=28.9784)
+
+        stmt = db.execute.await_args.args[0]
+        sql = str(stmt)
+
+        assert "asin" in sql
+        assert "sqrt" in sql
+        assert "sin" in sql
+        assert "cos" in sql
+        assert "radians" in sql
+
+    async def test_query_filters_null_coordinates(self):
+        db = AsyncMock()
+        db.execute.return_value.all = lambda: []
+
+        await get_nearby_stories(db, center_lat=41.0082, center_lng=28.9784)
+
+        stmt = db.execute.await_args.args[0]
+        sql = str(stmt)
+
+        assert "stories.latitude IS NOT NULL" in sql
+        assert "stories.longitude IS NOT NULL" in sql
+
+    async def test_query_filters_published_public_stories_only(self):
+        db = AsyncMock()
+        db.execute.return_value.all = lambda: []
+
+        await get_nearby_stories(db, center_lat=41.0082, center_lng=28.9784)
+
+        stmt = db.execute.await_args.args[0]
+        sql = str(stmt)
+
+        assert "stories.status" in sql
+        assert "stories.visibility" in sql
+
+    async def test_query_orders_by_distance_ascending(self):
+        db = AsyncMock()
+        db.execute.return_value.all = lambda: []
+
+        await get_nearby_stories(db, center_lat=41.0082, center_lng=28.9784)
+
+        stmt = db.execute.await_args.args[0]
+        sql = str(stmt)
+
+        assert "ORDER BY" in sql
+        assert "DESC" not in sql


### PR DESCRIPTION
## Description

Adds the `GET /stories/nearby` HTTP endpoint as required by #199.

This PR depends on #260 (the Haversine service function) and must be merged after it.

### Endpoint: `GET /stories/nearby`
| Parameter | Type | Required | Default | Constraint |
|---|---|---|---|---|
| `lat` | float | yes | — | -90 to 90 |
| `lng` | float | yes | — | -180 to 180 |
| `radius_km` | float | no | 10.0 | > 0, max 500 |

- Returns `StoryListResponse` — same shape as all other listing endpoints
- Only `PUBLISHED` + `PUBLIC` stories with non-null coordinates are returned
- Results are ordered by distance ascending (nearest first)
- No authentication required (consistent with `GET /stories` and `GET /stories/search`)

The `/nearby` route is placed **before** `/{story_id}` in the router to prevent FastAPI treating `nearby` as a story UUID.

## Related Issue(s)
- Closes #199
- Depends on #260

## Testing
- 8 new API tests in `TestNearbyStoriesAPI`
- Tests cover: story within radius returned, story outside radius excluded, empty response, invalid lat/lng/radius (422), missing required parameters (422)
- All 186 unit tests pass locally

## Checklist
- [x] Endpoint `GET /stories/nearby` designed and implemented
- [x] Accepts `lat`, `lng`, `radius_km` parameters
- [x] Geospatial query integrated (via `get_nearby_stories` from #260)
- [x] Results sorted by distance
- [x] Invalid/missing parameter handling (422)
- [x] Swagger summary and description added