### PR TITLE
feat: backend anonymous story sharing (#232)

### DIFF
--- a/backend/alembic/versions/20260509_0015_add_story_is_anonymous.py
+++ b/backend/alembic/versions/20260509_0015_add_story_is_anonymous.py
@@ -1,0 +1,34 @@
+"""Add is_anonymous column to stories table.
+
+Revision ID: 20260509_0015
+Revises: 20260508_0014
+Create Date: 2026-05-09 00:00:00
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260509_0015"
+down_revision: Union[str, Sequence[str], None] = "20260508_0014"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "stories",
+        sa.Column(
+            "is_anonymous",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("stories", "is_anonymous")

--- a/backend/app/db/story.py
+++ b/backend/app/db/story.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import date, datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import CheckConstraint, Date, DateTime, Enum, Float, ForeignKey, Index, String, Text, text
+from sqlalchemy import Boolean, CheckConstraint, Date, DateTime, Enum, Float, ForeignKey, Index, String, Text, text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -62,6 +62,12 @@ class Story(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     date_precision: Mapped[DatePrecision | None] = mapped_column(
         Enum(DatePrecision, name="date_precision", native_enum=False),
         nullable=True,
+    )
+    is_anonymous: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=False,
+        server_default=text("false"),
     )
     deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     deleted_by: Mapped[uuid.UUID | None] = mapped_column(

--- a/backend/app/models/story.py
+++ b/backend/app/models/story.py
@@ -82,6 +82,7 @@ class StoryCreateRequest(StoryDateInput):
     latitude: float = Field(ge=-90.0, le=90.0)
     longitude: float = Field(ge=-180.0, le=180.0)
     place_name: str | None = Field(default=None, max_length=255)
+    is_anonymous: bool = False
 
 
 class StoryUpdateRequest(StoryDateInput):
@@ -91,6 +92,7 @@ class StoryUpdateRequest(StoryDateInput):
     latitude: float = Field(ge=-90.0, le=90.0)
     longitude: float = Field(ge=-180.0, le=180.0)
     place_name: str | None = Field(default=None, max_length=255)
+    is_anonymous: bool = False
 
 
 class StoryBoundsFilter(BaseModel):
@@ -134,7 +136,8 @@ class StoryResponse(BaseModel):
     title: str
     summary: str | None
     content: str
-    author: str
+    author: str | None
+    is_anonymous: bool
     place_name: str | None
     latitude: float | None
     longitude: float | None
@@ -169,12 +172,15 @@ class StoryResponse(BaseModel):
         else:
             date_label = None
 
+        is_anonymous = getattr(story, "is_anonymous", False)
+
         return cls(
             id=story.id,
             title=story.title,
             summary=story.summary,
             content=story.content,
-            author=author_username,
+            author=None if is_anonymous else author_username,
+            is_anonymous=is_anonymous,
             place_name=story.place_name,
             latitude=story.latitude,
             longitude=story.longitude,

--- a/backend/app/models/story.py
+++ b/backend/app/models/story.py
@@ -92,7 +92,7 @@ class StoryUpdateRequest(StoryDateInput):
     latitude: float = Field(ge=-90.0, le=90.0)
     longitude: float = Field(ge=-180.0, le=180.0)
     place_name: str | None = Field(default=None, max_length=255)
-    is_anonymous: bool = False
+    is_anonymous: bool | None = None
 
 
 class StoryBoundsFilter(BaseModel):

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -592,7 +592,8 @@ async def update_story_with_location_and_dates(
     story.date_start = normalized_date_start
     story.date_end = normalized_date_end
     story.date_precision = normalized_date_precision
-    story.is_anonymous = payload.is_anonymous
+    if payload.is_anonymous is not None:
+        story.is_anonymous = payload.is_anonymous
 
     await db.commit()
     await db.refresh(story)

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -542,6 +542,7 @@ async def create_story_with_location(
         date_start=normalized_date_start,
         date_end=normalized_date_end,
         date_precision=normalized_date_precision,
+        is_anonymous=payload.is_anonymous,
     )
 
     db.add(story)
@@ -591,6 +592,7 @@ async def update_story_with_location_and_dates(
     story.date_start = normalized_date_start
     story.date_end = normalized_date_end
     story.date_precision = normalized_date_precision
+    story.is_anonymous = payload.is_anonymous
 
     await db.commit()
     await db.refresh(story)

--- a/backend/tests/api/test_story_api.py
+++ b/backend/tests/api/test_story_api.py
@@ -1715,3 +1715,128 @@ class TestNearbyStoriesAPI:
         resp = await client.get("/stories/nearby?lat=41.0082")
 
         assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+class TestAnonymousStoryAPI:
+    async def _create_user_and_token(self, client, username: str, email: str) -> str:
+        await client.post(
+            "/auth/register",
+            json={"username": username, "email": email, "password": "AnonPass1!"},
+        )
+        login_resp = await client.post(
+            "/auth/login",
+            json={"email": email, "password": "AnonPass1!"},
+        )
+        return login_resp.json()["access_token"]
+
+    async def test_create_anonymous_story_returns_null_author(self, client):
+        token = await self._create_user_and_token(client, "anonuser1", "anon1@example.com")
+
+        resp = await client.post(
+            "/stories",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "title": "Anonymous Story",
+                "content": "Secret content",
+                "place_name": "Istanbul",
+                "latitude": 41.0082,
+                "longitude": 28.9784,
+                "is_anonymous": True,
+            },
+        )
+
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["author"] is None
+        assert data["is_anonymous"] is True
+
+    async def test_create_non_anonymous_story_returns_real_author(self, client):
+        token = await self._create_user_and_token(client, "anonuser2", "anon2@example.com")
+
+        resp = await client.post(
+            "/stories",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "title": "Named Story",
+                "content": "Public content",
+                "place_name": "Istanbul",
+                "latitude": 41.0082,
+                "longitude": 28.9784,
+                "is_anonymous": False,
+            },
+        )
+
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["author"] == "anonuser2"
+        assert data["is_anonymous"] is False
+
+    async def test_list_stories_hides_author_for_anonymous_story(self, client, db_session):
+        user = User(
+            username="anonlistuser",
+            email="anonlist@example.com",
+            password_hash=hash_password("AnonPass1!"),
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        story = Story(
+            user_id=user.id,
+            title="Anonymous Listed Story",
+            content="content",
+            summary="summary",
+            status=StoryStatus.PUBLISHED,
+            visibility=StoryVisibility.PUBLIC,
+            place_name="Istanbul",
+            latitude=41.0082,
+            longitude=28.9784,
+            is_anonymous=True,
+        )
+        db_session.add(story)
+        await db_session.commit()
+
+        resp = await client.get("/stories")
+
+        assert resp.status_code == 200
+        items = [s for s in resp.json()["stories"] if s["title"] == "Anonymous Listed Story"]
+        assert len(items) == 1
+        assert items[0]["author"] is None
+        assert items[0]["is_anonymous"] is True
+
+    async def test_update_story_to_anonymous_hides_author(self, client):
+        token = await self._create_user_and_token(client, "anonuser3", "anon3@example.com")
+
+        create_resp = await client.post(
+            "/stories",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "title": "Will Be Anonymous",
+                "content": "content",
+                "place_name": "Istanbul",
+                "latitude": 41.0082,
+                "longitude": 28.9784,
+                "is_anonymous": False,
+            },
+        )
+        assert create_resp.status_code == 201
+        story_id = create_resp.json()["id"]
+        assert create_resp.json()["author"] == "anonuser3"
+
+        update_resp = await client.put(
+            f"/stories/{story_id}",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "title": "Will Be Anonymous",
+                "content": "content",
+                "place_name": "Istanbul",
+                "latitude": 41.0082,
+                "longitude": 28.9784,
+                "is_anonymous": True,
+            },
+        )
+
+        assert update_resp.status_code == 200
+        data = update_resp.json()
+        assert data["author"] is None
+        assert data["is_anonymous"] is True

--- a/backend/tests/factories/story_factory.py
+++ b/backend/tests/factories/story_factory.py
@@ -34,6 +34,7 @@ def make_story_payload(
     longitude: float = DEFAULT_LONGITUDE,
     date_start: int | None = DEFAULT_DATE_START,
     date_end: int | None = DEFAULT_DATE_END,
+    is_anonymous: bool = False,
     suffix: int | str | None = None,
 ) -> dict:
     """Return a dict that matches StoryCreateRequest, for use in API-level tests."""
@@ -46,6 +47,7 @@ def make_story_payload(
         "place_name": place_name,
         "latitude": latitude,
         "longitude": longitude,
+        "is_anonymous": is_anonymous,
     }
     if summary is not None:
         payload["summary"] = summary
@@ -98,6 +100,7 @@ def make_story_entity(
     date_precision: DatePrecision | None = DatePrecision.YEAR,
     status: StoryStatus = StoryStatus.PUBLISHED,
     visibility: StoryVisibility = StoryVisibility.PUBLIC,
+    is_anonymous: bool = False,
     suffix: int | str | None = None,
 ) -> Story:
     """Return a Story ORM object for direct insertion into a test DB session.
@@ -124,4 +127,5 @@ def make_story_entity(
         date_precision=date_precision,
         status=status,
         visibility=visibility,
+        is_anonymous=is_anonymous,
     )

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -47,6 +47,7 @@ def _make_story(**overrides):
         "date_precision": DatePrecision.YEAR,
         "status": StoryStatus.PUBLISHED,
         "visibility": StoryVisibility.PUBLIC,
+        "is_anonymous": False,
         "created_at": datetime.now(timezone.utc),
         "story_likes": [],
     }
