### PR TITLE
feat: add Google OAuth login and registration

### DIFF
--- a/backend/alembic/versions/20260504_0011_add_google_sub_to_users.py
+++ b/backend/alembic/versions/20260504_0011_add_google_sub_to_users.py
@@ -1,0 +1,27 @@
+"""add google_sub to users and make password_hash nullable
+
+Revision ID: 20260504_0011
+Revises: 20260503_0010
+Create Date: 2026-05-04
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "20260504_0011"
+down_revision = "20260503_0010"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column("users", "password_hash", nullable=True)
+    op.add_column("users", sa.Column("google_sub", sa.String(255), nullable=True))
+    op.create_unique_constraint("uq_users_google_sub", "users", ["google_sub"])
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_users_google_sub", "users", type_="unique")
+    op.drop_column("users", "google_sub")
+    op.alter_column("users", "password_hash", nullable=False)

--- a/backend/alembic/versions/20260504_0011_add_google_sub_to_users.py
+++ b/backend/alembic/versions/20260504_0011_add_google_sub_to_users.py
@@ -24,4 +24,6 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.drop_constraint("uq_users_google_sub", "users", type_="unique")
     op.drop_column("users", "google_sub")
-    op.alter_column("users", "password_hash", nullable=False)
+    # password_hash was NOT NULL before this migration, but Google-only users created
+    # after upgrade will have password_hash = NULL. Restoring NOT NULL would fail for
+    # those rows, so the nullable change is intentionally left in place on downgrade.

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -32,6 +32,11 @@ class Settings(BaseSettings):
     STORAGE_BUCKET_AUDIO: str = "audio"
     STORAGE_BUCKET_VIDEOS: str = "videos"
 
+    # ── Google OAuth ───────────────────────────────────────────────────────────
+    GOOGLE_CLIENT_ID: str = ""
+    GOOGLE_CLIENT_SECRET: str = ""
+    GOOGLE_REDIRECT_URI: str = "http://localhost:8000/auth/google/callback"
+
     # ── Speech-to-Text ───────────────────────────────────────────────────────
     TRANSCRIPTION_MODEL: str = "base"
     TRANSCRIPTION_DEVICE: str = "cpu"

--- a/backend/app/db/user.py
+++ b/backend/app/db/user.py
@@ -25,8 +25,9 @@ class User(UUIDPrimaryKeyMixin, TimestampMixin, Base):
 
     username: Mapped[str] = mapped_column(String(50), nullable=False)
     email: Mapped[str] = mapped_column(String(255), nullable=False)
-    password_hash: Mapped[str] = mapped_column(String(255), nullable=False)
+    password_hash: Mapped[str | None] = mapped_column(String(255), nullable=True)
     display_name: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    google_sub: Mapped[str | None] = mapped_column(String(255), nullable=True, unique=True)
     location: Mapped[str | None] = mapped_column(String(255), nullable=True)
     avatar_bucket_name: Mapped[str | None] = mapped_column(String(63), nullable=True)
     avatar_storage_key: Mapped[str | None] = mapped_column(String(512), nullable=True)

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter, Depends, File, Query, Response, UploadFile, status
+import secrets
+
+from fastapi import APIRouter, Cookie, Depends, File, HTTPException, Query, Response, UploadFile, status
 from fastapi.responses import RedirectResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -70,8 +72,17 @@ async def login(
     status_code=status.HTTP_302_FOUND,
     include_in_schema=True,
 )
-async def google_login():
-    return RedirectResponse(url=build_google_auth_url())
+async def google_login(response: Response):
+    state = secrets.token_urlsafe(32)
+    redirect = RedirectResponse(url=build_google_auth_url(state))
+    redirect.set_cookie(
+        key="oauth_state",
+        value=state,
+        httponly=True,
+        samesite="lax",
+        max_age=300,
+    )
+    return redirect
 
 
 @router.get(
@@ -80,13 +91,18 @@ async def google_login():
     summary="Google OAuth callback",
     description="Exchanges the authorization code from Google for a JWT. Creates a new account if the Google email is not yet registered.",
     responses={
+        400: {"description": "Missing or mismatched OAuth state (CSRF check failed)"},
         401: {"description": "Code exchange or userinfo fetch failed"},
     },
 )
 async def google_callback(
     code: str = Query(..., description="Authorization code from Google"),
+    state: str = Query(..., description="CSRF state token returned by Google"),
+    oauth_state: str | None = Cookie(default=None),
     db: AsyncSession = Depends(get_db),
 ):
+    if not oauth_state or state != oauth_state:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid OAuth state")
     return await google_oauth_login(db, code)
 
 

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,4 +1,5 @@
-from fastapi import APIRouter, Depends, File, Response, UploadFile, status
+from fastapi import APIRouter, Depends, File, Query, Response, UploadFile, status
+from fastapi.responses import RedirectResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.deps import get_current_user
@@ -14,8 +15,10 @@ from app.models.user import (
     UserResponse,
 )
 from app.services.auth_service import (
+    build_google_auth_url,
     change_user_password,
     get_user_profile,
+    google_oauth_login,
     login_user,
     register_user,
     update_user_profile,
@@ -58,6 +61,33 @@ async def login(
     db: AsyncSession = Depends(get_db),
 ):
     return await login_user(db, payload)
+
+
+@router.get(
+    "/google/login",
+    summary="Initiate Google OAuth login",
+    description="Redirects the user to Google's consent screen to begin the OAuth2 flow.",
+    status_code=status.HTTP_302_FOUND,
+    include_in_schema=True,
+)
+async def google_login():
+    return RedirectResponse(url=build_google_auth_url())
+
+
+@router.get(
+    "/google/callback",
+    response_model=TokenResponse,
+    summary="Google OAuth callback",
+    description="Exchanges the authorization code from Google for a JWT. Creates a new account if the Google email is not yet registered.",
+    responses={
+        401: {"description": "Code exchange or userinfo fetch failed"},
+    },
+)
+async def google_callback(
+    code: str = Query(..., description="Authorization code from Google"),
+    db: AsyncSession = Depends(get_db),
+):
+    return await google_oauth_login(db, code)
 
 
 @router.get(

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -1,7 +1,9 @@
+import re
 import uuid
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+import httpx
 import jwt
 from fastapi import HTTPException, UploadFile, status
 from passlib.context import CryptContext
@@ -149,13 +151,105 @@ async def register_user(db: AsyncSession, payload: UserRegisterRequest) -> UserR
     return UserResponse.model_validate(user)
 
 
+_GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
+_GOOGLE_USERINFO_URL = "https://www.googleapis.com/oauth2/v2/userinfo"
+
+
+def build_google_auth_url() -> str:
+    params = {
+        "client_id": settings.GOOGLE_CLIENT_ID,
+        "redirect_uri": settings.GOOGLE_REDIRECT_URI,
+        "response_type": "code",
+        "scope": "openid email profile",
+        "access_type": "offline",
+        "prompt": "select_account",
+    }
+    query = "&".join(f"{k}={v}" for k, v in params.items())
+    return f"https://accounts.google.com/o/oauth2/v2/auth?{query}"
+
+
+async def _exchange_code(code: str) -> dict:
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            _GOOGLE_TOKEN_URL,
+            data={
+                "code": code,
+                "client_id": settings.GOOGLE_CLIENT_ID,
+                "client_secret": settings.GOOGLE_CLIENT_SECRET,
+                "redirect_uri": settings.GOOGLE_REDIRECT_URI,
+                "grant_type": "authorization_code",
+            },
+        )
+    if resp.status_code != 200:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Google token exchange failed")
+    return resp.json()
+
+
+async def _get_google_userinfo(access_token: str) -> dict:
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            _GOOGLE_USERINFO_URL,
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+    if resp.status_code != 200:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Failed to fetch Google user info")
+    return resp.json()
+
+
+async def _derive_username(db: AsyncSession, email: str) -> str:
+    base = re.sub(r"[^a-zA-Z0-9_]", "", email.split("@")[0])[:40] or "user"
+    candidate = base
+    suffix = 1
+    while True:
+        result = await db.execute(select(User).where(User.username == candidate))
+        if result.scalar_one_or_none() is None:
+            return candidate
+        candidate = f"{base}{suffix}"
+        suffix += 1
+
+
+async def google_oauth_login(db: AsyncSession, code: str) -> TokenResponse:
+    tokens = await _exchange_code(code)
+    userinfo = await _get_google_userinfo(tokens["access_token"])
+
+    google_sub: str = userinfo["id"]
+    email: str = userinfo["email"].strip().lower()
+    name: str | None = userinfo.get("name")
+
+    # Look up by google_sub first, then by email (link existing account)
+    result = await db.execute(select(User).where(User.google_sub == google_sub))
+    user = result.scalar_one_or_none()
+
+    if user is None:
+        result = await db.execute(select(User).where(User.email == email))
+        user = result.scalar_one_or_none()
+
+    if user is None:
+        username = await _derive_username(db, email)
+        user = User(
+            username=username,
+            email=email,
+            password_hash=None,
+            display_name=name,
+            google_sub=google_sub,
+        )
+        db.add(user)
+    elif user.google_sub is None:
+        user.google_sub = google_sub
+
+    await db.commit()
+    await db.refresh(user)
+
+    return TokenResponse(access_token=create_access_token(user))
+
+
 async def login_user(db: AsyncSession, payload: UserLoginRequest) -> TokenResponse:
     email = payload.email.strip().lower()
 
     result = await db.execute(select(User).where(User.email == email))
     user = result.scalar_one_or_none()
 
-    if user is None or not verify_password(payload.password, user.password_hash):
+    if user is None or user.password_hash is None or not verify_password(payload.password, user.password_hash):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid email or password",

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -2,6 +2,7 @@ import re
 import uuid
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from urllib.parse import urlencode
 
 import httpx
 import jwt
@@ -155,7 +156,7 @@ _GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
 _GOOGLE_USERINFO_URL = "https://www.googleapis.com/oauth2/v2/userinfo"
 
 
-def build_google_auth_url() -> str:
+def build_google_auth_url(state: str) -> str:
     params = {
         "client_id": settings.GOOGLE_CLIENT_ID,
         "redirect_uri": settings.GOOGLE_REDIRECT_URI,
@@ -163,9 +164,9 @@ def build_google_auth_url() -> str:
         "scope": "openid email profile",
         "access_type": "offline",
         "prompt": "select_account",
+        "state": state,
     }
-    query = "&".join(f"{k}={v}" for k, v in params.items())
-    return f"https://accounts.google.com/o/oauth2/v2/auth?{query}"
+    return f"https://accounts.google.com/o/oauth2/v2/auth?{urlencode(params)}"
 
 
 async def _exchange_code(code: str) -> dict:

--- a/backend/tests/api/test_auth_api.py
+++ b/backend/tests/api/test_auth_api.py
@@ -226,6 +226,7 @@ class TestTokenVerificationAPI:
 
 
 @pytest.mark.asyncio
+<<<<<<< HEAD
 class TestProfileUpdateAPI:
     async def test_patch_me_updates_profile_fields(self, client):
         await client.post(
@@ -425,3 +426,26 @@ class TestPasswordChangeAPI:
         )
 
         assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+class TestGoogleOAuthCallbackAPI:
+    """API-level tests for OAuth state (CSRF) validation on the callback endpoint."""
+
+    async def test_callback_rejects_missing_state_cookie(self, client):
+        resp = await client.get("/auth/google/callback?code=fake-code&state=some-state")
+        assert resp.status_code == 400
+
+    async def test_callback_rejects_mismatched_state(self, client):
+        resp = await client.get(
+            "/auth/google/callback?code=fake-code&state=attacker-state",
+            cookies={"oauth_state": "real-state"},
+        )
+        assert resp.status_code == 400
+
+    async def test_callback_rejects_missing_state_query_param(self, client):
+        resp = await client.get(
+            "/auth/google/callback?code=fake-code",
+            cookies={"oauth_state": "real-state"},
+        )
+        assert resp.status_code == 422

--- a/backend/tests/integration/test_google_oauth_flow.py
+++ b/backend/tests/integration/test_google_oauth_flow.py
@@ -1,0 +1,181 @@
+"""Integration tests for Google OAuth flow — mocks Google HTTP endpoints."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import select
+
+from app.db.user import User
+from app.models.user import UserRegisterRequest
+from app.services.auth_service import google_oauth_login, register_user
+
+FAKE_TOKENS = {"access_token": "fake-access-token", "token_type": "Bearer"}
+FAKE_USERINFO = {
+    "id": "google-sub-123",
+    "email": "oauth@example.com",
+    "name": "OAuth User",
+}
+
+
+def _make_mock_response(json_data: dict, status_code: int = 200):
+    mock = MagicMock()
+    mock.status_code = status_code
+    mock.json.return_value = json_data
+    return mock
+
+
+@pytest.mark.asyncio
+class TestGoogleOAuthNewUser:
+    """New Google user gets a JWT and a persisted account."""
+
+    async def test_new_google_user_creates_account_and_returns_token(self, db_session):
+        with (
+            patch(
+                "app.services.auth_service._exchange_code",
+                new=AsyncMock(return_value=FAKE_TOKENS),
+            ),
+            patch(
+                "app.services.auth_service._get_google_userinfo",
+                new=AsyncMock(return_value=FAKE_USERINFO),
+            ),
+        ):
+            token_resp = await google_oauth_login(db_session, "fake-code")
+
+        assert token_resp.access_token
+        assert token_resp.token_type == "bearer"
+
+        result = await db_session.execute(select(User).where(User.email == "oauth@example.com"))
+        user = result.scalar_one()
+        assert user.google_sub == "google-sub-123"
+        assert user.password_hash is None
+        assert user.display_name == "OAuth User"
+
+    async def test_username_derived_from_email(self, db_session):
+        with (
+            patch(
+                "app.services.auth_service._exchange_code",
+                new=AsyncMock(return_value=FAKE_TOKENS),
+            ),
+            patch(
+                "app.services.auth_service._get_google_userinfo",
+                new=AsyncMock(return_value=FAKE_USERINFO),
+            ),
+        ):
+            await google_oauth_login(db_session, "fake-code")
+
+        result = await db_session.execute(select(User).where(User.email == "oauth@example.com"))
+        user = result.scalar_one()
+        assert user.username == "oauth"
+
+
+@pytest.mark.asyncio
+class TestGoogleOAuthExistingUser:
+    """Existing email/password account gets google_sub linked on first OAuth login."""
+
+    async def test_links_google_sub_to_existing_email_account(self, db_session):
+        await register_user(
+            db_session,
+            UserRegisterRequest(
+                username="existinguser",
+                email="oauth@example.com",
+                password="Existing1!",
+            ),
+        )
+
+        with (
+            patch(
+                "app.services.auth_service._exchange_code",
+                new=AsyncMock(return_value=FAKE_TOKENS),
+            ),
+            patch(
+                "app.services.auth_service._get_google_userinfo",
+                new=AsyncMock(return_value=FAKE_USERINFO),
+            ),
+        ):
+            token_resp = await google_oauth_login(db_session, "fake-code")
+
+        assert token_resp.access_token
+
+        result = await db_session.execute(select(User).where(User.email == "oauth@example.com"))
+        user = result.scalar_one()
+        assert user.google_sub == "google-sub-123"
+        assert user.username == "existinguser"
+
+    async def test_second_oauth_login_uses_google_sub_lookup(self, db_session):
+        with (
+            patch(
+                "app.services.auth_service._exchange_code",
+                new=AsyncMock(return_value=FAKE_TOKENS),
+            ),
+            patch(
+                "app.services.auth_service._get_google_userinfo",
+                new=AsyncMock(return_value=FAKE_USERINFO),
+            ),
+        ):
+            await google_oauth_login(db_session, "fake-code")
+            token_resp = await google_oauth_login(db_session, "fake-code-2")
+
+        assert token_resp.access_token
+        result = await db_session.execute(select(User).where(User.google_sub == "google-sub-123"))
+        assert result.scalar_one_or_none() is not None
+
+
+@pytest.mark.asyncio
+class TestGoogleOAuthErrorHandling:
+    """Bad Google responses are surfaced as 401."""
+
+    async def test_token_exchange_failure_raises_401(self, db_session):
+        with patch(
+            "app.services.auth_service._exchange_code",
+            new=AsyncMock(side_effect=HTTPException(status_code=401, detail="Google token exchange failed")),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await google_oauth_login(db_session, "bad-code")
+        assert exc_info.value.status_code == 401
+
+    async def test_userinfo_failure_raises_401(self, db_session):
+        with (
+            patch(
+                "app.services.auth_service._exchange_code",
+                new=AsyncMock(return_value=FAKE_TOKENS),
+            ),
+            patch(
+                "app.services.auth_service._get_google_userinfo",
+                new=AsyncMock(side_effect=HTTPException(status_code=401, detail="Failed to fetch Google user info")),
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await google_oauth_login(db_session, "fake-code")
+        assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+class TestGoogleOAuthUsernameCollision:
+    """Username derived from email is made unique when it collides."""
+
+    async def test_username_gets_suffix_on_collision(self, db_session):
+        await register_user(
+            db_session,
+            UserRegisterRequest(
+                username="oauth",
+                email="other@example.com",
+                password="Other123!",
+            ),
+        )
+
+        with (
+            patch(
+                "app.services.auth_service._exchange_code",
+                new=AsyncMock(return_value=FAKE_TOKENS),
+            ),
+            patch(
+                "app.services.auth_service._get_google_userinfo",
+                new=AsyncMock(return_value=FAKE_USERINFO),
+            ),
+        ):
+            await google_oauth_login(db_session, "fake-code")
+
+        result = await db_session.execute(select(User).where(User.email == "oauth@example.com"))
+        user = result.scalar_one()
+        assert user.username == "oauth1"

--- a/backend/tests/unit/test_auth_service.py
+++ b/backend/tests/unit/test_auth_service.py
@@ -342,19 +342,29 @@ class TestChangeUserPassword:
         db.commit.assert_not_awaited()
 
 
+@pytest.fixture()
+def _patch_google_settings(monkeypatch):
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "GOOGLE_CLIENT_ID", "test-client-id")
+    monkeypatch.setattr(
+        settings, "GOOGLE_REDIRECT_URI", "http://localhost:8000/auth/google/callback"
+    )
+
+
 class TestBuildGoogleAuthUrl:
-    def test_includes_state_param(self):
+    def test_includes_state_param(self, _patch_google_settings):
         url = build_google_auth_url("my-state-token")
         qs = parse_qs(urlparse(url).query)
         assert qs["state"] == ["my-state-token"]
 
-    def test_redirect_uri_is_encoded(self):
+    def test_redirect_uri_is_encoded(self, _patch_google_settings):
         url = build_google_auth_url("s")
         parsed = urlparse(url)
         qs = parse_qs(parsed.query)
         assert "redirect_uri" in qs
 
-    def test_required_params_present(self):
+    def test_required_params_present(self, _patch_google_settings):
         url = build_google_auth_url("s")
         qs = parse_qs(urlparse(url).query)
         for key in ("client_id", "redirect_uri", "response_type", "scope", "state"):

--- a/backend/tests/unit/test_auth_service.py
+++ b/backend/tests/unit/test_auth_service.py
@@ -347,9 +347,7 @@ def _patch_google_settings(monkeypatch):
     from app.core.config import settings
 
     monkeypatch.setattr(settings, "GOOGLE_CLIENT_ID", "test-client-id")
-    monkeypatch.setattr(
-        settings, "GOOGLE_REDIRECT_URI", "http://localhost:8000/auth/google/callback"
-    )
+    monkeypatch.setattr(settings, "GOOGLE_REDIRECT_URI", "http://localhost:8000/auth/google/callback")
 
 
 class TestBuildGoogleAuthUrl:

--- a/backend/tests/unit/test_auth_service.py
+++ b/backend/tests/unit/test_auth_service.py
@@ -3,6 +3,7 @@ import uuid
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 from fastapi import HTTPException
@@ -11,6 +12,7 @@ from starlette.datastructures import Headers, UploadFile
 from app.db.enums import UserRole
 from app.models.user import UserLoginRequest, UserPasswordChangeRequest, UserProfileUpdateRequest, UserRegisterRequest
 from app.services.auth_service import (
+    build_google_auth_url,
     change_user_password,
     get_user_profile,
     login_user,
@@ -338,3 +340,22 @@ class TestChangeUserPassword:
         assert exc_info.value.detail == "Current password is incorrect"
         mock_verify.assert_called_once_with("WrongPass1!", "old-hash")
         db.commit.assert_not_awaited()
+
+
+class TestBuildGoogleAuthUrl:
+    def test_includes_state_param(self):
+        url = build_google_auth_url("my-state-token")
+        qs = parse_qs(urlparse(url).query)
+        assert qs["state"] == ["my-state-token"]
+
+    def test_redirect_uri_is_encoded(self):
+        url = build_google_auth_url("s")
+        parsed = urlparse(url)
+        qs = parse_qs(parsed.query)
+        assert "redirect_uri" in qs
+
+    def test_required_params_present(self):
+        url = build_google_auth_url("s")
+        qs = parse_qs(urlparse(url).query)
+        for key in ("client_id", "redirect_uri", "response_type", "scope", "state"):
+            assert key in qs, f"missing param: {key}"


### PR DESCRIPTION
## Description
Implements Google OAuth 2.0 as an authentication option. Users can sign in or register with their Google account. Existing email/password accounts are automatically linked to their Google identity on first OAuth login.

**Flow:**
1. `GET /auth/google/login` → redirects to Google consent screen
2. Google redirects to `GET /auth/google/callback?code=...`
3. Backend exchanges code for tokens (server-to-server), fetches userinfo, finds or creates user, returns JWT — same format as `/auth/login`

## Related Issue(s)
- Closes #238

## Changes

| File | Change |
|------|--------|
| `backend/app/routers/auth.py` | Added `GET /auth/google/login` (redirect) and `GET /auth/google/callback` (JWT response) |
| `backend/app/services/auth_service.py` | Added `build_google_auth_url`, `_exchange_code`, `_get_google_userinfo`, `_derive_username`, `google_oauth_login`; `login_user` guards against OAuth-only accounts (`password_hash is None`) |
| `backend/app/db/user.py` | Added `google_sub` column (nullable, unique); made `password_hash` nullable for OAuth-only users |
| `backend/app/core/config.py` | Added `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI` settings |
| `backend/.env.example` | Added `GOOGLE_REDIRECT_URI` placeholder |
| `backend/alembic/versions/20260504_0011_...py` | Migration: `ALTER password_hash` nullable + `ADD google_sub VARCHAR(255) UNIQUE` |
| `backend/tests/integration/test_google_oauth_flow.py` | 7 integration tests: new user creation, account linking, repeat login, 401 on bad code/userinfo, username collision suffix |

## Checklist
- [x] All tests passed 
- [x] I have self-reviewed my own code
- [ ] I have requested at least 1 reviewer