### PR TITLE
Feat/frontend saved stories and stories near me

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,11 +9,14 @@ COPY story-detail.html /usr/share/nginx/html/story-detail.html
 COPY search.html /usr/share/nginx/html/search.html
 COPY profile.html /usr/share/nginx/html/profile.html
 COPY edit-profile.html /usr/share/nginx/html/edit-profile.html
+COPY saved.html /usr/share/nginx/html/saved.html
 COPY profile.js /usr/share/nginx/html/profile.js
 COPY edit-profile.js /usr/share/nginx/html/edit-profile.js
 COPY login.js /usr/share/nginx/html/login.js
 COPY auth.js /usr/share/nginx/html/auth.js
 COPY config.js /usr/share/nginx/html/config.js
+COPY saves.js /usr/share/nginx/html/saves.js
+COPY saved.js /usr/share/nginx/html/saved.js
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 EXPOSE 80

--- a/frontend/map.html
+++ b/frontend/map.html
@@ -113,6 +113,13 @@
             profileLink.setAttribute("role", "menuitem");
             profileMenuActions.appendChild(profileLink);
 
+            var savedLink = document.createElement("a");
+            savedLink.href = "saved.html";
+            savedLink.className = "flex w-full items-center justify-between rounded-xl px-4 py-3 text-sm font-medium text-primary transition hover:bg-stone-50";
+            savedLink.textContent = "Saved Stories";
+            savedLink.setAttribute("role", "menuitem");
+            profileMenuActions.appendChild(savedLink);
+
             var signOutButton = document.createElement("button");
             signOutButton.type = "button";
             signOutButton.className = "flex w-full items-center justify-between rounded-xl px-4 py-3 text-sm font-medium text-red-600 transition hover:bg-red-50";

--- a/frontend/map.html
+++ b/frontend/map.html
@@ -267,7 +267,64 @@
         #profile-menu[hidden] {
             display: none;
         }
-    </style>
+
+        /* User location: pulsing blue dot like Google/Apple Maps */
+        .user-location-dot {
+            width: 18px;
+            height: 18px;
+            border-radius: 50%;
+            background: #1a73e8;
+            border: 3px solid #ffffff;
+            box-shadow: 0 0 0 1px rgba(26, 115, 232, 0.35), 0 2px 6px rgba(0, 0, 0, 0.25);
+            position: relative;
+        }
+
+        .user-location-dot::before {
+            content: "";
+            position: absolute;
+            inset: -10px;
+            border-radius: 50%;
+            background: rgba(26, 115, 232, 0.25);
+            animation: user-loc-pulse 1.8s ease-out infinite;
+        }
+
+        @keyframes user-loc-pulse {
+            0%   { transform: scale(0.6); opacity: 0.8; }
+            100% { transform: scale(1.6); opacity: 0;   }
+        }
+
+        /* Near Me panel */
+        #near-me-panel {
+            min-width: 180px;
+        }
+
+        #near-me-panel.hidden { display: none; }
+
+        .radius-chip {
+            padding: 4px 10px;
+            border-radius: 999px;
+            font-size: 11px;
+            font-weight: 600;
+            border: 1px solid #e7e2d9;
+            background: #ffffff;
+            color: #5f584c;
+            cursor: pointer;
+            transition: all 0.15s ease;
+        }
+
+        .radius-chip:hover { background: #fef9f0; }
+
+        .radius-chip.active {
+            background: #775a19;
+            color: #ffffff;
+            border-color: #775a19;
+        }
+
+        #btn-near-me.active {
+            background: #35618f !important;
+            color: #ffffff !important;
+        }
+</style>
 </head>
 
 <body class="bg-background text-textmain font-body md:overflow-hidden">
@@ -332,6 +389,24 @@
                     title="Go to my location">
                     <span class="material-symbols-outlined text-xl">my_location</span>
                 </button>
+                <button id="btn-near-me"
+                    class="glass-panel w-11 h-11 flex items-center justify-center rounded-xl text-tertiary shadow-sm hover:bg-white transition-colors border border-border/30"
+                    title="Show stories near me" aria-pressed="false">
+                    <span class="material-symbols-outlined text-xl">near_me</span>
+                </button>
+            </div>
+
+            <!-- Near Me Radius Panel -->
+            <div id="near-me-panel"
+                class="hidden absolute left-20 top-[152px] z-[1000] glass-panel rounded-xl p-3 shadow-sm border border-border/30 md:top-[208px]">
+                <div class="text-[11px] font-semibold uppercase tracking-wide text-textmuted mb-2">Search radius</div>
+                <div id="radius-chips" class="flex items-center gap-1.5">
+                    <button type="button" class="radius-chip" data-radius="1">1 km</button>
+                    <button type="button" class="radius-chip active" data-radius="5">5 km</button>
+                    <button type="button" class="radius-chip" data-radius="10">10 km</button>
+                    <button type="button" class="radius-chip" data-radius="25">25 km</button>
+                </div>
+                <div id="near-me-status" class="mt-2 text-[11px] text-textmuted"></div>
             </div>
 
             <!-- Story Count Badge -->