@@ -1346,4 +1347,31 @@ class TestAnonymousStoryService:
         assert result.is_anonymous is True
         assert result.author is None
         assert story.is_anonymous is True
+        db.commit.assert_awaited_once()
+
+    async def test_update_story_omitting_is_anonymous_preserves_existing_value(self):
+        story_id = uuid.uuid4()
+        story = _make_story(id=story_id, user_id=uuid.uuid4(), is_anonymous=True)
+        current_user = SimpleNamespace(id=story.user_id, username="realauthor")
+
+        payload = StoryUpdateRequest(
+            title="Updated Story",
+            content="Updated content",
+            summary="Updated summary",
+            place_name="Istanbul",
+            latitude=41.0082,
+            longitude=28.9784,
+            # is_anonymous intentionally omitted
+        )
+
+        db = AsyncMock()
+        db.execute.side_effect = [
+            SimpleNamespace(scalar_one_or_none=lambda: story),
+            SimpleNamespace(scalar_one=lambda: 0),
+        ]
+
+        result = await update_story_with_location_and_dates(db, story_id, current_user, payload)
+
+        assert story.is_anonymous is True
+        assert result.author is None
         db.commit.assert_awaited_once()

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -11,7 +11,7 @@ from starlette.datastructures import Headers, UploadFile
 from app.db.enums import DatePrecision, MediaType, NotificationEventType, ReportStatus, StoryStatus, StoryVisibility
 from app.db.notification import Notification
 from app.models.comment import CommentCreateRequest
