### PR TITLE
anon sharing imp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,10 @@ dist/
 *.log
 logs/
 
+# Jest reports
+test-report.html
+test-report.xml
+
 # Docker
 docker-compose.override.yml
 

--- a/frontend/anonymous.js
+++ b/frontend/anonymous.js
@@ -1,0 +1,29 @@
+// Display helpers for anonymous story sharing.
+// Backend masks `author` to null when `is_anonymous` is true, so we never
+// have access to the real username here
+
+
+function isAnonymousStory(story) {
+    if (!story) return false;
+    return story.is_anonymous === true;
+}
+
+function getAuthorLabel(story) {
+    if (isAnonymousStory(story)) return "Anonymous";
+    if (story && typeof story.author === "string" && story.author.length > 0) {
+        return story.author;
+    }
+    return "Unknown";
+}
+
+function getAuthorByLine(story) {
+    return "by " + getAuthorLabel(story);
+}
+
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = {
+        isAnonymousStory: isAnonymousStory,
+        getAuthorLabel: getAuthorLabel,
+        getAuthorByLine: getAuthorByLine
+    };
+}

--- a/frontend/anonymous.test.js
+++ b/frontend/anonymous.test.js
@@ -1,0 +1,38 @@
+const {
+    isAnonymousStory,
+    getAuthorLabel,
+    getAuthorByLine
+} = require("./anonymous");
+
+describe("anonymous story display helpers", () => {
+    test("isAnonymousStory is true only when is_anonymous === true", () => {
+        expect(isAnonymousStory({ is_anonymous: true })).toBe(true);
+        expect(isAnonymousStory({ is_anonymous: false })).toBe(false);
+        expect(isAnonymousStory({})).toBe(false);
+        expect(isAnonymousStory(null)).toBe(false);
+        expect(isAnonymousStory(undefined)).toBe(false);
+    });
+
+    test("getAuthorLabel returns 'Anonymous' for anonymous stories even if author is somehow set", () => {
+        // Defense in depth: if the backend ever leaks an author for an
+        // anonymous story, the UI must still hide it.
+        expect(getAuthorLabel({ is_anonymous: true, author: "alice" })).toBe("Anonymous");
+        expect(getAuthorLabel({ is_anonymous: true, author: null })).toBe("Anonymous");
+    });
+
+    test("getAuthorLabel returns the username for non-anonymous stories", () => {
+        expect(getAuthorLabel({ is_anonymous: false, author: "alice" })).toBe("alice");
+    });
+
+    test("getAuthorLabel falls back to 'Unknown' when author is missing", () => {
+        expect(getAuthorLabel({ is_anonymous: false, author: null })).toBe("Unknown");
+        expect(getAuthorLabel({ is_anonymous: false, author: "" })).toBe("Unknown");
+        expect(getAuthorLabel({})).toBe("Unknown");
+    });
+
+    test("getAuthorByLine prefixes the label with 'by '", () => {
+        expect(getAuthorByLine({ is_anonymous: true, author: "alice" })).toBe("by Anonymous");
+        expect(getAuthorByLine({ is_anonymous: false, author: "alice" })).toBe("by alice");
+        expect(getAuthorByLine({})).toBe("by Unknown");
+    });
+});

--- a/frontend/map.html
+++ b/frontend/map.html
@@ -454,6 +454,7 @@
 
     <script src="config.js"></script>
     <script src="auth.js"></script>
+    <script src="anonymous.js"></script>
     <!-- Leaflet JS -->
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 
@@ -791,6 +792,7 @@
                 headerHtml +
                 '<div style="padding:16px;">' +
                 '<h3 style="font-family:\'Noto Serif\',serif;font-size:16px;font-weight:700;color:#1d1c16;margin:0 0 6px 0;line-height:1.3;">' + story.title + '</h3>' +
+                '<p style="font-size:11px;color:#5f584c;margin:0 0 8px 0;' + (isAnonymousStory(story) ? 'font-style:italic;' : '') + '">' + getAuthorByLine(story) + '</p>' +
                 '<p style="font-size:13px;color:#5f584c;line-height:1.5;margin:0 0 12px 0;font-style:italic;">"' + preview + '"</p>' +
                 '<div style="display:flex;align-items:center;justify-content:space-between;">' +
                 (placeName ? '<span style="font-size:11px;color:#35618f;font-weight:600;">' + placeName + '</span>' : '<span></span>') +
@@ -874,6 +876,7 @@
                 div.innerHTML =
                     (dateLabel ? '<div class="text-[10px] font-bold text-tertiary tracking-widest uppercase mb-1">' + dateLabel + '</div>' : '') +
                     '<h4 class="font-semibold text-sm text-textmain leading-snug mb-1">' + story.title + '</h4>' +
+                    '<p class="text-[11px] text-textmuted mb-1' + (isAnonymousStory(story) ? ' italic' : '') + '">' + getAuthorByLine(story) + '</p>' +
                     '<p class="text-xs text-textmuted line-clamp-2 leading-relaxed">' + preview + '</p>' +
                     '<div class="mt-2 flex items-center justify-between">' +
                     '<span class="text-[10px] text-textmuted">' + placeName + '</span>' +