@@ -390,6 +465,7 @@
         var fetchTimeout = null;
 
         async function fetchStoriesInBounds() {
+            if (nearMeActive) return;
             var bounds = map.getBounds();
             var params = new URLSearchParams({
                 min_lat: Math.max(-90, bounds.getSouthWest().lat),
@@ -452,6 +528,213 @@
                 map.removeLayer(topoLayer);
                 osmLayer.addTo(map);
                 currentLayer = "osm";
+            }
+        });
+
+        // ─── Stories Near Me ───
+        var nearMeActive = false;
+        var nearMeRadiusKm = 5;
+        var userLocationMarker = null;
+        var userAccuracyCircle = null;
+        var radiusCircle = null;
+        var lastUserLatLng = null;
+
+        var nearMeButton = document.getElementById("btn-near-me");
+        var nearMePanel = document.getElementById("near-me-panel");
+        var nearMeStatus = document.getElementById("near-me-status");
+        var radiusChipsContainer = document.getElementById("radius-chips");
+
+        function userLocationIcon() {
+            return L.divIcon({
+                className: "",
+                html: '<div class="user-location-dot"></div>',
+                iconSize: [18, 18],
+                iconAnchor: [9, 9]
+            });
+        }
+
+        function clearUserLocationLayers() {
+            if (userLocationMarker) { map.removeLayer(userLocationMarker); userLocationMarker = null; }
+            if (userAccuracyCircle) { map.removeLayer(userAccuracyCircle); userAccuracyCircle = null; }
+            if (radiusCircle) { map.removeLayer(radiusCircle); radiusCircle = null; }
+        }
+
+        function renderUserLocation(latlng, accuracy) {
+            if (userLocationMarker) {
+                userLocationMarker.setLatLng(latlng);
+            } else {
+                userLocationMarker = L.marker(latlng, {
+                    icon: userLocationIcon(),
+                    interactive: false,
+                    keyboard: false,
+                    zIndexOffset: 1000
+                }).addTo(map);
+            }
+
+            if (accuracy && accuracy > 0) {
+                if (userAccuracyCircle) {
+                    userAccuracyCircle.setLatLng(latlng);
+                    userAccuracyCircle.setRadius(accuracy);
+                } else {
+                    userAccuracyCircle = L.circle(latlng, {
+                        radius: accuracy,
+                        color: "#1a73e8",
+                        weight: 1,
+                        opacity: 0.4,
+                        fillColor: "#1a73e8",
+                        fillOpacity: 0.08,
+                        interactive: false
+                    }).addTo(map);
+                }
+            }
+        }
+
+        function renderRadiusCircle(latlng, radiusKm) {
+            var meters = radiusKm * 1000;
+            if (radiusCircle) {
+                radiusCircle.setLatLng(latlng);
+                radiusCircle.setRadius(meters);
+            } else {
+                radiusCircle = L.circle(latlng, {
+                    radius: meters,
+                    color: "#775a19",
+                    weight: 2,
+                    opacity: 0.6,
+                    dashArray: "6 6",
+                    fillColor: "#c5a059",
+                    fillOpacity: 0.08,
+                    interactive: false
+                }).addTo(map);
+            }
+        }
+
+        async function fetchNearbyStories(lat, lng, radiusKm) {
+            var params = new URLSearchParams({ lat: lat, lng: lng, radius_km: radiusKm });
+            try {
+                var response = await fetch(API_BASE + "/stories/nearby?" + params.toString());
+                if (!response.ok) throw new Error("Failed to fetch nearby stories");
+                var data = await response.json();
+                cachedStories = data.stories || [];
+                loadStories(cachedStories);
+                populateSidebar(cachedStories);
+                nearMeStatus.textContent = cachedStories.length + " stor" + (cachedStories.length === 1 ? "y" : "ies") + " within " + radiusKm + " km";
+            } catch (err) {
+                console.error("Error fetching nearby stories:", err);
+                nearMeStatus.textContent = "Failed to load nearby stories";
+                document.getElementById("story-count").textContent = "Failed to load stories";
+            }
+        }
+
+        function zoomForRadiusKm(radiusKm) {
+            // Pick a zoom level that keeps the radius circle comfortably in view.
+            if (radiusKm <= 1) return 15;
+            if (radiusKm <= 5) return 13;
+            if (radiusKm <= 10) return 12;
+            if (radiusKm <= 25) return 11;
+            return 10;
+        }
+
+        function fitToRadius(latlng, radiusKm) {
+            try {
+                map.setView(latlng, zoomForRadiusKm(radiusKm), { animate: true });
+            } catch (err) {
+                console.error("fitToRadius failed:", err);
+            }
+        }
+
+        function activateNearMe() {
+            if (!navigator.geolocation) {
+                alert("Geolocation is not supported in this browser.");
+                return;
+            }
+
+            var NEAR_ME_CONSENT_KEY = "nearMeConsent";
+            var alreadyConsented = false;
+            try { alreadyConsented = localStorage.getItem(NEAR_ME_CONSENT_KEY) === "1"; } catch (_) {}
+
+            if (!alreadyConsented) {
+                var consent = window.confirm(
+                    "Use your current location to show stories nearby?\n\n" +
+                    "Your browser will ask permission next. Your location stays on this device."
+                );
+                if (!consent) return;
+                try { localStorage.setItem(NEAR_ME_CONSENT_KEY, "1"); } catch (_) {}
+            }
+
+            // Mark active up-front so the bounds-based fetch (triggered by map moves) is suppressed,
+            // and immediately clear any previously rendered markers so we never show "all stories".
+            nearMeActive = true;
+            nearMeButton.classList.add("active");
+            nearMeButton.setAttribute("aria-pressed", "true");
+            nearMePanel.classList.remove("hidden");
+            nearMeStatus.textContent = "Locating you…";
+            cachedStories = [];
+            loadStories([]);
+            populateSidebar([]);
+
+            navigator.geolocation.getCurrentPosition(
+                function (pos) {
+                    var latlng = [pos.coords.latitude, pos.coords.longitude];
+                    lastUserLatLng = latlng;
+
+                    // Update status FIRST so it never gets stuck on "Locating you…"
+                    // even if a Leaflet call below throws.
+                    nearMeStatus.textContent = "Loading nearby stories…";
+
+                    try { renderUserLocation(latlng, pos.coords.accuracy); }
+                    catch (e) { console.error("renderUserLocation failed:", e); }
+
+                    try { renderRadiusCircle(latlng, nearMeRadiusKm); }
+                    catch (e) { console.error("renderRadiusCircle failed:", e); }
+
+                    fitToRadius(latlng, nearMeRadiusKm);
+                    fetchNearbyStories(latlng[0], latlng[1], nearMeRadiusKm);
+                },
+                function (err) {
+                    nearMeStatus.textContent = err && err.code === 1
+                        ? "Location permission denied."
+                        : "Unable to access your location.";
+                    console.error("Geolocation error:", err);
+                    // Roll back active state so bounds browsing resumes.
+                    deactivateNearMe();
+                },
+                { enableHighAccuracy: true, timeout: 10000, maximumAge: 60000 }
+            );
+        }
+
+        function deactivateNearMe() {
+            nearMeActive = false;
+            nearMeButton.classList.remove("active");
+            nearMeButton.setAttribute("aria-pressed", "false");
+            nearMePanel.classList.add("hidden");
+            clearUserLocationLayers();
+            lastUserLatLng = null;
+            fetchStoriesInBounds();
+        }
+
+        nearMeButton.addEventListener("click", function () {
+            if (nearMeActive) {
+                deactivateNearMe();
+            } else {
+                activateNearMe();
+            }
+        });
+
+        radiusChipsContainer.addEventListener("click", function (e) {
+            var btn = e.target.closest(".radius-chip");
+            if (!btn) return;
+            var r = parseFloat(btn.getAttribute("data-radius"));
+            if (!Number.isFinite(r) || r <= 0) return;
+
+            nearMeRadiusKm = r;
+            radiusChipsContainer.querySelectorAll(".radius-chip").forEach(function (el) {
+                el.classList.toggle("active", el === btn);
+            });
+
+            if (nearMeActive && lastUserLatLng) {
+                renderRadiusCircle(lastUserLatLng, nearMeRadiusKm);
+                fitToRadius(lastUserLatLng, nearMeRadiusKm);
+                fetchNearbyStories(lastUserLatLng[0], lastUserLatLng[1], nearMeRadiusKm);
             }
         });
 

