### PR TITLE
ci: add release workflow for final milestone packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
   pull_request:
+  workflow_call:
 
 jobs:
   # ── 0a. LINT & FORMAT ───────────────────────────────────────────────────────
@@ -345,7 +346,7 @@ jobs:
       - name: Run Playwright UAT tests
         run: |
           if [ -d "frontend/tests/uat" ]; then
-            cd frontend && npx playwright test tests/uat/ --reporter=html,junit
+            cd frontend && npx playwright test tests/uat/
           else
             echo "UAT placeholder — tests/uat/ not yet created (see issue #282)"
           fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,7 @@ name: Deploy
 
 on:
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   deploy-backend:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,142 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g. v1.0.0)'
+        required: true
+      release_name:
+        description: 'Release title (e.g. Final Milestone Submission)'
+        required: true
+
+jobs:
+  # ── 0. GUARD ──────────────────────────────────────────────────────────────────
+
+  check-branch:
+    name: Enforce Main Branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if not main
+        run: |
+          if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
+            echo "::error::Release workflow must run from the main branch. Got: ${{ github.ref }}"
+            exit 1
+          fi
+
+  # ── 1. FULL CI SUITE ──────────────────────────────────────────────────────────
+
+  call-ci:
+    name: Run Full CI Suite
+    needs: check-branch
+    uses: ./.github/workflows/ci.yml
+
+  # ── 2. DEPLOY TO PRODUCTION ───────────────────────────────────────────────────
+
+  call-deploy:
+    name: Deploy to Production
+    needs: call-ci
+    uses: ./.github/workflows/deploy.yml
+    secrets: inherit
+
+  # ── 3. PACKAGE & PUBLISH RELEASE ─────────────────────────────────────────────
+
+  create-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: [call-ci, call-deploy]
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts/
+
+      - name: Parse test results and generate release-summary.md
+        id: parse
+        env:
+          RELEASE_NAME: ${{ inputs.release_name }}
+          TAG: ${{ inputs.tag }}
+          SHA: ${{ github.sha }}
+          APP_URL: ${{ vars.FRONTEND_PROD_URL }}
+        run: |
+          python3 << 'EOF'
+          import os, glob, xml.etree.ElementTree as ET
+          from datetime import datetime, timezone
+
+          total = failures = errors = 0
+          for path in glob.glob("artifacts/**/*.xml", recursive=True):
+              try:
+                  tree = ET.parse(path)
+                  root = tree.getroot()
+                  if root.tag == 'testsuites':
+                      suites = root.findall('testsuite')
+                  elif root.tag == 'testsuite':
+                      suites = [root]
+                  else:
+                      suites = root.findall('.//testsuite')
+                  for suite in suites:
+                      total    += int(suite.get('tests',    0))
+                      failures += int(suite.get('failures', 0))
+                      errors   += int(suite.get('errors',   0))
+              except Exception as e:
+                  print(f"Skipping {path}: {e}")
+
+          passed = total - failures - errors
+          failed = failures + errors
+
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+              f.write(f"total={total}\n")
+              f.write(f"passed={passed}\n")
+              f.write(f"failed={failed}\n")
+          print(f"Tests: {total} total, {passed} passed, {failed} failed/errored")
+
+          release_name = os.environ.get('RELEASE_NAME', '')
+          tag          = os.environ.get('TAG', '')
+          sha          = os.environ.get('SHA', '')
+          app_url = os.environ.get('APP_URL') or 'https://TBD.onrender.com'
+          now          = datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')
+
+          lines = [
+              "# Release Definition: " + release_name,
+              "",
+              "## Overview",
+              "",
+              "Tag `" + tag + "` — built from commit `" + sha + "` on " + now + ".",
+              "All CI checks passed and production services were deployed before this release was created.",
+              "",
+              "## App",
+              "",
+              "- **URL:** " + app_url,
+              "",
+              "## Test Results",
+              "",
+              "- **Total:** " + str(total),
+              "- **Passed:** " + str(passed),
+              "- **Failed:** " + str(failed),
+              "",
+              "## Attached Assets",
+              "",
+              "- HTML test reports: unit, integration, API, UAT",
+              "- Android debug APK",
+              "",
+          ]
+          with open('release-summary.md', 'w') as f:
+              f.write('\n'.join(lines))
+          EOF
+
+      - name: Collect release assets
+        run: |
+          mkdir -p release-assets
+          find artifacts/ -name "*.html" -exec cp {} release-assets/ \; 2>/dev/null || true
+          find artifacts/ -name "app-debug.apk" -exec cp {} release-assets/ \; 2>/dev/null || true
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.tag }}
+          name: ${{ inputs.release_name }}
+          body_path: release-summary.md
+          files: release-assets/*
+          draft: false
+          prerelease: false


### PR DESCRIPTION
## Description

Adds a `release.yml` workflow that packages everything needed for a milestone submission: runs the full CI suite, deploys to production, then publishes a tagged GitHub Release with all test reports and the Android APK attached.

Also makes `ci.yml` and `deploy.yml` reusable via `workflow_call` so `release.yml` can compose them without duplicating steps. Fixes the UAT Playwright reporter flag that was overriding the config.

## Related Issue(s)
- Closes #283

## Changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Added `workflow_call:` trigger; removed `--reporter=html,junit` CLI flag from UAT step (let config drive reporters) |
| `.github/workflows/deploy.yml` | Added `workflow_call:` trigger so release workflow can call it directly |
| `.github/workflows/release.yml` | New workflow: `workflow_dispatch` with `tag` + `release_name` inputs; `check-branch` guard (main only); calls `ci.yml` → `deploy.yml` → `create-release` (downloads artifacts, parses JUnit XML, generates release body, publishes via `softprops/action-gh-release@v2`) |

## Checklist
- [x] All tests passed 
- [x] I have self-reviewed my own code
- [ ] I have requested at least 1 reviewer