-from app.models.story import MediaUploadRequest, StoryCreateRequest, StoryUpdateRequest
+from app.models.story import MediaUploadRequest, StoryCreateRequest, StoryResponse, StoryUpdateRequest
 from app.services.story_service import (
     create_comment_for_story,
     create_story_with_location,
@@ -1268,3 +1268,82 @@ class TestAdminRemoveStoryService:
         assert exc_info.value.status_code == 404
         assert exc_info.value.detail == "Story not found"
         db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+class TestAnonymousStoryService:
+    async def test_from_orm_with_author_masks_author_when_anonymous(self):
+        story = _make_story(is_anonymous=True)
+
+        response = StoryResponse.from_orm_with_author(story, "realauthor")
+
+        assert response.author is None
+        assert response.is_anonymous is True
+
+    async def test_from_orm_with_author_exposes_author_when_not_anonymous(self):
+        story = _make_story(is_anonymous=False)
+
+        response = StoryResponse.from_orm_with_author(story, "realauthor")
+
+        assert response.author == "realauthor"
+        assert response.is_anonymous is False
+
+    async def test_create_story_persists_is_anonymous_and_masks_author(self):
+        payload = StoryCreateRequest(
+            title="Anonymous Story",
+            content="Content",
+            summary="Summary",
+            place_name="Istanbul",
+            latitude=41.0082,
+            longitude=28.9784,
+            is_anonymous=True,
+        )
+        current_user = SimpleNamespace(id=uuid.uuid4(), username="realauthor")
+
+        db = AsyncMock()
+        db.add = MagicMock()
+
+        async def _refresh_side_effect(story_obj):
+            story_obj.id = uuid.uuid4()
+            story_obj.created_at = datetime.now(timezone.utc)
+            story_obj.status = StoryStatus.PUBLISHED
+            story_obj.visibility = StoryVisibility.PUBLIC
+
+        db.refresh.side_effect = _refresh_side_effect
+        db.execute.return_value.scalar_one = lambda: 0
+
+        result = await create_story_with_location(db, current_user, payload)
+
+        assert result.is_anonymous is True
+        assert result.author is None
+        db.add.assert_called_once()
+        added_story = db.add.call_args.args[0]
+        assert added_story.is_anonymous is True
+
+    async def test_update_story_sets_is_anonymous_and_masks_author(self):
+        story_id = uuid.uuid4()
+        story = _make_story(id=story_id, user_id=uuid.uuid4(), is_anonymous=False)
+        current_user = SimpleNamespace(id=story.user_id, username="realauthor")
+
+        payload = StoryUpdateRequest(
+            title="Updated Story",
+            content="Updated content",
+            summary="Updated summary",
+            place_name="Istanbul",
+            latitude=41.0082,
+            longitude=28.9784,
+            is_anonymous=True,
+        )
+
+        db = AsyncMock()
+        db.execute.side_effect = [
+            SimpleNamespace(scalar_one_or_none=lambda: story),
+            SimpleNamespace(scalar_one=lambda: 0),
+        ]
+
+        result = await update_story_with_location_and_dates(db, story_id, current_user, payload)
+
+        assert result.is_anonymous is True
+        assert result.author is None
+        assert story.is_anonymous is True
+        db.commit.assert_awaited_once()


### PR DESCRIPTION
## Description
Adds anonymous story sharing to the backend. Authors can now set `is_anonymous: true` when creating or updating a story, which hides their identity in all public API responses. The real `user_id` is always preserved in the database for moderation purposes.

## Related Issue(s)
- Closes #232

## Changes

| File | Change |
|------|--------|
| `backend/app/db/story.py` | Added `is_anonymous` boolean column to the Story ORM model. |
| `backend/alembic/versions/20260509_0015_add_story_is_anonymous.py` | Added migration to add the `is_anonymous` column to the stories table. |
| `backend/app/models/story.py` | Added `is_anonymous` field to request models; changed `author` to nullable; added masking logic in `from_orm_with_author`. |
| `backend/app/services/story_service.py` | Persists `is_anonymous` flag on both create and update paths. |
| `backend/tests/factories/story_factory.py` | Added `is_anonymous` parameter to payload and entity factories. |
| `backend/tests/unit/test_story_service.py` | Added unit tests for author masking in `from_orm_with_author`, and flag persistence in create/update. |
| `backend/tests/api/test_story_api.py` | Added API tests for anonymous create, named create, list masking, and update toggle. |

## Checklist
- [x] All tests passed
- [x] I have self-reviewed my own code
- [x] I have requested at least 1 reviewer