--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -121,10 +121,10 @@
               <div class="text-2xl font-bold text-emerald-600">0</div>
               <div class="text-xs text-textmuted font-semibold uppercase tracking-wider mt-1">Likes</div>
             </div>
-            <div class="text-center p-4 bg-background rounded-xl border border-border/50">
-              <div class="text-2xl font-bold text-orange-600">0</div>
+            <a href="saved.html" class="text-center p-4 bg-background rounded-xl border border-border/50 hover:bg-white transition-colors block">
+              <div id="stat-saved" class="text-2xl font-bold text-orange-600">0</div>
               <div class="text-xs text-textmuted font-semibold uppercase tracking-wider mt-1">Saved</div>
-            </div>
+            </a>
           </div>
         </div>
 

--- a/frontend/profile.js
+++ b/frontend/profile.js
@@ -19,8 +19,23 @@ async function loadProfile() {
             joinedEl.innerHTML = '<span class="material-symbols-outlined text-[18px]">calendar_month</span> Joined ' + date.toLocaleDateString('en-US', options);
         }
         await loadUserStories(data.username);
+        await loadSavedCount();
     } catch (err) {
         console.error("Error loading profile:", err);
+    }
+}
+
+async function loadSavedCount() {
+    var el = document.getElementById("stat-saved");
+    if (!el) return;
+    try {
+        var res = await authFetch(API_BASE + "/stories/saved");
+        if (!res.ok) return;
+        var data = await res.json();
+        var n = ((data && data.stories) || []).length;
+        el.textContent = String(n);
+    } catch (err) {
+        console.error("Error loading saved count:", err);
     }
 }
 