--- a/frontend/search.html
+++ b/frontend/search.html
@@ -91,6 +91,7 @@
     </main>
 
     <script src="config.js"></script>
+    <script src="anonymous.js"></script>
     <script>
         var searchForm = document.getElementById("search-form");
         var searchInput = document.getElementById("search-input");
@@ -210,7 +211,7 @@
                         (placeName ? '<span class="text-[11px] font-semibold text-primary truncate">' + escapeHtml(placeName) + '</span>' : '') +
                     '</div>' +
                     '<h3 class="font-headline font-bold text-base text-textmain leading-snug group-hover:text-primary transition-colors">' + escapeHtml(story.title) + '</h3>' +
-                    (story.author ? '<p class="mt-1 text-xs text-textmuted">by ' + escapeHtml(story.author) + '</p>' : '') +
+                    '<p class="mt-1 text-xs text-textmuted' + (isAnonymousStory(story) ? ' italic' : '') + '">' + escapeHtml(getAuthorByLine(story)) + '</p>' +
                     '<p class="mt-2.5 text-sm text-textmuted leading-relaxed line-clamp-3">' + escapeHtml(preview) + '</p>' +
                     '<div class="mt-4 flex items-center gap-1 text-xs font-bold text-primary">' +
                         'Read Story' +

--- a/frontend/story-create.html
+++ b/frontend/story-create.html
@@ -237,6 +237,45 @@
           </div>
         </div>
 
+        <!-- Anonymous sharing card -->
+        <div>
+          <label class="mb-2 block text-sm font-semibold text-textmain">Author visibility</label>
+          <button
+            type="button"
+            id="anon-card"
+            role="switch"
+            aria-checked="false"
+            aria-describedby="anon-card-desc"
+            class="group w-full rounded-2xl border border-border bg-white p-5 text-left transition hover:border-primary-light hover:bg-[rgba(197,160,89,0.06)] focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+          >
+            <div class="flex items-start gap-4">
+              <span
+                id="anon-card-indicator"
+                aria-hidden="true"
+                class="mt-0.5 flex h-6 w-6 flex-none items-center justify-center rounded-full border border-border bg-white text-white transition"
+              >
+                <span id="anon-card-check" class="material-symbols-outlined text-[16px] leading-none opacity-0 transition-opacity">check</span>
+              </span>
+              <span class="flex-1">
+                <span class="flex items-center gap-2">
+                  <span class="material-symbols-outlined text-[18px] leading-none text-primary">visibility_off</span>
+                  <span class="text-sm font-semibold text-textmain">Share anonymously</span>
+                </span>
+                <span id="anon-card-desc" class="mt-1.5 block text-xs leading-5 text-textmuted">
+                  Your username will be hidden everywhere this story appears — feed, map, search, and the story page. Readers will see the author as <strong class="text-primary">Anonymous</strong>. You can change this later by editing the story.
+                </span>
+                <span id="anon-card-state" class="mt-2 inline-flex items-center gap-1.5 rounded-full bg-stone-100 px-2.5 py-0.5 text-[11px] font-semibold text-textmuted transition">
+                  <span id="anon-card-state-dot" class="h-1.5 w-1.5 rounded-full bg-textmuted"></span>
+                  <span id="anon-card-state-text">Off — your username will be shown</span>
+                </span>
+              </span>
+            </div>
+          </button>
+          <input type="hidden" id="is-anonymous" name="is_anonymous" value="false" />
+        </div>
+
+        <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet">
+
         <!-- Error / Success Messages -->
         <div id="form-error" class="hidden rounded-xl bg-red-50 border border-red-200 p-3 text-sm text-red-700"></div>
         <div id="form-success" class="hidden rounded-xl bg-green-50 border border-green-200 p-3 text-sm text-green-700"></div>
@@ -753,6 +792,59 @@
     setRecordingStatus("Recording canceled. Start again when ready.", false);
   }
 
