### PR TITLE
Feat/dashboard

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,13 +1,13 @@
 # ── Database ──────────────────────────────────────────────────────────────────
-# Local Postgres (matches docker-compose db service)
-DATABASE_URL=postgresql://postgres:postgres@db:5432/localhistory
+# Local Postgres from your host machine (docker-compose publishes db on 5433)
+DATABASE_URL=postgresql://postgres:postgres@localhost:5433/localhistory
 
 # Useful during development — leave false in production
 LOG_SQL=false
 
 # ── Object Storage ────────────────────────────────────────────────────────────
-# Local: MinIO (docker-compose minio service uses "minio" as the hostname inside Docker)
-STORAGE_ENDPOINT=http://minio:9000
+# Local host access to MinIO
+STORAGE_ENDPOINT=http://localhost:9000
 STORAGE_ACCESS_KEY=minioadmin
 STORAGE_SECRET_KEY=minioadmin
 STORAGE_REGION=us-east-1

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,13 +1,13 @@
 # ── Database ──────────────────────────────────────────────────────────────────
-# Local Postgres from your host machine (docker-compose publishes db on 5433)
-DATABASE_URL=postgresql://postgres:postgres@localhost:5433/localhistory
+# Local Postgres (matches docker-compose db service)
+DATABASE_URL=postgresql://postgres:postgres@db:5432/localhistory
 
 # Useful during development — leave false in production
 LOG_SQL=false
 
 # ── Object Storage ────────────────────────────────────────────────────────────
-# Local host access to MinIO
-STORAGE_ENDPOINT=http://localhost:9000
+# Local: MinIO (docker-compose minio service uses "minio" as the hostname inside Docker)
+STORAGE_ENDPOINT=http://minio:9000
 STORAGE_ACCESS_KEY=minioadmin
 STORAGE_SECRET_KEY=minioadmin
 STORAGE_REGION=us-east-1

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,6 +8,7 @@ from app.core.config import settings
 from app.db.session import engine
 from app.routers.auth import router as auth_router
 from app.routers.story import router as story_router
+from app.routers.users import router as users_router
 from app.services.storage import check_connection
 
 
@@ -42,6 +43,7 @@ app.add_middleware(
 )
 app.include_router(auth_router)
 app.include_router(story_router)
+app.include_router(users_router)
 
 
 @app.get("/")

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from pydantic import BaseModel, EmailStr, Field, field_validator
 
 from app.db.enums import UserRole
+from app.models.story import StoryResponse
 
 
 class UserRegisterRequest(BaseModel):
@@ -48,3 +49,25 @@ class UserResponse(BaseModel):
 class TokenResponse(BaseModel):
     access_token: str
     token_type: str = "bearer"