--- a/frontend/saved.html
+++ b/frontend/saved.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Local History Map - Saved Stories</title>
+  <script src="https://cdn.tailwindcss.com?plugins=forms"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Serif:wght@700;800&display=swap"
+    rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+    rel="stylesheet">
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            background: "#fef9f0",
+            surface: "#ffffff",
+            primary: "#775a19",
+            "primary-light": "#c5a059",
+            secondary: "#506169",
+            tertiary: "#35618f",
+            border: "#e7e2d9",
+            textmain: "#1d1c16",
+            textmuted: "#5f584c"
+          },
+          fontFamily: {
+            body: ["Inter", "sans-serif"],
+            headline: ["Noto Serif", "serif"]
+          },
+          boxShadow: {
+            soft: "0 20px 50px rgba(0,0,0,0.08)"
+          }
+        }
+      }
+    };
+  </script>
+  <style>
+    .material-symbols-outlined {
+      font-variation-settings: "FILL" 0, "wght" 400, "GRAD" 0, "opsz" 24;
+    }
+  </style>
+</head>
+
+<body class="bg-background text-textmain font-body min-h-screen">
+
+  <!-- Top Navigation Bar -->
+  <header class="fixed top-0 left-0 right-0 z-[1000] bg-[#f8f3ea]/95 backdrop-blur-sm border-b border-border/30">
+    <div class="flex justify-between items-center w-full px-8 py-4 max-w-screen-2xl mx-auto">
+      <div class="flex items-center gap-8">
+        <h1 class="text-2xl font-bold font-headline text-textmain tracking-tight">Local History Map</h1>
+        <nav class="hidden md:flex items-center gap-6">
+          <a class="text-textmain font-medium hover:text-tertiary transition-colors" href="map.html">Map</a>
+          <a class="text-textmain font-medium hover:text-tertiary transition-colors"
+            href="story-create.html">Create Story</a>
+          <a class="text-tertiary font-semibold" href="saved.html">Saved</a>
+          <a class="text-textmain font-medium hover:text-tertiary transition-colors" href="profile.html">Profile</a>
+        </nav>
+      </div>
+      <div class="flex items-center gap-3 sm:gap-4">
+        <a href="profile.html"
+          class="inline-flex h-11 w-11 items-center justify-center rounded-full border border-primary bg-primary/10 text-primary shadow-sm transition hover:bg-primary/20"
+          aria-label="Open profile">
+          <span class="material-symbols-outlined text-[20px] leading-none">account_circle</span>
+        </a>
+      </div>
+    </div>
+  </header>
+
+  <main class="w-full px-4 pt-32 pb-10 lg:px-8 xl:px-10 2xl:px-14 max-w-5xl mx-auto">
+    <header class="mb-8 flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+      <div>
+        <a href="map.html" class="inline-flex items-center gap-2 text-sm font-semibold text-primary hover:underline">
+          <span aria-hidden="true">&larr;</span> Back to Map
+        </a>
+        <h1 class="mt-3 font-headline text-3xl md:text-4xl font-extrabold leading-tight text-textmain">Saved Stories</h1>
+        <p class="mt-2 text-textmuted">Stories you've bookmarked for later. They stay here until you remove them.</p>
+      </div>
+      <p id="saved-count" class="text-sm text-textmuted"></p>
+    </header>
+
+    <div id="saved-container" class="space-y-4">
+      <div class="text-center p-8">
+        <p class="text-textmuted italic">Loading your saved stories...</p>
+      </div>
+    </div>
+  </main>
+
+  <script src="config.js"></script>
+  <script src="auth.js"></script>
+  <script src="saved.js"></script>
+</body>
+
+</html>

