### PR TITLE
ci: fix job order and add parallel UAT job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,6 +355,7 @@ jobs:
             curl -sf http://localhost:8000/health && break
             sleep 3
           done
+          curl -sf http://localhost:8000/health || exit 1
 
       - name: Run Playwright UAT tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,23 +331,8 @@ jobs:
 
       - name: Start full stack
         run: |
-          cat > .env <<'EOF'
-          DATABASE_URL=postgresql://postgres:postgres@db:5432/localhistory
-          JWT_SECRET_KEY=ci-test-secret
-          JWT_ALGORITHM=HS256
-          JWT_EXPIRE_MINUTES=30
-          CORS_ORIGINS=http://localhost:3002
-          STORAGE_ENDPOINT=http://minio:9000
-          STORAGE_ACCESS_KEY=minioadmin
-          STORAGE_SECRET_KEY=minioadmin
-          STORAGE_REGION=us-east-1
-          STORAGE_PUBLIC_URL=http://localhost:9001
-          STORAGE_BUCKET_IMAGES=images
-          STORAGE_BUCKET_AUDIO=audio
-          STORAGE_BUCKET_VIDEOS=videos
-          LOG_SQL=false
-          EOF
-          docker compose -f docker-compose.yml up -d --build
+          cp backend/.env.example backend/.env
+          docker compose up -d --build
 
       - name: Wait for backend health
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
   backend-integration:
     name: Backend Integration Tests
     runs-on: ubuntu-latest
-    needs: [backend-unit]
+    needs: [backend-api]
 
     services:
       postgres:
@@ -250,7 +250,7 @@ jobs:
   backend-api:
     name: Backend API Tests
     runs-on: ubuntu-latest
-    needs: [backend-integration]
+    needs: [backend-unit]
 
     services:
       postgres:
@@ -304,7 +304,7 @@ jobs:
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
-    needs: [backend-api, frontend-unit]
+    needs: [backend-integration, frontend-unit]
 
     steps:
       - name: Checkout code
@@ -313,12 +313,72 @@ jobs:
       - name: Run E2E tests
         run: echo "playwright test"  # placeholder
 
-  # ── 5. DEPLOY ─────────────────────────────────────────────────────────────────
+  # ── 5. UAT TESTS ──────────────────────────────────────────────────────────────
+
+  uat:
+    name: UAT Tests
+    runs-on: ubuntu-latest
+    needs: [backend-integration, frontend-unit]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Start full stack
+        run: |
+          cat > .env <<'EOF'
+          DATABASE_URL=postgresql://postgres:postgres@db:5432/localhistory
+          JWT_SECRET_KEY=ci-test-secret
+          JWT_ALGORITHM=HS256
+          JWT_EXPIRE_MINUTES=30
+          CORS_ORIGINS=http://localhost:3002
+          STORAGE_ENDPOINT=http://minio:9000
+          STORAGE_ACCESS_KEY=minioadmin
+          STORAGE_SECRET_KEY=minioadmin
+          STORAGE_REGION=us-east-1
+          STORAGE_PUBLIC_URL=http://localhost:9001
+          STORAGE_BUCKET_IMAGES=images
+          STORAGE_BUCKET_AUDIO=audio
+          STORAGE_BUCKET_VIDEOS=videos
+          LOG_SQL=false
+          EOF
+          docker compose -f docker-compose.yml up -d --build
+
+      - name: Wait for backend health
+        run: |
+          for i in $(seq 1 30); do
+            curl -sf http://localhost:8000/health && break
+            sleep 3
+          done
+
+      - name: Run Playwright UAT tests
+        run: |
+          if [ -d "frontend/tests/uat" ]; then
+            cd frontend && npx playwright test tests/uat/ --reporter=html,junit
+          else
+            echo "UAT placeholder — tests/uat/ not yet created (see issue #282)"
+          fi
+
+      - name: Upload UAT test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: uat-test-reports
+          path: |
+            frontend/playwright-report/
+            frontend/uat-report.xml
+
+  # ── 6. DEPLOY ─────────────────────────────────────────────────────────────────
 
   trigger-deploy:
     name: Trigger Deployment
     runs-on: ubuntu-latest
-    needs: e2e
+    needs: [e2e, uat]
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
 
     steps:


### PR DESCRIPTION
## Description
Fixes the backend test job execution order in CI and adds a new parallel `uat` job for acceptance testing.

**Before:** `unit → integration → api → e2e`
**After:** `unit → api → integration → (e2e ∥ uat)`

API tests are faster and catch endpoint regressions earlier, so they should gate integration tests — not the other way around. The new `uat` job runs in parallel with `e2e` once both `backend-integration` and `frontend-unit` pass. It spins up the full Docker Compose stack, health-waits on the backend, and runs Playwright UAT tests (with a safe placeholder until `tests/uat/` is created in issue #282).

## Related Issue(s)
- Closes #281

## Changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Swapped `backend-api`/`backend-integration` `needs` to fix order; updated `e2e` gate; added `uat` job with Docker Compose stack startup, health-wait, Playwright run, and artifact upload; updated `trigger-deploy` to require both `e2e` and `uat` |

## Checklist
- [x] All tests passed
- [x] I have self-reviewed my own code
- [ ] I have requested at least 1 reviewer