### PR TITLE
fix: the frontend of the like and comment features are connected to backend

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -18,6 +18,9 @@ COPY auth.js /usr/share/nginx/html/auth.js
 COPY config.js /usr/share/nginx/html/config.js
 COPY saves.js /usr/share/nginx/html/saves.js
 COPY saved.js /usr/share/nginx/html/saved.js
+COPY likes.js /usr/share/nginx/html/likes.js
+COPY comments.js /usr/share/nginx/html/comments.js
+COPY recording.js /usr/share/nginx/html/recording.js
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 EXPOSE 80

--- a/frontend/comments.js
+++ b/frontend/comments.js
@@ -25,8 +25,15 @@ function setCommentError(message) {
 }
 
 function normalizeComment(raw) {
-    // Backend is not implemented yet; tolerate common response shapes.
-    var author = raw.author || raw.username || raw.user || "Anonymous";
+    // Backend returns `author: { id, username, display_name }`.
+    // Older mocks/tests pass `author` as a plain string or use `username`/`user`.
+    var rawAuthor = raw.author;
+    var author;
+    if (rawAuthor && typeof rawAuthor === "object") {
+        author = rawAuthor.display_name || rawAuthor.username || "Anonymous";
+    } else {
+        author = rawAuthor || raw.username || raw.user || "Anonymous";
+    }
     var content = raw.content || raw.text || raw.message || "";
     var createdAt = raw.created_at || raw.createdAt || raw.created || null;
     return {

--- a/frontend/comments.test.js
+++ b/frontend/comments.test.js
@@ -46,6 +46,21 @@ describe("comments UI", () => {
         );
     });
 
+    test("normalizeComment resolves nested author object from backend", () => {
+        // Real backend shape: author = { id, username, display_name }.
+        expect(normalizeComment({
+            id: "c1",
+            content: "Hi",
+            author: { id: "u1", username: "alice", display_name: "Alice A." }
+        })).toEqual(expect.objectContaining({ id: "c1", author: "Alice A.", content: "Hi" }));
+
+        // Fall back to username when display_name is missing.
+        expect(normalizeComment({
+            content: "Hi",
+            author: { id: "u2", username: "bob", display_name: null }
+        })).toEqual(expect.objectContaining({ author: "bob" }));
+    });
+
     test("shows login prompt when logged out", async () => {
         global.isLoggedIn.mockReturnValue(false);
         global.fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([]) });

--- a/frontend/likes.js
+++ b/frontend/likes.js
@@ -33,14 +33,32 @@ function setLikeUi(state) {
     }
 }
 
+function normalizeLikeSummary(raw, fallbackStoryId) {
+    // Backend returns { story_id, liked, like_count }; UI uses { story_id, liked_by_me, likes_count }.
+    // Tolerate either shape so older tests/mocks keep working.
+    if (!raw || typeof raw !== "object") {
+        return { story_id: fallbackStoryId, liked_by_me: false, likes_count: 0 };
+    }
+    var liked = (typeof raw.liked === "boolean") ? raw.liked : !!raw.liked_by_me;
+    var count = (typeof raw.like_count === "number") ? raw.like_count
+        : (typeof raw.likes_count === "number") ? raw.likes_count
+        : 0;
+    return {
+        story_id: raw.story_id || fallbackStoryId,
+        liked_by_me: liked,
+        likes_count: Math.max(0, count)
+    };
+}
+
 async function fetchLikeSummary(apiBase, storyId) {
-    var res = await authFetch(apiBase + "/stories/" + storyId + "/likes");
+    var res = await authFetch(apiBase + "/stories/" + storyId + "/like");
     if (!res.ok) {
         var err = new Error("Likes endpoint unavailable");
         err.status = res.status;
         throw err;
     }
-    return await res.json();
+    var data = await res.json();
+    return normalizeLikeSummary(data, storyId);
 }
 
 async function sendLikeToggle(apiBase, storyId, likedByMe) {
@@ -50,36 +68,46 @@ async function sendLikeToggle(apiBase, storyId, likedByMe) {
     }
 
     var method = likedByMe ? "DELETE" : "POST";
-    var res = await authFetch(apiBase + "/stories/" + storyId + "/likes", { method: method });
+    var res = await authFetch(apiBase + "/stories/" + storyId + "/like", { method: method });
     if (!res.ok) {
         var err = new Error("Failed to update like");
         err.status = res.status;
         throw err;
     }
-    return await res.json();
+    var data = await res.json();
+    return normalizeLikeSummary(data, storyId);
 }
 