--- a/frontend/saved.js
+++ b/frontend/saved.js
@@ -1,0 +1,135 @@
+function escapeHtml(value) {
+    if (value === undefined || value === null) return "";
+    return String(value)
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#039;");
+}
+
+function renderEmptyState(container) {
+    container.innerHTML = `
+        <div class="bg-surface rounded-2xl p-8 border border-border flex flex-col items-center justify-center text-center shadow-sm">
+            <span class="material-symbols-outlined text-4xl text-stone-300 mb-3">bookmark</span>
+            <p class="text-textmain font-medium">You haven't saved any stories yet.</p>
+            <p class="text-sm text-textmuted mt-1">Tap the Save button on a story to bookmark it for later.</p>
+            <a href="map.html" class="mt-4 px-4 py-2 rounded-xl bg-primary text-white text-sm font-semibold hover:opacity-95 transition">Browse stories on the map</a>
+        </div>
+    `;
+}
+
+function renderSavedCard(story) {
+    var dateLabel = story.created_at
+        ? new Date(story.created_at).toLocaleDateString()
+        : "";
+    var preview = (story.content || "").length > 200
+        ? story.content.substring(0, 200) + "…"
+        : (story.content || "");
+    var place = story.place_name || story.location_name || "";
+
+    return `
+        <article class="bg-surface rounded-2xl p-6 border border-border shadow-sm hover:shadow-md transition-shadow" data-story-id="${escapeHtml(story.id)}">
+            <div class="flex justify-between items-start mb-2 gap-3">
+                <h3 class="font-headline text-xl font-bold text-textmain">${escapeHtml(story.title || "Untitled")}</h3>
+                ${dateLabel ? `<span class="text-xs font-medium px-2 py-1 bg-background rounded-full border border-border whitespace-nowrap">${escapeHtml(dateLabel)}</span>` : ""}
+            </div>
+            <p class="text-textmuted text-sm line-clamp-2 mb-4">${escapeHtml(preview)}</p>
+            <div class="flex items-center justify-between text-xs text-textmuted gap-3">
+                <span class="flex items-center gap-1 truncate">
+                    <span class="material-symbols-outlined text-sm">location_on</span>
+                    ${escapeHtml(place || "Unknown location")}
+                </span>
+                <div class="flex items-center gap-3 shrink-0">
+                    <button type="button" data-action="unsave"
+                        class="inline-flex items-center gap-1 text-xs font-semibold text-red-600 hover:text-red-700 transition-colors">
+                        <span class="material-symbols-outlined text-[16px]">bookmark_remove</span>
+                        Unsave
+                    </button>
+                    <a href="story-detail.html?id=${encodeURIComponent(story.id)}" class="text-primary font-semibold hover:underline">Read more</a>
+                </div>
+            </div>
+        </article>
+    `;
+}
+
+async function unsaveStory(storyId) {
+    var res = await authFetch(API_BASE + "/stories/" + storyId + "/save", { method: "DELETE" });
+    if (!res.ok) throw new Error("Failed to unsave");
+    return await res.json();
+}
+
+function attachUnsaveHandlers(container, onCountChange) {
+    container.addEventListener("click", async function (e) {
+        var btn = e.target.closest("[data-action='unsave']");
+        if (!btn) return;
+        var card = btn.closest("article[data-story-id]");
+        if (!card) return;
+
+        var storyId = card.getAttribute("data-story-id");
+        btn.disabled = true;
+        try {
+            await unsaveStory(storyId);
+            card.remove();
+            onCountChange();
+        } catch (err) {
+            console.error("Unsave failed:", err);
+            btn.disabled = false;
+            alert("Could not remove from saved. Please try again.");
+        }
+    });
+}
+
+async function loadSavedStories() {
+    if (typeof requireAuth === "function" && !requireAuth()) return;
+
+    var container = document.getElementById("saved-container");
+    var countEl = document.getElementById("saved-count");
+    if (!container) return;
+
+    function updateCount() {
+        var n = container.querySelectorAll("article[data-story-id]").length;
+        if (countEl) countEl.textContent = n + " saved " + (n === 1 ? "story" : "stories");
+        if (n === 0) renderEmptyState(container);
+    }
+
+    try {
+        var res = await authFetch(API_BASE + "/stories/saved");
+        if (!res.ok) {
+            if (res.status === 401 && typeof logout === "function") {
+                logout();
+                return;
+            }
+            throw new Error("Failed to fetch saved stories");
+        }
+        var data = await res.json();
+        var stories = (data && data.stories) || [];
+
+        if (stories.length === 0) {
+            renderEmptyState(container);
+            if (countEl) countEl.textContent = "0 saved stories";
+            return;
+        }
+
+        container.innerHTML = stories.map(renderSavedCard).join("");
+        if (countEl) {
+            countEl.textContent = stories.length + " saved " + (stories.length === 1 ? "story" : "stories");
+        }
+        attachUnsaveHandlers(container, updateCount);
+    } catch (err) {
+        console.error("Error loading saved stories:", err);
+        container.innerHTML = `<p class="text-red-600 text-center p-4">Could not load your saved stories. Please try again later.</p>`;
+    }
+}
+
+if (typeof document !== "undefined") {
+    document.addEventListener("DOMContentLoaded", loadSavedStories);
+}
+
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = {
+        loadSavedStories: loadSavedStories,
+        renderSavedCard: renderSavedCard,
+        renderEmptyState: renderEmptyState
+    };
+}