+  // ─── Anonymous card toggle ───
+  (function setupAnonymousCard() {
+    var card = document.getElementById("anon-card");
+    var hidden = document.getElementById("is-anonymous");
+    var indicator = document.getElementById("anon-card-indicator");
+    var check = document.getElementById("anon-card-check");
+    var statePill = document.getElementById("anon-card-state");
+    var stateDot = document.getElementById("anon-card-state-dot");
+    var stateText = document.getElementById("anon-card-state-text");
+
+    function applyState(on) {
+      hidden.value = on ? "true" : "false";
+      card.setAttribute("aria-checked", on ? "true" : "false");
+
+      card.classList.toggle("border-primary", on);
+      card.classList.toggle("bg-[rgba(119,90,25,0.06)]", on);
+      card.classList.toggle("border-border", !on);
+      card.classList.toggle("bg-white", !on);
+
+      indicator.classList.toggle("bg-primary", on);
+      indicator.classList.toggle("border-primary", on);
+      indicator.classList.toggle("bg-white", !on);
+      indicator.classList.toggle("border-border", !on);
+      check.classList.toggle("opacity-0", !on);
+      check.classList.toggle("opacity-100", on);
+
+      statePill.classList.toggle("bg-[rgba(119,90,25,0.12)]", on);
+      statePill.classList.toggle("text-primary", on);
+      statePill.classList.toggle("bg-stone-100", !on);
+      statePill.classList.toggle("text-textmuted", !on);
+
+      stateDot.classList.toggle("bg-primary", on);
+      stateDot.classList.toggle("bg-textmuted", !on);
+
+      stateText.textContent = on
+        ? "On — you will appear as Anonymous"
+        : "Off — your username will be shown";
+    }
+
+    card.addEventListener("click", function () {
+      applyState(hidden.value !== "true");
+    });
+
+    card.addEventListener("keydown", function (e) {
+      if (e.key === " " || e.key === "Enter") {
+        e.preventDefault();
+        applyState(hidden.value !== "true");
+      }
+    });
+
+    applyState(false);
+  })();
+
   document.getElementById("btn-start-recording").addEventListener("click", startRecording);
   document.getElementById("btn-stop-recording").addEventListener("click", stopRecording);
   document.getElementById("btn-cancel-recording").addEventListener("click", cancelRecording);
@@ -878,6 +970,8 @@
       }
     }
 
+    var isAnonymous = document.getElementById("is-anonymous").value === "true";
+
     var payload = {
       title: title,
       content: content,
@@ -886,7 +980,8 @@
       longitude: parseFloat(lng),
       place_name: placeName,
       date_start: usingDateRange ? getISODateFromDateInput(dateStart) : getISODateFromDateInput(dateSingle),
-      date_end: usingDateRange ? getISODateFromDateInput(dateEnd) : null
+      date_end: usingDateRange ? getISODateFromDateInput(dateEnd) : null,
+      is_anonymous: isAnonymous
     };
 
     setSubmittingState(true, "Creating Story...");

--- a/frontend/story-detail.html
+++ b/frontend/story-detail.html
@@ -200,6 +200,7 @@
 <script src="comments.js"></script>
 <script src="auth.js"></script>
 <script src="saves.js"></script>
+<script src="anonymous.js"></script>
 <script>
   // Initialize mini-map with arbitrary center initially
   var detailMap = L.map("detail-map", {
@@ -231,7 +232,10 @@
       .then(story => {
           document.getElementById('story-title').textContent = story.title || "Untitled";
           document.getElementById('story-summary').textContent = story.summary || "";
-          document.getElementById('story-author').innerHTML = 'by ' + (story.author || "Unknown");
+          document.getElementById('story-author').textContent = getAuthorByLine(story);
+          if (isAnonymousStory(story)) {
+            document.getElementById('story-author').classList.add('italic');
+          }
           document.getElementById('story-date').textContent = story.date_label || "No Date";
           document.getElementById('story-location').textContent = story.place_name || "Istanbul";
           document.getElementById('story-content').textContent = story.content || "No content available.";


### PR DESCRIPTION
 ## Description
  Implements the frontend portion of anonymous story sharing on top of the
  already-merged backend (PR #311). Authors can opt to publish a story
  anonymously from the create page; readers see "by Anonymous" instead of a
  username on the story detail page, search results, and the map (popups +
  sidebar). The real username is never rendered on the client when
  `is_anonymous` is true — even as a defense-in-depth fallback if the
  backend ever leaks an `author` value.

  The UI uses a selectable card (matching the existing rounded-2xl card
  vocabulary on `story-create.html`) with `role="switch"`, keyboard
  support, a live status pill, and explanatory copy describing exactly
  where the username gets hidden.

  A small `anonymous.js` helper centralizes the display logic
  (`isAnonymousStory`, `getAuthorLabel`, `getAuthorByLine`) so the same
  rule is applied everywhere and is unit-testable.



  ## Related Issue(s)
  - Closes #242

  ## Changes

  | File | Change |
  |------|--------|
  | `frontend/anonymous.js` | Added — display helpers (`isAnonymousStory`, `getAuthorLabel`, `getAuthorByLine`) used across all story views. |
  | `frontend/anonymous.test.js` | Added — Jest unit tests covering the masking invariant ("never show real username when `is_anonymous` is true"), fallbacks, and bylines. |
  | `frontend/story-create.html` | Added an "Author visibility" selectable card (switch-role, keyboard accessible, with explanatory text and a live state pill); send
  `is_anonymous` in the create payload. |
  | `frontend/story-detail.html` | Loads `anonymous.js`; author byline now uses `getAuthorByLine(story)` and italicizes when anonymous. |
  | `frontend/search.html` | Loads `anonymous.js`; feed cards always render the byline and italicize when anonymous. |
  | `frontend/map.html` | Loads `anonymous.js`; popups and sidebar cards now show the byline (Anonymous-aware). |
  | `.gitignore` | Ignored Jest reporter output (`test-report.html`, `test-report.xml`). |

  ## Checklist
  - [x] All tests passed (`npx jest` → 49 passed across 9 suites; 5 new tests in `anonymous.test.js`)
  - [x] I have self-reviewed my own code
  - [x] I have requested at least 1 reviewer