### PR TITLE
feat: add DB indexes for search and geospatial queries

### DIFF
--- a/backend/alembic/versions/20260424_0009_add_search_indexes.py
+++ b/backend/alembic/versions/20260424_0009_add_search_indexes.py
@@ -1,0 +1,45 @@
+"""Add indexes on stories for search and geospatial queries.
+
+Revision ID: 20260424_0009
+Revises: 20260419_0007
+Create Date: 2026-04-24 00:00:00
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260424_0009"
+down_revision: Union[str, Sequence[str], None] = "20260419_0007"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Partial composite index for geospatial queries (bounding box + nearby).
+    # Only indexes rows that have coordinates, keeping the index small.
+    op.create_index(
+        "ix_stories_lat_lng",
+        "stories",
+        ["latitude", "longitude"],
+        unique=False,
+        postgresql_where=sa.text("latitude IS NOT NULL AND longitude IS NOT NULL"),
+    )
+
+    # B-tree index on place_name for equality and prefix lookups.
+    # Also speeds up IS NOT NULL checks used in search filters.
+    op.create_index("ix_stories_place_name", "stories", ["place_name"], unique=False)
+
+    # Indexes for date-range overlap queries (date_start <= query_end AND date_end >= query_start).
+    op.create_index("ix_stories_date_start", "stories", ["date_start"], unique=False)
+    op.create_index("ix_stories_date_end", "stories", ["date_end"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_stories_date_end", table_name="stories")
+    op.drop_index("ix_stories_date_start", table_name="stories")
+    op.drop_index("ix_stories_place_name", table_name="stories")
+    op.drop_index("ix_stories_lat_lng", table_name="stories")


### PR DESCRIPTION
## Description
Adds database indexes to the stories table to eliminate full table scans on the high-traffic search and geospatial endpoints. Before this change, every bounding box query, nearby stories query, place name search, and date range filter was doing a sequential scan regardless of table size.

## Related Issue(s)
- Closes #200

## Changes

| File | Change |
|------|--------|
| `backend/alembic/versions/20260509_0009_add_search_indexes.py` | Added partial composite index on `(latitude, longitude)`, B-tree index on `place_name`, and indexes on `date_start` and `date_end`. |

## Checklist
- [x] All tests passed
- [x] I have self-reviewed my own code
- [x] I have requested at least 1 reviewer