### PR TITLE
feat: add audio transcription pipeline for uploaded story media

### DIFF
--- a/backend/alembic/versions/20260508_0014_add_media_file_transcript.py
+++ b/backend/alembic/versions/20260508_0014_add_media_file_transcript.py
@@ -1,0 +1,28 @@
+"""Add transcript column to media_files.
+
+Revision ID: 20260508_0014
+Revises: 20260508_0013
+Create Date: 2026-05-08 00:00:00
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260508_0014"
+down_revision: Union[str, Sequence[str], None] = "20260508_0013"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("media_files") as batch_op:
+        batch_op.add_column(sa.Column("transcript", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("media_files") as batch_op:
+        batch_op.drop_column("transcript")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -32,6 +32,11 @@ class Settings(BaseSettings):
     STORAGE_BUCKET_AUDIO: str = "audio"
     STORAGE_BUCKET_VIDEOS: str = "videos"
 
+    # ── Speech-to-Text ───────────────────────────────────────────────────────
+    TRANSCRIPTION_MODEL: str = "base"
+    TRANSCRIPTION_DEVICE: str = "cpu"
+    TRANSCRIPTION_COMPUTE_TYPE: str = "int8"
+
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
 

--- a/backend/app/db/media_file.py
+++ b/backend/app/db/media_file.py
@@ -59,5 +59,6 @@ class MediaFile(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     )
     alt_text: Mapped[str | None] = mapped_column(Text, nullable=True)
     caption: Mapped[str | None] = mapped_column(Text, nullable=True)
+    transcript: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     story: Mapped["Story"] = relationship(back_populates="media_files")

--- a/backend/app/models/story.py
+++ b/backend/app/models/story.py
@@ -213,6 +213,7 @@ class MediaFileResponse(BaseModel):
     sort_order: int
     alt_text: str | None
     caption: str | None
+    transcript: str | None
     created_at: datetime
 
     model_config = {"from_attributes": True}

--- a/backend/app/routers/story.py
+++ b/backend/app/routers/story.py
@@ -1,6 +1,6 @@
 import uuid
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile, status
+from fastapi import APIRouter, BackgroundTasks, Depends, File, Form, HTTPException, Query, UploadFile, status
 from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -403,6 +403,7 @@ async def unsave_story(
 )
 async def upload_story_media(
     story_id: uuid.UUID,
+    background_tasks: BackgroundTasks,
     file: UploadFile = File(...),
     media_type: MediaType = Form(...),
     alt_text: str | None = Form(default=None),
@@ -417,7 +418,13 @@ async def upload_story_media(
         caption=caption,
         sort_order=sort_order,
     )
-    return await upload_media_for_story(db, story_id, file, payload)
+    return await upload_media_for_story(
+        db,
+        story_id,
+        file,
+        payload,
+        background_tasks=background_tasks,
+    )
 
 
 @router.post(

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -2,13 +2,13 @@ import uuid
 from datetime import date, datetime, timezone
 from pathlib import Path
 
-from fastapi import HTTPException, UploadFile, status
+from fastapi import BackgroundTasks, HTTPException, UploadFile, status
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.db.enums import NotificationEventType, ReportStatus, StoryStatus, StoryVisibility
+from app.db.enums import MediaType, NotificationEventType, ReportStatus, StoryStatus, StoryVisibility
 from app.db.media_file import MediaFile
 from app.db.notification import Notification
 from app.db.story import Story
@@ -38,6 +38,7 @@ from app.services.storage import (
     get_bucket_for_media_type,
     upload_bytes,
 )
+from app.services.transcription_service import transcribe_media_file
 
 MAX_MEDIA_UPLOAD_BYTES = 20 * 1024 * 1024  # 20 MB
 
@@ -50,6 +51,49 @@ ALLOWED_MIME_TYPES = {
         "text/plain",
         "application/msword",
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    },
+}
+
+MIME_TYPE_ALIASES = {
+    "image/jpg": "image/jpeg",
+    "audio/x-wav": "audio/wav",
+    "audio/wave": "audio/wav",
+    "audio/vnd.wave": "audio/wav",
+    "audio/x-m4a": "audio/mp4",
+    "audio/m4a": "audio/mp4",
+    "video/x-m4v": "video/mp4",
+    "application/x-pdf": "application/pdf",
+}
+
+GENERIC_BINARY_MIME_TYPES = {"application/octet-stream", "binary/octet-stream"}
+
+MIME_TYPE_FALLBACKS_BY_EXTENSION = {
+    "image": {
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".png": "image/png",
+        ".webp": "image/webp",
+        ".gif": "image/gif",
+    },
+    "audio": {
+        ".mp3": "audio/mpeg",
+        ".wav": "audio/wav",
+        ".ogg": "audio/ogg",
+        ".m4a": "audio/mp4",
+        ".mp4": "audio/mp4",
+        ".webm": "audio/webm",
+    },
+    "video": {
+        ".mp4": "video/mp4",
+        ".m4v": "video/mp4",
+        ".webm": "video/webm",
+        ".mov": "video/quicktime",
+    },
+    "document": {
+        ".pdf": "application/pdf",
+        ".txt": "text/plain",
+        ".doc": "application/msword",
+        ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     },
 }
 
@@ -76,6 +120,7 @@ def _map_media_file(media: MediaFile) -> MediaFileResponse:
         sort_order=media.sort_order,
         alt_text=media.alt_text,
         caption=media.caption,
+        transcript=media.transcript,
         created_at=media.created_at,
     )
 
@@ -137,7 +182,20 @@ def _map_comment_row(comment: StoryComment, author: User) -> CommentResponse:
     )
 
 
-def _validate_media_upload(file: UploadFile, payload: MediaUploadRequest) -> None:
+def _normalize_media_content_type(file: UploadFile, payload: MediaUploadRequest) -> str:
+    raw_content_type = (file.content_type or "").split(";")[0].strip().lower()
+    normalized_content_type = MIME_TYPE_ALIASES.get(raw_content_type, raw_content_type)
+
+    if normalized_content_type in GENERIC_BINARY_MIME_TYPES:
+        extension = Path(file.filename or "").suffix.lower()
+        fallback_content_type = MIME_TYPE_FALLBACKS_BY_EXTENSION[payload.media_type.value].get(extension)
+        if fallback_content_type:
+            return fallback_content_type
+
+    return normalized_content_type
+
+
+def _validate_media_upload(file: UploadFile, payload: MediaUploadRequest) -> str:
     if not file.filename:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -151,12 +209,14 @@ def _validate_media_upload(file: UploadFile, payload: MediaUploadRequest) -> Non
         )
 
     allowed_for_type = ALLOWED_MIME_TYPES[payload.media_type.value]
-    base_content_type = (file.content_type or "").split(";")[0].strip().lower()
-    if base_content_type not in allowed_for_type:
+    normalized_content_type = _normalize_media_content_type(file, payload)
+    if normalized_content_type not in allowed_for_type:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=(f"Unsupported mime type '{base_content_type}' for media type '{payload.media_type.value}'"),
+            detail=(f"Unsupported mime type '{normalized_content_type}' for media type '{payload.media_type.value}'"),
         )
+
+    return normalized_content_type
 
 
 def _build_media_storage_key(story_id: uuid.UUID, filename: str) -> str:
@@ -603,8 +663,9 @@ async def upload_media_for_story(
     story_id: uuid.UUID,
     file: UploadFile,
     payload: MediaUploadRequest,
+    background_tasks: BackgroundTasks | None = None,
 ) -> MediaUploadResponse:
-    _validate_media_upload(file, payload)
+    normalized_content_type = _validate_media_upload(file, payload)
 
     story_result = await db.execute(select(Story).where(Story.id == story_id, Story.deleted_at.is_(None)))
     story = story_result.scalar_one_or_none()
@@ -636,7 +697,7 @@ async def upload_media_for_story(
             bucket_name=bucket_name,
             storage_key=storage_key,
             content=file_bytes,
-            content_type=file.content_type,
+            content_type=normalized_content_type,
         )
     except Exception:
         raise HTTPException(
@@ -649,7 +710,7 @@ async def upload_media_for_story(
         bucket_name=bucket_name,
         storage_key=storage_key,
         original_filename=file.filename,
-        mime_type=file.content_type,
+        mime_type=normalized_content_type,
         media_type=payload.media_type,
         file_size_bytes=file_size,
         sort_order=payload.sort_order,
@@ -670,6 +731,15 @@ async def upload_media_for_story(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to persist media metadata",
+        )
+
+    if payload.media_type == MediaType.AUDIO and background_tasks is not None:
+        background_tasks.add_task(
+            transcribe_media_file,
+            media_file_id=media.id,
+            filename=file.filename,
+            content=file_bytes,
+            mime_type=normalized_content_type,
         )
 
     return MediaUploadResponse(media=_map_media_file(media))

--- a/backend/app/services/transcription_service.py
+++ b/backend/app/services/transcription_service.py
@@ -1,0 +1,116 @@
+import asyncio
+import logging
+import os
+import uuid
+from functools import lru_cache
+from tempfile import NamedTemporaryFile
+
+from sqlalchemy import select
+
+from app.core.config import settings
+from app.db.enums import MediaType
+from app.db.media_file import MediaFile
+from app.db.session import AsyncSessionLocal
+
+logger = logging.getLogger(__name__)
+
+
+async def transcribe_media_file(
+    *,
+    media_file_id: uuid.UUID,
+    filename: str,
+    content: bytes,
+    mime_type: str | None,
+) -> None:
+    transcript = await transcribe_audio_content(
+        filename=filename,
+        content=content,
+        mime_type=mime_type,
+    )
+    if not transcript:
+        return
+
+    try:
+        async with AsyncSessionLocal() as db:
+            result = await db.execute(select(MediaFile).where(MediaFile.id == media_file_id))
+            media = result.scalar_one_or_none()
+            if media is None:
+                logger.warning("Skipping transcript persistence because media file %s was not found", media_file_id)
+                return
+
+            if media.media_type != MediaType.AUDIO:
+                logger.warning("Skipping transcript persistence because media file %s is not audio", media_file_id)
+                return
+
+            media.transcript = transcript
+            await db.commit()
+    except Exception:
+        logger.exception("Failed to persist transcript for media file %s", media_file_id)
+
+
+async def transcribe_audio_content(
+    *,
+    filename: str,
+    content: bytes,
+    mime_type: str | None,
+) -> str | None:
+    try:
+        return await _transcribe_with_whisper(
+            filename=filename,
+            content=content,
+            mime_type=mime_type,
+        )
+    except Exception:
+        logger.exception("Audio transcription failed for %s", filename)
+        return None
+
+
+async def _transcribe_with_whisper(
+    *,
+    filename: str,
+    content: bytes,
+    mime_type: str | None,
+) -> str | None:
+    # Model inference is synchronous and CPU-heavy, so run it off the event loop.
+    return await asyncio.to_thread(
+        _transcribe_with_whisper_sync,
+        filename=filename,
+        content=content,
+        mime_type=mime_type,
+    )
+
+
+@lru_cache(maxsize=1)
+def _load_whisper_model():
+    try:
+        from faster_whisper import WhisperModel
+    except ImportError as exc:
+        raise RuntimeError("faster-whisper is not installed") from exc
+
+    return WhisperModel(
+        settings.TRANSCRIPTION_MODEL,
+        device=settings.TRANSCRIPTION_DEVICE,
+        compute_type=settings.TRANSCRIPTION_COMPUTE_TYPE,
+    )
+
+
+def _transcribe_with_whisper_sync(
+    *,
+    filename: str,
+    content: bytes,
+    mime_type: str | None,
+) -> str | None:
+    suffix = os.path.splitext(filename)[1] or ".audio"
+    with NamedTemporaryFile(suffix=suffix, delete=True) as temp_audio:
+        temp_audio.write(content)
+        temp_audio.flush()
+
+        model = _load_whisper_model()
+        segments, _info = model.transcribe(temp_audio.name, beam_size=5)
+        transcript = " ".join(segment.text.strip() for segment in segments if getattr(segment, "text", "").strip())
+
+    if not transcript:
+        logger.warning("Whisper transcription for %s returned no text", filename)
+        return None
+
+    return transcript

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -24,5 +24,8 @@ python-multipart
 # Object storage (S3-compatible — works with MinIO locally and Supabase Storage in prod)
 boto3
 
+# Speech-to-text
+faster-whisper
+
 # Linting & formatting
 ruff

--- a/backend/tests/api/test_story_api.py
+++ b/backend/tests/api/test_story_api.py
@@ -371,6 +371,54 @@ class TestStoryDetailAPI:
         assert media_item["media_type"] == "image"
         assert media_item["file_size_bytes"] == 777
         assert media_item["media_url"].endswith("/images/stories/test/photo.png")
+        assert media_item["transcript"] is None
+
+    async def test_get_story_detail_includes_audio_transcript_when_present(self, client, db_session):
+        author = User(
+            username="detailaudioauthor",
+            email="detailaudioauthor@example.com",
+            password_hash="hashed-password",
+        )
+        db_session.add(author)
+        await db_session.flush()
+
+        story = Story(
+            user_id=author.id,
+            title="Audio Detail Story",
+            summary="Audio summary",
+            content="Audio content",
+            status=StoryStatus.PUBLISHED,
+            visibility=StoryVisibility.PUBLIC,
+            place_name="Istanbul",
+            latitude=41.0082,
+            longitude=28.9784,
+            date_start=date(1923, 1, 1),
+            date_end=date(1923, 12, 31),
+            date_precision=DatePrecision.YEAR,
+        )
+        db_session.add(story)
+        await db_session.flush()
+
+        media = MediaFile(
+            story_id=story.id,
+            bucket_name="audio",
+            storage_key="stories/test/audio.webm",
+            original_filename="audio.webm",
+            mime_type="audio/webm",
+            media_type=MediaType.AUDIO,
+            file_size_bytes=321,
+            sort_order=0,
+            transcript="Transcribed local history narration",
+        )
+        db_session.add(media)
+        await db_session.commit()
+
+        resp = await client.get(f"/stories/{story.id}")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["media_files"]) == 1
+        assert data["media_files"][0]["transcript"] == "Transcribed local history narration"
 
     async def test_get_story_detail_not_found(self, client):
         resp = await client.get(f"/stories/{uuid.uuid4()}")

--- a/backend/tests/integration/test_story_recorded_media_flow.py
+++ b/backend/tests/integration/test_story_recorded_media_flow.py
@@ -78,7 +78,7 @@ class TestRecordedMediaUploadFlow:
         assert resp.status_code == 201
         media = resp.json()["media"]
         assert media["media_type"] == "audio"
-        assert media["mime_type"] == "audio/webm;codecs=opus"
+        assert media["mime_type"] == "audio/webm"
 
     async def test_upload_recorded_audio_webm_mixed_case_mime_is_accepted(self, client, monkeypatch):
         monkeypatch.setattr("app.services.story_service.upload_bytes", lambda **kwargs: None)
@@ -131,7 +131,7 @@ class TestRecordedMediaUploadFlow:
         assert resp.status_code == 201
         media = resp.json()["media"]
         assert media["media_type"] == "video"
-        assert media["mime_type"] == "video/webm;codecs=vp8,opus"
+        assert media["mime_type"] == "video/webm"
 
 
 @pytest.mark.asyncio
@@ -194,7 +194,7 @@ class TestRecordedMediaStoryDetailFlow:
         media_files = data["media_files"]
 
         assert media_files[0]["media_type"] == "audio"
-        assert media_files[0]["mime_type"] == "audio/webm;codecs=opus"
+        assert media_files[0]["mime_type"] == "audio/webm"
         assert media_files[0]["original_filename"] == "recorded-audio.webm"
         assert media_files[0]["sort_order"] == 0
 

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from fastapi import HTTPException
+from fastapi import BackgroundTasks, HTTPException
 from starlette.datastructures import Headers, UploadFile
 
 from app.db.enums import DatePrecision, MediaType, NotificationEventType, ReportStatus, StoryStatus, StoryVisibility
@@ -75,6 +75,7 @@ def _make_media_file(**overrides):
         "sort_order": 0,
         "alt_text": None,
         "caption": None,
+        "transcript": None,
         "created_at": datetime.now(timezone.utc),
     }
     base.update(overrides)
@@ -311,8 +312,71 @@ class TestUploadMediaForStoryService:
         with patch("app.services.story_service.upload_bytes"):
             result = await upload_media_for_story(db, story_id, file, payload)
 
-        assert result.media.mime_type == "audio/webm;codecs=opus"
+        assert result.media.mime_type == "audio/webm"
         assert result.media.media_type == MediaType.AUDIO
+
+    async def test_upload_audio_queues_background_transcription(self):
+        story_id = uuid.uuid4()
+        story = _make_story(id=story_id)
+        payload = MediaUploadRequest(media_type=MediaType.AUDIO)
+        file = _make_upload_file("recording.webm", b"audio-bytes", "audio/webm")
+        background_tasks = BackgroundTasks()
+
+        db = AsyncMock()
+        db.add = MagicMock()
+        db.execute.return_value.scalar_one_or_none = lambda: story
+
+        async def _refresh_side_effect(media_obj):
+            media_obj.id = uuid.uuid4()
+            media_obj.created_at = datetime.now(timezone.utc)
+
+        db.refresh.side_effect = _refresh_side_effect
+
+        with patch("app.services.story_service.upload_bytes"):
+            result = await upload_media_for_story(
+                db,
+                story_id,
+                file,
+                payload,
+                background_tasks=background_tasks,
+            )
+
+        assert result.media.media_type == MediaType.AUDIO
+        assert len(background_tasks.tasks) == 1
+        task = background_tasks.tasks[0]
+        assert task.func.__name__ == "transcribe_media_file"
+        assert task.kwargs["media_file_id"] == result.media.id
+        assert task.kwargs["filename"] == "recording.webm"
+        assert task.kwargs["content"] == b"audio-bytes"
+        assert task.kwargs["mime_type"] == "audio/webm"
+
+    async def test_upload_image_does_not_queue_background_transcription(self):
+        story_id = uuid.uuid4()
+        story = _make_story(id=story_id)
+        payload = MediaUploadRequest(media_type=MediaType.IMAGE)
+        file = _make_upload_file("photo.png", b"fake-image-bytes", "image/png")
+        background_tasks = BackgroundTasks()
+
+        db = AsyncMock()
+        db.add = MagicMock()
+        db.execute.return_value.scalar_one_or_none = lambda: story
+
+        async def _refresh_side_effect(media_obj):
+            media_obj.id = uuid.uuid4()
+            media_obj.created_at = datetime.now(timezone.utc)
+
+        db.refresh.side_effect = _refresh_side_effect
+
+        with patch("app.services.story_service.upload_bytes"):
+            await upload_media_for_story(
+                db,
+                story_id,
+                file,
+                payload,
+                background_tasks=background_tasks,
+            )
+
+        assert background_tasks.tasks == []
 
     async def test_upload_accepts_audio_webm_mixed_case(self):
         story_id = uuid.uuid4()
@@ -334,6 +398,61 @@ class TestUploadMediaForStoryService:
 
         assert result.media.media_type == MediaType.AUDIO
 
+    async def test_upload_accepts_audio_x_m4a_alias(self):
+        story_id = uuid.uuid4()
+        story = _make_story(id=story_id)
+        payload = MediaUploadRequest(media_type=MediaType.AUDIO)
+        file = _make_upload_file("recording.m4a", b"audio-bytes", "audio/x-m4a")
+        db = AsyncMock()
+        db.add = MagicMock()
+        db.execute.return_value.scalar_one_or_none = lambda: story
+
+        async def _refresh_side_effect(media_obj):
+            media_obj.id = uuid.uuid4()
+            media_obj.created_at = datetime.now(timezone.utc)
+
+        db.refresh.side_effect = _refresh_side_effect
+
+        with patch("app.services.story_service.upload_bytes"):
+            result = await upload_media_for_story(db, story_id, file, payload)
+
+        assert result.media.mime_type == "audio/mp4"
+        assert result.media.media_type == MediaType.AUDIO
+
+    async def test_upload_accepts_audio_octet_stream_when_extension_is_m4a(self):
+        story_id = uuid.uuid4()
+        story = _make_story(id=story_id)
+        payload = MediaUploadRequest(media_type=MediaType.AUDIO)
+        file = _make_upload_file("recording.m4a", b"audio-bytes", "application/octet-stream")
+        db = AsyncMock()
+        db.add = MagicMock()
+        db.execute.return_value.scalar_one_or_none = lambda: story
+
+        async def _refresh_side_effect(media_obj):
+            media_obj.id = uuid.uuid4()
+            media_obj.created_at = datetime.now(timezone.utc)
+
+        db.refresh.side_effect = _refresh_side_effect
+
+        with patch("app.services.story_service.upload_bytes") as mock_upload:
+            result = await upload_media_for_story(db, story_id, file, payload)
+
+        assert result.media.mime_type == "audio/mp4"
+        assert mock_upload.call_args.kwargs["content_type"] == "audio/mp4"
+
+    async def test_upload_rejects_audio_octet_stream_without_supported_extension(self):
+        payload = MediaUploadRequest(media_type=MediaType.AUDIO)
+        file = _make_upload_file("recording.bin", b"audio-bytes", "application/octet-stream")
+        db = AsyncMock()
+
+        with patch("app.services.story_service.upload_bytes") as mock_upload:
+            with pytest.raises(HTTPException) as exc_info:
+                await upload_media_for_story(db, uuid.uuid4(), file, payload)
+
+        assert exc_info.value.status_code == 422
+        assert "application/octet-stream" in exc_info.value.detail
+        mock_upload.assert_not_called()
+
     async def test_upload_accepts_video_webm(self):
         story_id = uuid.uuid4()
         story = _make_story(id=story_id)
@@ -352,7 +471,7 @@ class TestUploadMediaForStoryService:
         with patch("app.services.story_service.upload_bytes"):
             result = await upload_media_for_story(db, story_id, file, payload)
 
-        assert result.media.mime_type == "video/webm;codecs=vp8,opus"
+        assert result.media.mime_type == "video/webm"
         assert result.media.media_type == MediaType.VIDEO
 
     async def test_upload_accepts_video_webm_mixed_case(self):

--- a/backend/tests/unit/test_transcription_service.py
+++ b/backend/tests/unit/test_transcription_service.py
@@ -1,0 +1,119 @@
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.db.enums import MediaType
+from app.services.transcription_service import transcribe_audio_content, transcribe_media_file
+
+
+class _SessionContextManager:
+    def __init__(self, session):
+        self.session = session
+
+    async def __aenter__(self):
+        return self.session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.mark.asyncio
+class TestTranscribeAudioContent:
+    async def test_returns_transcript_when_provider_succeeds(self):
+        with patch(
+            "app.services.transcription_service._transcribe_with_whisper",
+            new=AsyncMock(return_value="Transcribed text"),
+        ) as mock_stt:
+            result = await transcribe_audio_content(
+                filename="audio.webm",
+                content=b"audio-bytes",
+                mime_type="audio/webm",
+            )
+
+        assert result == "Transcribed text"
+        mock_stt.assert_awaited_once()
+
+    async def test_returns_none_when_provider_raises(self):
+        with patch(
+            "app.services.transcription_service._transcribe_with_whisper",
+            new=AsyncMock(side_effect=RuntimeError("boom")),
+        ) as mock_stt:
+            result = await transcribe_audio_content(
+                filename="audio.webm",
+                content=b"audio-bytes",
+                mime_type="audio/webm",
+            )
+
+        assert result is None
+        mock_stt.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+class TestTranscribeMediaFile:
+    async def test_persists_transcript_for_audio_media(self):
+        media_file_id = uuid.uuid4()
+        media = SimpleNamespace(id=media_file_id, media_type=MediaType.AUDIO, transcript=None)
+        db = AsyncMock()
+        db.execute.return_value.scalar_one_or_none = lambda: media
+
+        with patch(
+            "app.services.transcription_service.transcribe_audio_content",
+            new=AsyncMock(return_value="Audio transcript"),
+        ) as mock_transcribe:
+            with patch(
+                "app.services.transcription_service.AsyncSessionLocal",
+                return_value=_SessionContextManager(db),
+            ) as mock_session_factory:
+                await transcribe_media_file(
+                    media_file_id=media_file_id,
+                    filename="audio.webm",
+                    content=b"audio-bytes",
+                    mime_type="audio/webm",
+                )
+
+        assert media.transcript == "Audio transcript"
+        mock_transcribe.assert_awaited_once()
+        mock_session_factory.assert_called_once()
+        db.commit.assert_awaited_once()
+
+    async def test_skips_persist_when_no_transcript_is_returned(self):
+        with patch(
+            "app.services.transcription_service.transcribe_audio_content",
+            new=AsyncMock(return_value=None),
+        ) as mock_transcribe:
+            with patch("app.services.transcription_service.AsyncSessionLocal") as mock_session_factory:
+                await transcribe_media_file(
+                    media_file_id=uuid.uuid4(),
+                    filename="audio.webm",
+                    content=b"audio-bytes",
+                    mime_type="audio/webm",
+                )
+
+        mock_transcribe.assert_awaited_once()
+        mock_session_factory.assert_not_called()
+
+    async def test_skips_persist_for_non_audio_media(self):
+        media_file_id = uuid.uuid4()
+        media = SimpleNamespace(id=media_file_id, media_type=MediaType.VIDEO, transcript=None)
+        db = AsyncMock()
+        db.execute.return_value.scalar_one_or_none = lambda: media
+
+        with patch(
+            "app.services.transcription_service.transcribe_audio_content",
+            new=AsyncMock(return_value="Should not be stored"),
+        ):
+            with patch(
+                "app.services.transcription_service.AsyncSessionLocal",
+                return_value=_SessionContextManager(db),
+            ):
+                await transcribe_media_file(
+                    media_file_id=media_file_id,
+                    filename="audio.webm",
+                    content=b"audio-bytes",
+                    mime_type="audio/webm",
+                )
+
+        assert media.transcript is None
+        db.commit.assert_not_awaited()


### PR DESCRIPTION
## Description
Implements the backend audio transcription pipeline for uploaded story media. Audio files attached to stories are now transcribed asynchronously after upload, the transcript is stored on the related media record, and the transcript is exposed in the story detail API. This also hardens media upload handling for common real-world MIME variations such as `.m4a` uploads.

## Related Issue(s)
- Closes #235

## Changes

| File | Change |
|------|--------|
| `backend/app/core/config.py` | Added transcription-related settings for the local Whisper-based transcription pipeline. |
| `backend/app/db/media_file.py` | Added nullable `transcript` field to persist audio transcription text for media files. |
| `backend/app/models/story.py` | Extended media response models to return `transcript` in API responses. |
| `backend/app/routers/story.py` | Updated story media upload endpoint to use `BackgroundTasks` for non-blocking transcription after upload. |
| `backend/app/services/story_service.py` | Integrated background transcription triggering, transcript serialization, and robust MIME normalization/fallback logic for uploaded media. |
| `backend/app/services/transcription_service.py` | Added asynchronous transcription service using `faster-whisper`, including safe persistence and graceful failure handling. |
| `backend/alembic/versions/20260508_0014_add_media_file_transcript.py` | Added migration for the new `media_files.transcript` column. |
| `backend/requirements.txt` | Added `faster-whisper` dependency for free local speech-to-text support. |
| `backend/tests/api/test_story_api.py` | Added API coverage to verify transcript exposure in story detail responses. |
| `backend/tests/integration/test_story_recorded_media_flow.py` | Updated recorded-media integration expectations to match canonical MIME normalization behavior. |
| `backend/tests/unit/test_story_service.py` | Added unit coverage for background task scheduling, MIME alias handling, octet-stream fallback behavior, and canonical MIME storage. |
| `backend/tests/unit/test_transcription_service.py` | Added unit tests for transcription success, failure handling, and transcript persistence behavior. |

## Checklist
- [x] All tests passed 
- [x] I have self-reviewed my own code
- [x] I have requested at least 1 reviewer