--- a/frontend/saves.js
+++ b/frontend/saves.js
@@ -1,0 +1,137 @@
+function setSaveStatus(message) {
+    var el = document.getElementById("save-status");
+    if (!el) return;
+    if (!message) {
+        el.classList.add("hidden");
+        el.textContent = "";
+        return;
+    }
+    el.textContent = message;
+    el.classList.remove("hidden");
+}
+
+function setSaveUi(state) {
+    var btn = document.getElementById("save-button");
+    var label = document.getElementById("save-button-text");
+    var icon = document.getElementById("save-button-icon");
+    if (!btn || !label) return;
+
+    btn.dataset.saved = state.saved ? "true" : "false";
+    btn.setAttribute("aria-pressed", state.saved ? "true" : "false");
+
+    if (state.saved) {
+        btn.classList.remove("bg-white", "text-primary", "hover:bg-stone-50");
+        btn.classList.add("bg-primary", "text-white", "hover:opacity-95");
+        label.textContent = "Saved";
+        if (icon) icon.style.fontVariationSettings = "'FILL' 1";
+        btn.setAttribute("aria-label", "Remove this story from your saved list");
+    } else {
+        btn.classList.remove("bg-primary", "text-white", "hover:opacity-95");
+        btn.classList.add("bg-white", "text-primary", "hover:bg-stone-50");
+        label.textContent = "Save";
+        if (icon) icon.style.fontVariationSettings = "'FILL' 0";
+        btn.setAttribute("aria-label", "Save this story");
+    }
+}
+
+async function fetchIsSaved(apiBase, storyId) {
+    // Backend has no per-story "saved by me" endpoint — derive membership from the saved list.
+    var res = await authFetch(apiBase + "/stories/saved");
+    if (!res.ok) {
+        var err = new Error("Saved list unavailable");
+        err.status = res.status;
+        throw err;
+    }
+    var data = await res.json();
+    var stories = (data && data.stories) || [];
+    return stories.some(function (s) { return String(s.id) === String(storyId); });
+}
+
+async function sendSaveToggle(apiBase, storyId, savedNow) {
+    if (!isLoggedIn()) {
+        window.location.assign("index.html");
+        return null;
+    }
+
+    var method = savedNow ? "DELETE" : "POST";
+    var res = await authFetch(apiBase + "/stories/" + storyId + "/save", { method: method });
+    if (!res.ok) {
+        var err = new Error("Failed to update saved state");
+        err.status = res.status;
+        throw err;
+    }
+    return await res.json();
+}
+
+function setupSaveButton(apiBase, storyId) {
+    var btn = document.getElementById("save-button");
+    if (!btn) return;
+
+    var state = { story_id: storyId, saved: false };
+
+    btn.disabled = true;
+    setSaveStatus("");
+
+    if (!isLoggedIn()) {
+        // Not signed in: show the button in default state; click will redirect to login.
+        setSaveUi(state);
+        btn.disabled = false;
+    } else {
+        fetchIsSaved(apiBase, storyId)
+            .then(function (saved) {
+                state = { story_id: storyId, saved: !!saved };
+                setSaveUi(state);
+            })
+            .catch(function () {
+                setSaveUi(state);
+                setSaveStatus("Saved status unavailable.");
+            })
+            .finally(function () {
+                btn.disabled = false;
+            });
+    }
+
+    btn.addEventListener("click", async function () {
+        if (btn.disabled) return;
+
+        if (!isLoggedIn()) {
+            window.location.assign("index.html");
+            return;
+        }
+
+        btn.dataset.animating = "true";
+        window.setTimeout(function () { btn.dataset.animating = "false"; }, 200);
+
+        setSaveStatus("");
+
+        var optimistic = { story_id: storyId, saved: !state.saved };
+        setSaveUi(optimistic);
+
+        btn.disabled = true;
+        try {
+            var updated = await sendSaveToggle(apiBase, storyId, state.saved);
+            if (updated) {
+                state = updated;
+                setSaveUi(state);
+            } else {
+                state = optimistic;
+                setSaveUi(state);
+            }
+        } catch (err) {
+            setSaveUi(state);
+            setSaveStatus("Unable to update saved state.");
+        } finally {
+            btn.disabled = false;
+        }
+    });
+}
+
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = {
+        setSaveStatus: setSaveStatus,
+        setSaveUi: setSaveUi,
+        fetchIsSaved: fetchIsSaved,
+        sendSaveToggle: sendSaveToggle,
+        setupSaveButton: setupSaveButton
+    };
+}