-function setupLikes(apiBase, storyId) {
+function setupLikes(apiBase, storyId, seed) {
+    // `seed` is optional: { like_count?: number } from the public story detail.
+    // Used to render the count for anonymous viewers (GET /like requires auth).
     var btn = document.getElementById("like-button");
     if (!btn) return;
 
-    var state = { story_id: storyId, likes_count: 0, liked_by_me: false };
+    var seedCount = (seed && typeof seed.like_count === "number") ? Math.max(0, seed.like_count) : 0;
+    var state = { story_id: storyId, likes_count: seedCount, liked_by_me: false };
 
     btn.disabled = true;
     setLikeStatus("");
 
-    fetchLikeSummary(apiBase, storyId)
-        .then(function (summary) {
-            state = summary || state;
-            setLikeUi(state);
-        })
-        .catch(function () {
-            setLikeUi(state);
-            setLikeStatus("Likes unavailable (backend pending).");
-        })
-        .finally(function () {
-            btn.disabled = false;
-        });
+    if (!isLoggedIn()) {
+        // GET /like requires auth; render seed-only state and let click redirect to login.
+        setLikeUi(state);
+        btn.disabled = false;
+    } else {
+        fetchLikeSummary(apiBase, storyId)
+            .then(function (summary) {
+                state = summary || state;
+                setLikeUi(state);
+            })
+            .catch(function () {
+                setLikeUi(state);
+                setLikeStatus("Likes unavailable (backend pending).");
+            })
+            .finally(function () {
+                btn.disabled = false;
+            });
+    }
 
     btn.addEventListener("click", async function () {
         if (btn.disabled) return;
@@ -120,6 +148,7 @@ if (typeof module !== "undefined" && module.exports) {
     module.exports = {
         setLikeStatus: setLikeStatus,
         setLikeUi: setLikeUi,
+        normalizeLikeSummary: normalizeLikeSummary,
         fetchLikeSummary: fetchLikeSummary,
         sendLikeToggle: sendLikeToggle,
         setupLikes: setupLikes

--- a/frontend/likes.test.js
+++ b/frontend/likes.test.js
@@ -1,4 +1,4 @@
-const { setupLikes, setLikeUi } = require("./likes");
+const { setupLikes, setLikeUi, normalizeLikeSummary } = require("./likes");
 
 describe("likes UI", () => {
     let assignMock;
@@ -54,7 +54,20 @@ describe("likes UI", () => {
         expect(document.getElementById("like-count").textContent).toBe("2");
     });
 
-    test("setupLikes shows backend pending message when GET /likes fails", async () => {
+    test("normalizeLikeSummary maps API shape to UI shape", () => {
+        expect(normalizeLikeSummary({ story_id: "s1", liked: true, like_count: 7 }, "fallback"))
+            .toEqual({ story_id: "s1", liked_by_me: true, likes_count: 7 });
+
+        // Tolerates the older UI shape used by some legacy mocks.
+        expect(normalizeLikeSummary({ liked_by_me: false, likes_count: 2 }, "fallback"))
+            .toEqual({ story_id: "fallback", liked_by_me: false, likes_count: 2 });
+
+        expect(normalizeLikeSummary(null, "fallback"))
+            .toEqual({ story_id: "fallback", liked_by_me: false, likes_count: 0 });
+    });
+
+    test("setupLikes shows backend pending message when GET /like fails", async () => {
+        global.isLoggedIn.mockReturnValue(true);
         global.authFetch.mockResolvedValueOnce({ ok: false, status: 404, json: () => Promise.resolve({}) });
 
         setupLikes("http://api", "story-1");
@@ -66,18 +79,30 @@ describe("likes UI", () => {
         expect(status.textContent).toContain("backend pending");
     });
 
+    test("setupLikes uses seed.like_count for anonymous viewers and skips GET", async () => {
+        global.isLoggedIn.mockReturnValue(false);
+
+        setupLikes("http://api", "story-1", { like_count: 12 });
+
+        await flushMicrotasks();
+
+        expect(global.authFetch).not.toHaveBeenCalled();
+        expect(document.getElementById("like-count").textContent).toBe("12");
+        expect(document.getElementById("like-status").classList.contains("hidden")).toBe(true);
+    });
+
     test("click optimistically increments count and sets animating flag", async () => {
         jest.useFakeTimers();
         global.authFetch
-            // initial GET /likes
+            // initial GET /like
             .mockResolvedValueOnce({
                 ok: true,
-                json: () => Promise.resolve({ story_id: "story-1", likes_count: 10, liked_by_me: false })
+                json: () => Promise.resolve({ story_id: "story-1", like_count: 10, liked: false })
             })
-            // POST /likes
+            // POST /like
             .mockResolvedValueOnce({
                 ok: true,
-                json: () => Promise.resolve({ story_id: "story-1", likes_count: 11, liked_by_me: true })
+                json: () => Promise.resolve({ story_id: "story-1", like_count: 11, liked: true })
             });
 
         global.isLoggedIn.mockReturnValue(true);
@@ -102,13 +127,12 @@ describe("likes UI", () => {
         await flushMicrotasks();
 
         expect(document.getElementById("like-button-text").textContent).toBe("Liked");
-        expect(global.authFetch).toHaveBeenCalledWith("http://api/stories/story-1/likes");
-        expect(global.authFetch).toHaveBeenCalledWith("http://api/stories/story-1/likes", { method: "POST" });
+        expect(global.authFetch).toHaveBeenCalledWith("http://api/stories/story-1/like");
+        expect(global.authFetch).toHaveBeenCalledWith("http://api/stories/story-1/like", { method: "POST" });
         jest.useRealTimers();
     });
 
     test("click redirects to index when not logged in", async () => {
-        global.authFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ likes_count: 0, liked_by_me: false }) });
         global.isLoggedIn.mockReturnValue(false);
 
         setupLikes("http://api", "story-1");

--- a/frontend/story-detail.html
+++ b/frontend/story-detail.html
@@ -266,7 +266,8 @@
           }
 
           setupComments(API_BASE, String(story.id || storyId));
-          setupLikes(API_BASE, String(story.id || storyId));
+          var likeSeed = { like_count: typeof story.like_count === "number" ? story.like_count : 0 };
+          setupLikes(API_BASE, String(story.id || storyId), likeSeed);
       })
       .catch(err => {
          console.error("Error loading story details:", err);


### PR DESCRIPTION
## Description

Wires the story-detail page up to the existing backend like and comment endpoints so the Like button and the Comments section actually work end-to-end. Also fixes a Dockerfile gap that was causing `likes.js` / `comments.js` (and `recording.js`) to 404 in the running container, which made the like button silently do nothing even after the URL fix.

## Related Issue(s)
- Closes #287 

## Changes

| File | Change |
|------|--------|
| `frontend/likes.js` | Switched URLs from `/stories/{id}/likes` to `/stories/{id}/like` to match the FastAPI route in `app/routers/story.py`. Added `normalizeLikeSummary` to map the API shape `{ liked, like_count }` to the UI shape `{ liked_by_me, likes_count }` while still tolerating the legacy shape. Extended `setupLikes(apiBase, storyId, seed)` with an optional `seed = { like_count }` and skipped the auth-only `GET /like` for anonymous viewers (the click listener still runs and redirects to login). |
| `frontend/story-detail.html` | After the public `GET /stories/{id}` resolves, pass `{ like_count: story.like_count }` as the seed into `setupLikes(...)` so anonymous viewers see the correct count immediately. |
| `frontend/comments.js` | Updated `normalizeComment` to handle the real backend shape `author: { id, username, display_name }` (preferring `display_name`, falling back to `username`). Without this the rendered author was `"[object Object]"`. |
| `frontend/likes.test.js` | Imported and unit-tested `normalizeLikeSummary`. Added a test for the seeded-anonymous path (asserts `authFetch` is never called and the seed count is rendered). Updated mocks to use the real API shape (`liked` / `like_count`) and asserted the singular `/like` URL for both GET and POST. |
| `frontend/comments.test.js` | Added a test verifying the nested `author` object is resolved to `display_name`, with a fallback to `username` when `display_name` is null. |
| `frontend/Dockerfile` | Added `COPY likes.js`, `COPY comments.js`, and `COPY recording.js`. Without these, nginx returned 404 for the scripts and `setupLikes` / `setupComments` were never defined, which is why the like button appeared dead in the Docker build. |

## Checklist
- [x] All tests passed
- [x] I have self-reviewed my own code
- [x] I have requested at least 1 reviewer