+
+
+class UserStoryListResponse(BaseModel):
+    stories: list[StoryResponse]
+    total: int = Field(ge=0)
+    limit: int = Field(ge=1)
+    offset: int = Field(ge=0)
+
+
+class UserEngagementStatsResponse(BaseModel):
+    total_stories: int = Field(ge=0)
+    total_likes_received: int = Field(ge=0)
+    total_comments_received: int = Field(ge=0)
+    total_saves_received: int = Field(ge=0)
+
+
+class UserDashboardResponse(BaseModel):
+    stories_count: int = Field(ge=0)
+    saved_count: int = Field(ge=0)
+    total_likes_received: int = Field(ge=0)
+    total_comments_received: int = Field(ge=0)
+    total_saves_received: int = Field(ge=0)

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -1,0 +1,107 @@
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.deps import get_current_user
+from app.db.session import get_db
+from app.db.user import User
+from app.models.user import UserDashboardResponse, UserEngagementStatsResponse, UserStoryListResponse
+from app.services.user_service import (
+    get_current_user_dashboard,
+    get_current_user_engagement_stats,
+    list_current_user_saved_stories,
+    list_current_user_stories,
+)
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+
+@router.get(
+    "/me/stories",
+    response_model=UserStoryListResponse,
+    summary="List current user's stories",
+    description=(
+        "Return a paginated list of stories created by the authenticated user, "
+        "including private or draft stories. Soft-deleted stories are excluded."
+    ),
+    responses={
+        401: {"description": "Missing or invalid authentication token"},
+        422: {"description": "Validation error for pagination parameters"},
+    },
+)
+async def list_my_stories(
+    limit: int = Query(default=20, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await list_current_user_stories(
+        db,
+        current_user,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.get(
+    "/me/saved",
+    response_model=UserStoryListResponse,
+    summary="List current user's saved stories",
+    description=(
+        "Return a paginated list of stories bookmarked by the authenticated user. "
+        "Only stories that are still public, published, and not soft-deleted are included."
+    ),
+    responses={
+        401: {"description": "Missing or invalid authentication token"},
+        422: {"description": "Validation error for pagination parameters"},
+    },
+)
+async def list_my_saved_stories(
+    limit: int = Query(default=20, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await list_current_user_saved_stories(
+        db,
+        current_user,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.get(
+    "/me/stats",
+    response_model=UserEngagementStatsResponse,
+    summary="Get current user engagement stats",
+    description=(
+        "Return aggregate engagement statistics for the authenticated user's non-deleted stories: "
+        "story count, likes received, comments received, and saves received."
+    ),
+    responses={
+        401: {"description": "Missing or invalid authentication token"},
+    },
+)
+async def get_my_stats(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await get_current_user_engagement_stats(db, current_user)
+
+
+@router.get(
+    "/me/dashboard",
+    response_model=UserDashboardResponse,
+    summary="Get current user dashboard summary",
+    description=(
+        "Return a summary card for the authenticated user's dashboard, combining created-story count, "
+        "currently visible saved-story count, and top engagement metrics."
+    ),
+    responses={
+        401: {"description": "Missing or invalid authentication token"},
+    },
+)
+async def get_my_dashboard(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await get_current_user_dashboard(db, current_user)

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -1,0 +1,154 @@
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.enums import StoryStatus, StoryVisibility
+from app.db.story import Story
+from app.db.story_comment import StoryComment
+from app.db.story_like import StoryLike
+from app.db.story_save import StorySave
+from app.db.user import User
+from app.models.story import StoryResponse
+from app.models.user import UserDashboardResponse, UserEngagementStatsResponse, UserStoryListResponse
+
+
+def _map_user_story_rows(
+    rows: list[tuple[Story, str]],
+    *,
+    total: int,
+    limit: int,
+    offset: int,
+) -> UserStoryListResponse:
+    stories = [StoryResponse.from_orm_with_author(story, author_username) for story, author_username in rows]
+    return UserStoryListResponse(
+        stories=stories,
+        total=total,
+        limit=limit,
+        offset=offset,
+    )
+
+
+async def list_current_user_stories(
+    db: AsyncSession,
+    current_user: User,
+    *,
+    limit: int,
+    offset: int,
+) -> UserStoryListResponse:
+    total_result = await db.execute(
+        select(func.count(Story.id)).where(
+            Story.user_id == current_user.id,
+            Story.deleted_at.is_(None),
+        )
+    )
+    total = total_result.scalar_one()
+
+    rows_result = await db.execute(
+        select(Story, User.username)
+        .join(User, Story.user_id == User.id)
+        .where(
+            Story.user_id == current_user.id,
+            Story.deleted_at.is_(None),
+        )
+        .order_by(Story.created_at.desc())
+        .limit(limit)
+        .offset(offset)
+    )
+
+    return _map_user_story_rows(rows_result.all(), total=total, limit=limit, offset=offset)
+
+
+async def list_current_user_saved_stories(
+    db: AsyncSession,
+    current_user: User,
+    *,
+    limit: int,
+    offset: int,
+) -> UserStoryListResponse:
+    filters = (
+        StorySave.user_id == current_user.id,
+        Story.status == StoryStatus.PUBLISHED,
+        Story.visibility == StoryVisibility.PUBLIC,
+        Story.deleted_at.is_(None),
+    )
+
+    total_result = await db.execute(
+        select(func.count(Story.id)).select_from(Story).join(StorySave, StorySave.story_id == Story.id).where(*filters)
+    )
+    total = total_result.scalar_one()
+
+    rows_result = await db.execute(
+        select(Story, User.username)
+        .join(StorySave, StorySave.story_id == Story.id)
+        .join(User, Story.user_id == User.id)
+        .where(*filters)
+        .order_by(StorySave.created_at.desc())
+        .limit(limit)
+        .offset(offset)
+    )
+
+    return _map_user_story_rows(rows_result.all(), total=total, limit=limit, offset=offset)
+
+
+async def get_current_user_engagement_stats(
+    db: AsyncSession,
+    current_user: User,
+) -> UserEngagementStatsResponse:
+    story_filters = (
+        Story.user_id == current_user.id,
+        Story.deleted_at.is_(None),
+    )
+
+    total_stories_result = await db.execute(select(func.count(Story.id)).where(*story_filters))
+    total_likes_result = await db.execute(
+        select(func.count(StoryLike.id))
+        .select_from(StoryLike)
+        .join(Story, StoryLike.story_id == Story.id)
+        .where(*story_filters)
+    )
+    total_comments_result = await db.execute(
+        select(func.count(StoryComment.id))
+        .select_from(StoryComment)
+        .join(Story, StoryComment.story_id == Story.id)
+        .where(*story_filters)
+    )
+    total_saves_result = await db.execute(
+        select(func.count(StorySave.id))
+        .select_from(StorySave)
+        .join(Story, StorySave.story_id == Story.id)
+        .where(*story_filters)
+    )
+
+    return UserEngagementStatsResponse(
+        total_stories=total_stories_result.scalar_one(),
+        total_likes_received=total_likes_result.scalar_one(),
+        total_comments_received=total_comments_result.scalar_one(),
+        total_saves_received=total_saves_result.scalar_one(),
+    )
+
+
+async def get_current_user_dashboard(
+    db: AsyncSession,
+    current_user: User,
+) -> UserDashboardResponse:
+    stats = await get_current_user_engagement_stats(db, current_user)
+
+    saved_count_result = await db.execute(
+        select(func.count(Story.id))
+        .select_from(Story)
+        .join(StorySave, StorySave.story_id == Story.id)
+        .where(
+            StorySave.user_id == current_user.id,
+            Story.status == StoryStatus.PUBLISHED,
+            Story.visibility == StoryVisibility.PUBLIC,
+            Story.deleted_at.is_(None),
+        )
+    )
+    saved_count = saved_count_result.scalar_one()
+
+    return UserDashboardResponse(
+        stories_count=stats.total_stories,
+        saved_count=saved_count,
+        total_likes_received=stats.total_likes_received,
+        total_comments_received=stats.total_comments_received,
+        total_saves_received=stats.total_saves_received,
+    )

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -98,31 +98,38 @@ async def get_current_user_engagement_stats(
         Story.deleted_at.is_(None),
     )
 
-    total_stories_result = await db.execute(select(func.count(Story.id)).where(*story_filters))
-    total_likes_result = await db.execute(
-        select(func.count(StoryLike.id))
-        .select_from(StoryLike)
-        .join(Story, StoryLike.story_id == Story.id)
-        .where(*story_filters)
-    )
-    total_comments_result = await db.execute(
-        select(func.count(StoryComment.id))
-        .select_from(StoryComment)
-        .join(Story, StoryComment.story_id == Story.id)
-        .where(*story_filters)
-    )
-    total_saves_result = await db.execute(
-        select(func.count(StorySave.id))
-        .select_from(StorySave)
-        .join(Story, StorySave.story_id == Story.id)
-        .where(*story_filters)
-    )
+    row = (
+        await db.execute(
+            select(
+                select(func.count(Story.id)).where(*story_filters).scalar_subquery().label("total_stories"),
+                select(func.count(StoryLike.id))
+                .select_from(StoryLike)
+                .join(Story, StoryLike.story_id == Story.id)
+                .where(*story_filters)
+                .scalar_subquery()
+                .label("total_likes_received"),
+                select(func.count(StoryComment.id))
+                .select_from(StoryComment)
+                .join(Story, StoryComment.story_id == Story.id)
+                .where(*story_filters)
+                .scalar_subquery()
+                .label("total_comments_received"),
+                select(func.count(StorySave.id))
+                .select_from(StorySave)
+                .join(Story, StorySave.story_id == Story.id)
+                .where(*story_filters)
+                .scalar_subquery()
+                .label("total_saves_received"),
+            )
+        )
+    ).one()
+    values = row._mapping
 
     return UserEngagementStatsResponse(
-        total_stories=total_stories_result.scalar_one(),
-        total_likes_received=total_likes_result.scalar_one(),
-        total_comments_received=total_comments_result.scalar_one(),
-        total_saves_received=total_saves_result.scalar_one(),
+        total_stories=values["total_stories"],
+        total_likes_received=values["total_likes_received"],
+        total_comments_received=values["total_comments_received"],
+        total_saves_received=values["total_saves_received"],
     )
 
 
@@ -130,25 +137,54 @@ async def get_current_user_dashboard(
     db: AsyncSession,
     current_user: User,
 ) -> UserDashboardResponse:
-    stats = await get_current_user_engagement_stats(db, current_user)
-
-    saved_count_result = await db.execute(
-        select(func.count(Story.id))
-        .select_from(Story)
-        .join(StorySave, StorySave.story_id == Story.id)
-        .where(
-            StorySave.user_id == current_user.id,
-            Story.status == StoryStatus.PUBLISHED,
-            Story.visibility == StoryVisibility.PUBLIC,
-            Story.deleted_at.is_(None),
-        )
+    story_filters = (
+        Story.user_id == current_user.id,
+        Story.deleted_at.is_(None),
     )
-    saved_count = saved_count_result.scalar_one()
+    saved_filters = (
+        StorySave.user_id == current_user.id,
+        Story.status == StoryStatus.PUBLISHED,
+        Story.visibility == StoryVisibility.PUBLIC,
+        Story.deleted_at.is_(None),
+    )
+
+    row = (
+        await db.execute(
+            select(
+                select(func.count(Story.id)).where(*story_filters).scalar_subquery().label("stories_count"),
+                select(func.count(Story.id))
+                .select_from(Story)
+                .join(StorySave, StorySave.story_id == Story.id)
+                .where(*saved_filters)
+                .scalar_subquery()
+                .label("saved_count"),
+                select(func.count(StoryLike.id))
+                .select_from(StoryLike)
+                .join(Story, StoryLike.story_id == Story.id)
+                .where(*story_filters)
+                .scalar_subquery()
+                .label("total_likes_received"),
+                select(func.count(StoryComment.id))
+                .select_from(StoryComment)
+                .join(Story, StoryComment.story_id == Story.id)
+                .where(*story_filters)
+                .scalar_subquery()
+                .label("total_comments_received"),
+                select(func.count(StorySave.id))
+                .select_from(StorySave)
+                .join(Story, StorySave.story_id == Story.id)
+                .where(*story_filters)
+                .scalar_subquery()
+                .label("total_saves_received"),
+            )
+        )
+    ).one()
+    values = row._mapping
 
     return UserDashboardResponse(
-        stories_count=stats.total_stories,
-        saved_count=saved_count,
-        total_likes_received=stats.total_likes_received,
-        total_comments_received=stats.total_comments_received,
-        total_saves_received=stats.total_saves_received,
+        stories_count=values["stories_count"],
+        saved_count=values["saved_count"],
+        total_likes_received=values["total_likes_received"],
+        total_comments_received=values["total_comments_received"],
+        total_saves_received=values["total_saves_received"],
     )

--- a/backend/tests/api/test_user_dashboard_api.py
+++ b/backend/tests/api/test_user_dashboard_api.py
@@ -1,0 +1,294 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from app.db.enums import StoryStatus, StoryVisibility
+from app.db.story_comment import StoryComment
+from app.db.story_like import StoryLike
+from app.db.story_save import StorySave
+from tests.factories.story_factory import make_story_entity
+from tests.factories.user_factory import make_login_payload, make_user_entity
+
+
+@pytest.mark.asyncio
+class TestUserDashboardAPI:
+    async def _create_user_and_token(self, client, db_session, *, username, email, password="ValidPass1!"):
+        user = make_user_entity(username=username, email=email, password=password)
+        db_session.add(user)
+        await db_session.commit()
+
+        login_resp = await client.post("/auth/login", json=make_login_payload(email=email, password=password))
+        assert login_resp.status_code == 200
+        return user, login_resp.json()["access_token"]
+
+    @pytest.mark.parametrize(
+        ("path", "method"),
+        [
+            ("/users/me/stories", "get"),
+            ("/users/me/saved", "get"),
+            ("/users/me/stats", "get"),
+            ("/users/me/dashboard", "get"),
+        ],
+    )
+    async def test_dashboard_endpoints_require_auth(self, client, path, method):
+        resp = await getattr(client, method)(path)
+        assert resp.status_code in (401, 403)
+
+    async def test_list_my_stories_returns_paginated_non_deleted_user_stories(self, client, db_session):
+        owner, token = await self._create_user_and_token(
+            client,
+            db_session,
+            username="dashownerstories",
+            email="dashownerstories@example.com",
+        )
+        other_user = make_user_entity(username="otherauthorstories", email="otherauthorstories@example.com")
+        db_session.add(other_user)
+        await db_session.flush()
+
+        newest_story = make_story_entity(
+            user_id=owner.id,
+            title="Newest Story",
+            status=StoryStatus.PUBLISHED,
+            visibility=StoryVisibility.PUBLIC,
+        )
+        newest_story.created_at = datetime(2026, 5, 3, 12, 0, tzinfo=timezone.utc)
+
+        middle_story = make_story_entity(
+            user_id=owner.id,
+            title="Private Story",
+            status=StoryStatus.PUBLISHED,
+            visibility=StoryVisibility.PRIVATE,
+        )
+        middle_story.created_at = datetime(2026, 5, 2, 12, 0, tzinfo=timezone.utc)
+
+        oldest_story = make_story_entity(
+            user_id=owner.id,
+            title="Draft Story",
+            status=StoryStatus.DRAFT,
+            visibility=StoryVisibility.PUBLIC,
+        )
+        oldest_story.created_at = datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc)
+
+        deleted_story = make_story_entity(
+            user_id=owner.id,
+            title="Deleted Story",
+            status=StoryStatus.PUBLISHED,
+            visibility=StoryVisibility.PUBLIC,
+        )
+        deleted_story.created_at = datetime(2026, 5, 4, 12, 0, tzinfo=timezone.utc)
+        deleted_story.deleted_at = datetime(2026, 5, 5, 12, 0, tzinfo=timezone.utc)
+
+        other_story = make_story_entity(
+            user_id=other_user.id,
+            title="Other User Story",
+            status=StoryStatus.PUBLISHED,
+            visibility=StoryVisibility.PUBLIC,
+        )
+
+        db_session.add_all([newest_story, middle_story, oldest_story, deleted_story, other_story])
+        await db_session.commit()
+
+        resp = await client.get(
+            "/users/me/stories?limit=2&offset=1",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload["total"] == 3
+        assert payload["limit"] == 2
+        assert payload["offset"] == 1
+        assert [story["title"] for story in payload["stories"]] == ["Private Story", "Draft Story"]
+        assert payload["stories"][0]["visibility"] == "private"
+        assert payload["stories"][1]["status"] == "draft"
+
+    async def test_list_my_saved_returns_paginated_visible_saved_stories_only(self, client, db_session):
+        saver, token = await self._create_user_and_token(
+            client,
+            db_session,
+            username="dashsaver",
+            email="dashsaver@example.com",
+        )
+        author = make_user_entity(username="savedauthor", email="savedauthor@example.com")
+        db_session.add(author)
+        await db_session.flush()
+
+        visible_first = make_story_entity(user_id=author.id, title="Visible First")
+        visible_second = make_story_entity(user_id=author.id, title="Visible Second")
+        private_story = make_story_entity(
+            user_id=author.id,
+            title="Private Hidden",
+            visibility=StoryVisibility.PRIVATE,
+        )
+        deleted_story = make_story_entity(user_id=author.id, title="Deleted Hidden")
+        deleted_story.deleted_at = datetime(2026, 5, 4, 12, 0, tzinfo=timezone.utc)
+        draft_story = make_story_entity(
+            user_id=author.id,
+            title="Draft Hidden",
+            status=StoryStatus.DRAFT,
+        )
+
+        db_session.add_all([visible_first, visible_second, private_story, deleted_story, draft_story])
+        await db_session.flush()
+
+        db_session.add_all(
+            [
+                StorySave(
+                    story_id=visible_first.id,
+                    user_id=saver.id,
+                    created_at=datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc),
+                ),
+                StorySave(
+                    story_id=visible_second.id,
+                    user_id=saver.id,
+                    created_at=datetime(2026, 5, 2, 12, 0, tzinfo=timezone.utc),
+                ),
+                StorySave(
+                    story_id=private_story.id,
+                    user_id=saver.id,
+                    created_at=datetime(2026, 5, 3, 12, 0, tzinfo=timezone.utc),
+                ),
+                StorySave(
+                    story_id=deleted_story.id,
+                    user_id=saver.id,
+                    created_at=datetime(2026, 5, 4, 12, 0, tzinfo=timezone.utc),
+                ),
+                StorySave(
+                    story_id=draft_story.id,
+                    user_id=saver.id,
+                    created_at=datetime(2026, 5, 5, 12, 0, tzinfo=timezone.utc),
+                ),
+            ]
+        )
+        await db_session.commit()
+
+        resp = await client.get(
+            "/users/me/saved?limit=1&offset=1",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload["total"] == 2
+        assert payload["limit"] == 1
+        assert payload["offset"] == 1
+        assert [story["title"] for story in payload["stories"]] == ["Visible First"]
+
+    async def test_get_my_stats_returns_story_and_engagement_totals(self, client, db_session):
+        owner, token = await self._create_user_and_token(
+            client,
+            db_session,
+            username="dashstatsowner",
+            email="dashstatsowner@example.com",
+        )
+        liker_a = make_user_entity(username="likera", email="likera@example.com")
+        liker_b = make_user_entity(username="likerb", email="likerb@example.com")
+        liker_c = make_user_entity(username="likerc", email="likerc@example.com")
+        db_session.add_all([liker_a, liker_b, liker_c])
+        await db_session.flush()
+
+        published_story = make_story_entity(user_id=owner.id, title="Published Story")
+        private_story = make_story_entity(
+            user_id=owner.id,
+            title="Private Story",
+            visibility=StoryVisibility.PRIVATE,
+        )
+        deleted_story = make_story_entity(user_id=owner.id, title="Deleted Story")
+        deleted_story.deleted_at = datetime(2026, 5, 6, 12, 0, tzinfo=timezone.utc)
+        db_session.add_all([published_story, private_story, deleted_story])
+        await db_session.flush()
+
+        db_session.add_all(
+            [
+                StoryLike(story_id=published_story.id, user_id=liker_a.id),
+                StoryLike(story_id=published_story.id, user_id=liker_b.id),
+                StoryLike(story_id=private_story.id, user_id=liker_c.id),
+                StoryLike(story_id=deleted_story.id, user_id=liker_a.id),
+                StoryComment(story_id=published_story.id, user_id=liker_a.id, content="One"),
+                StoryComment(story_id=published_story.id, user_id=liker_b.id, content="Two"),
+                StoryComment(story_id=private_story.id, user_id=liker_c.id, content="Three"),
+                StoryComment(story_id=deleted_story.id, user_id=liker_a.id, content="Hidden"),
+                StorySave(story_id=published_story.id, user_id=liker_a.id),
+                StorySave(story_id=private_story.id, user_id=liker_b.id),
+                StorySave(story_id=private_story.id, user_id=liker_c.id),
+                StorySave(story_id=deleted_story.id, user_id=liker_a.id),
+            ]
+        )
+        await db_session.commit()
+
+        resp = await client.get("/users/me/stats", headers={"Authorization": f"Bearer {token}"})
+
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "total_stories": 2,
+            "total_likes_received": 3,
+            "total_comments_received": 3,
+            "total_saves_received": 3,
+        }
+
+    async def test_get_my_dashboard_combines_saved_count_and_top_stats(self, client, db_session):
+        owner, token = await self._create_user_and_token(
+            client,
+            db_session,
+            username="dashsummaryowner",
+            email="dashsummaryowner@example.com",
+        )
+        other_author = make_user_entity(username="dashotherauthor", email="dashotherauthor@example.com")
+        actor = make_user_entity(username="dashactor", email="dashactor@example.com")
+        second_actor = make_user_entity(username="dashactor2", email="dashactor2@example.com")
+        db_session.add_all([other_author, actor, second_actor])
+        await db_session.flush()
+
+        own_story = make_story_entity(user_id=owner.id, title="Own Story")
+        second_own_story = make_story_entity(
+            user_id=owner.id,
+            title="Own Private Story",
+            visibility=StoryVisibility.PRIVATE,
+        )
+        deleted_own_story = make_story_entity(user_id=owner.id, title="Removed Story")
+        deleted_own_story.deleted_at = datetime(2026, 5, 6, 12, 0, tzinfo=timezone.utc)
+
+        visible_saved_story = make_story_entity(user_id=other_author.id, title="Saved Visible Story")
+        hidden_saved_story = make_story_entity(
+            user_id=other_author.id,
+            title="Saved Hidden Story",
+            visibility=StoryVisibility.PRIVATE,
+        )
+
+        db_session.add_all([own_story, second_own_story, deleted_own_story, visible_saved_story, hidden_saved_story])
+        await db_session.flush()
+
+        db_session.add_all(
+            [
+                StoryLike(story_id=own_story.id, user_id=actor.id),
+                StoryLike(story_id=second_own_story.id, user_id=second_actor.id),
+                StoryComment(story_id=own_story.id, user_id=actor.id, content="Insightful"),
+                StorySave(story_id=own_story.id, user_id=actor.id),
+                StorySave(story_id=second_own_story.id, user_id=second_actor.id),
+                StorySave(story_id=visible_saved_story.id, user_id=owner.id),
+                StorySave(story_id=hidden_saved_story.id, user_id=owner.id),
+            ]
+        )
+        await db_session.commit()
+
+        resp = await client.get("/users/me/dashboard", headers={"Authorization": f"Bearer {token}"})
+
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "stories_count": 2,
+            "saved_count": 1,
+            "total_likes_received": 2,
+            "total_comments_received": 1,
+            "total_saves_received": 2,
+        }
+
+    async def test_openapi_includes_dashboard_paths(self, client):
+        resp = await client.get("/openapi.json")
+
+        assert resp.status_code == 200
+        paths = resp.json()["paths"]
+        assert "/users/me/stories" in paths
+        assert "/users/me/saved" in paths
+        assert "/users/me/stats" in paths
+        assert "/users/me/dashboard" in paths
+        assert paths["/users/me/dashboard"]["get"]["summary"] == "Get current user dashboard summary"


### PR DESCRIPTION
## Description
Adds the backend dashboard APIs required for the user dashboard feature. This PR introduces authenticated `/users/me/*` endpoints for listing a user's own stories, listing saved stories, returning engagement statistics, and returning a dashboard summary card. It also adds API tests and OpenAPI coverage for the new endpoints.

## Related Issue(s)
- Closes #236

## Changes

| File | Change |
|------|--------|
| `backend/app/routers/users.py` | Added new authenticated dashboard endpoints: `GET /users/me/stories`, `GET /users/me/saved`, `GET /users/me/stats`, and `GET /users/me/dashboard`. |
| `backend/app/services/user_service.py` | Added service-layer logic for paginated user story lists, saved story lists, engagement stats, and dashboard summary aggregation. |
| `backend/app/models/user.py` | Added response schemas for paginated dashboard story lists, engagement stats, and dashboard summary responses. |
| `backend/app/main.py` | Registered the new `users` router so the dashboard APIs are exposed by the application. |
| `backend/tests/api/test_user_dashboard_api.py` | Added API tests covering auth requirements, pagination behavior, stats/dashboard aggregation, and OpenAPI path presence. |

## Checklist
- [x] All tests passed 
- [x] I have self-reviewed my own code
- [x] I have requested at least 1 reviewer