--- a/frontend/saves.test.js
+++ b/frontend/saves.test.js
@@ -1,0 +1,121 @@
+const { setupSaveButton, setSaveUi } = require("./saves");
+
+describe("saves UI", () => {
+    let assignMock;
+
+    async function flushMicrotasks() {
+        await Promise.resolve();
+        await Promise.resolve();
+    }
+
+    async function waitForButtonEnabled() {
+        const btn = document.getElementById("save-button");
+        for (let i = 0; i < 5 && btn && btn.disabled; i++) {
+            await flushMicrotasks();
+        }
+    }
+
+    beforeEach(() => {
+        document.body.innerHTML = `
+      <button id="save-button" type="button" data-animating="false" class="bg-white text-primary hover:bg-stone-50">
+        <span id="save-button-icon"></span>
+        <span id="save-button-text">Save</span>
+      </button>
+      <span id="save-status" class="hidden"></span>
+    `;
+
+        assignMock = jest.fn();
+        Object.defineProperty(window, "location", {
+            value: { assign: assignMock, origin: "http://localhost" },
+            writable: true,
+            configurable: true
+        });
+
+        global.authFetch = jest.fn();
+        global.isLoggedIn = jest.fn();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test("setSaveUi toggles styles and labels", () => {
+        setSaveUi({ saved: true });
+
+        const btn = document.getElementById("save-button");
+        expect(btn.getAttribute("aria-pressed")).toBe("true");
+        expect(document.getElementById("save-button-text").textContent).toBe("Saved");
+
+        setSaveUi({ saved: false });
+        expect(btn.getAttribute("aria-pressed")).toBe("false");
+        expect(document.getElementById("save-button-text").textContent).toBe("Save");
+    });
+
+    test("setupSaveButton renders default state when GET /stories/saved fails", async () => {
+        global.isLoggedIn.mockReturnValue(true);
+        global.authFetch.mockResolvedValueOnce({ ok: false, status: 500, json: () => Promise.resolve({}) });
+
+        setupSaveButton("http://api", "story-1");
+        await waitForButtonEnabled();
+
+        expect(document.getElementById("save-button-text").textContent).toBe("Save");
+        expect(document.getElementById("save-status").textContent).toMatch(/unavailable/i);
+    });
+
+    test("setupSaveButton reflects saved=true when story is in saved list", async () => {
+        global.isLoggedIn.mockReturnValue(true);
+        global.authFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve({ stories: [{ id: "story-1" }, { id: "other" }] })
+        });
+
+        setupSaveButton("http://api", "story-1");
+        await waitForButtonEnabled();
+
+        expect(document.getElementById("save-button-text").textContent).toBe("Saved");
+        expect(document.getElementById("save-button").getAttribute("aria-pressed")).toBe("true");
+    });
+
+    test("clicking Save sends POST and flips to saved", async () => {
+        global.isLoggedIn.mockReturnValue(true);
+
+        // Initial GET → not in saved list.
+        global.authFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve({ stories: [] })
+        });
+        // Toggle POST → returns saved=true.
+        global.authFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve({ story_id: "story-1", saved: true })
+        });
+
+        setupSaveButton("http://api", "story-1");
+        await waitForButtonEnabled();
+
+        document.getElementById("save-button").click();
+        await flushMicrotasks();
+        await waitForButtonEnabled();
+
+        const lastCall = global.authFetch.mock.calls[global.authFetch.mock.calls.length - 1];
+        expect(lastCall[0]).toBe("http://api/stories/story-1/save");
+        expect(lastCall[1]).toEqual({ method: "POST" });
+        expect(document.getElementById("save-button-text").textContent).toBe("Saved");
+    });
+
+    test("clicking Save while logged out redirects to login", async () => {
+        global.isLoggedIn.mockReturnValue(false);
+
+        setupSaveButton("http://api", "story-1");
+        await waitForButtonEnabled();
+
+        document.getElementById("save-button").click();
+        await flushMicrotasks();
+
+        expect(assignMock).toHaveBeenCalledWith("index.html");
+        expect(global.authFetch).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/story-detail.html
+++ b/frontend/story-detail.html
@@ -42,7 +42,21 @@
       background: rgba(254,249,240,0.75) !important;
       font-size: 10px;
     }
+    .material-symbols-outlined {
+      font-variation-settings: "FILL" 0, "wght" 400, "GRAD" 0, "opsz" 24;
+    }
+    .save-button { transform-origin: center; }
+    .save-button[data-animating="true"] { animation: save-pop 180ms ease-out; }
+    @keyframes save-pop {
+      0% { transform: scale(1); }
+      55% { transform: scale(1.08); }
+      100% { transform: scale(1); }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .save-button[data-animating="true"] { animation: none; }
+    }
   </style>
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet">
 </head>
 <body class="bg-background text-textmain font-body min-h-screen">
 <main class="max-w-6xl mx-auto px-6 py-10 lg:px-10">
@@ -76,8 +90,15 @@
           <!-- Media injected via JS -->
         </div>
 
-        <div class="mt-8 flex flex-wrap gap-3">
+        <div class="mt-8 flex flex-wrap items-center gap-3">
           <a href="map.html" class="inline-flex items-center justify-center rounded-xl bg-primary px-5 py-3 text-sm font-semibold text-white transition hover:opacity-95">Back to Map</a>
+          <button id="save-button" type="button"
+            class="save-button inline-flex items-center justify-center gap-2 rounded-xl border border-border bg-white px-5 py-3 text-sm font-semibold text-primary transition hover:bg-stone-50"
+            data-animating="false" aria-pressed="false" aria-label="Save this story" disabled>
+            <span id="save-button-icon" class="material-symbols-outlined text-[18px] leading-none">bookmark</span>
+            <span id="save-button-text">Save</span>
+          </button>
+          <span id="save-status" class="hidden text-xs text-red-600"></span>
         </div>
       </div>
     </article>
@@ -103,6 +124,8 @@
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 
 <script src="config.js"></script>
+<script src="auth.js"></script>
+<script src="saves.js"></script>
 <script>
   // Initialize mini-map with arbitrary center initially
   var detailMap = L.map("detail-map", {
@@ -125,6 +148,10 @@
     document.getElementById('story-title').textContent = "Story not found";
     document.getElementById('story-summary').textContent = "No ID provided in the URL.";
   } else {
+    if (typeof setupSaveButton === "function") {
+      setupSaveButton(API_BASE, storyId);
+    }
+
     fetch(API_BASE + "/stories/" + storyId)
       .then(res => res.json())
       .then(story => {


### PR DESCRIPTION
## Description
Saved stories page and mechanics added 
Stories near me added


## Related Issue(s)

- Closes # https://github.com/bounswe/bounswe2026group2/issues/227 https://github.com/bounswe/bounswe2026group2/issues/225


## Changes
<!-- List changes file by file. Add/remove rows as needed. -->

| File | Change |
Changes        

  File: frontend/saves.js                                                       
  Change: Added bookmark logic (setupSaveButton, setSaveUi, setSaveStatus,
    fetchIsSaved, sendSaveToggle) — wires the Save button on the story detail   
    page to POST/DELETE /stories/{id}/save with optimistic UI and login redirect

    for unauth users. Pattern mirrors likes.js from feature/like-button-ui.     
  ────────────────────────────────────────
  File: frontend/saves.test.js                                                  
  Change: Added 5 jest unit tests covering UI toggling, error fallback,
    saved-state hydration from GET /stories/saved, the POST toggle path, and the
                       
    unauth redirect.
  ────────────────────────────────────────
  File: frontend/saved.html                                                     
  Change: Added the dedicated "Saved Stories" view page with header, count
  badge,                                                                        
    and container, matching the project's Tailwind style.   
  ────────────────────────────────────────
  File: frontend/saved.js                                                       
  Change: Added the saved-view loader: fetches GET /stories/saved, renders cards
                                                                                
    (escaped HTML), per-card "Unsave" → DELETE /stories/{id}/save, empty state,
    and live count updates. Requires auth via requireAuth().
  ────────────────────────────────────────
  File: frontend/story-detail.html                                              
  Change: Modified to add a Save/Saved bookmark button next to "Back to Map",
    include auth.js + saves.js, and call setupSaveButton(API_BASE, storyId) on  
    load. Adds the save-pop animation styles and the Material Symbols font link.
  ────────────────────────────────────────
  File: frontend/map.html                                                       
  Change: Modified the profile dropdown (renderProfileMenu) to add a "Saved
    Stories" link between "View Profile" and "Sign Out" for authenticated users.
  ────────────────────────────────────────                  
  File: frontend/profile.html                                                   
  Change: Modified the "Saved" stat tile to be a link to saved.html and gave its
                                                                                
    counter the stat-saved id so it can be populated dynamically.
  ────────────────────────────────────────
  File: frontend/profile.js                                                     
  Change: Modified loadProfile to call a new loadSavedCount() that fetches GET 
    /stories/saved and writes the count into #stat-saved.                       
  ────────────────────────────────────────                  
  File: frontend/Dockerfile                                                     
  Change: Modified to COPY the new files (saved.html, saved.js, saves.js) into
    the nginx image so they ship with the frontend container.                   
                                                            
  Checklist

  - All tests passed                                                            
  - I have self-reviewed my own code
  - I have requested at least 1 reviewer  
