### PR TITLE
feat: add backend transcription preview endpoint for story audio

### DIFF
--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -10,13 +10,19 @@ from app.core.config import settings
 from app.db.session import get_db
 from app.db.user import User
 
-security = HTTPBearer()
+security = HTTPBearer(auto_error=False)
 
 
 async def get_current_user(
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    credentials: HTTPAuthorizationCredentials | None = Depends(security),
     db: AsyncSession = Depends(get_db),
 ) -> User:
+    if credentials is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+        )
+
     token = credentials.credentials
     try:
         payload = jwt.decode(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,6 +8,7 @@ from app.core.config import settings
 from app.db.session import engine
 from app.routers.auth import router as auth_router
 from app.routers.story import router as story_router
+from app.routers.transcription import router as transcription_router
 from app.routers.users import router as users_router
 from app.services.storage import check_connection
 
@@ -43,6 +44,7 @@ app.add_middleware(
 )
 app.include_router(auth_router)
 app.include_router(story_router)
+app.include_router(transcription_router)
 app.include_router(users_router)
 
 

--- a/backend/app/models/transcription.py
+++ b/backend/app/models/transcription.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+
+
+class TranscriptionPreviewResponse(BaseModel):
+    transcript: str | None

--- a/backend/app/routers/transcription.py
+++ b/backend/app/routers/transcription.py
@@ -1,0 +1,31 @@
+from fastapi import APIRouter, Depends, File, UploadFile, status
+
+from app.core.deps import get_current_user
+from app.db.user import User
+from app.models.transcription import TranscriptionPreviewResponse
+from app.services.transcription_service import preview_audio_transcription
+
+router = APIRouter(prefix="/transcription", tags=["transcription"])
+
+
+@router.post(
+    "/preview",
+    response_model=TranscriptionPreviewResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Preview an audio transcript",
+    description=(
+        "Transcribe an uploaded audio file without persisting media metadata or requiring a story id. "
+        "Requires authentication."
+    ),
+    responses={
+        400: {"description": "Empty or invalid file"},
+        401: {"description": "Missing or invalid authentication token"},
+        413: {"description": "File exceeds the 20 MB size limit"},
+    },
+)
+async def preview_transcription(
+    file: UploadFile = File(...),
+    _current_user: User = Depends(get_current_user),
+):
+    transcript = await preview_audio_transcription(file)
+    return TranscriptionPreviewResponse(transcript=transcript)

--- a/backend/app/services/media_validation.py
+++ b/backend/app/services/media_validation.py
@@ -1,0 +1,121 @@
+from pathlib import Path
+
+from fastapi import HTTPException, UploadFile, status
+
+from app.db.enums import MediaType
+
+MAX_MEDIA_UPLOAD_BYTES = 20 * 1024 * 1024  # 20 MB
+
+ALLOWED_MIME_TYPES = {
+    "image": {"image/jpeg", "image/png", "image/webp", "image/gif"},
+    "audio": {"audio/mpeg", "audio/wav", "audio/ogg", "audio/mp4", "audio/webm"},
+    "video": {"video/mp4", "video/webm", "video/quicktime"},
+    "document": {
+        "application/pdf",
+        "text/plain",
+        "application/msword",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    },
+}
+
+MIME_TYPE_ALIASES = {
+    "image/jpg": "image/jpeg",
+    "audio/x-wav": "audio/wav",
+    "audio/wave": "audio/wav",
+    "audio/vnd.wave": "audio/wav",
+    "audio/x-m4a": "audio/mp4",
+    "audio/m4a": "audio/mp4",
+    "video/x-m4v": "video/mp4",
+    "application/x-pdf": "application/pdf",
+}
+
+GENERIC_BINARY_MIME_TYPES = {"application/octet-stream", "binary/octet-stream"}
+
+MIME_TYPE_FALLBACKS_BY_EXTENSION = {
+    "image": {
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".png": "image/png",
+        ".webp": "image/webp",
+        ".gif": "image/gif",
+    },
+    "audio": {
+        ".mp3": "audio/mpeg",
+        ".wav": "audio/wav",
+        ".ogg": "audio/ogg",
+        ".m4a": "audio/mp4",
+        ".mp4": "audio/mp4",
+        ".webm": "audio/webm",
+    },
+    "video": {
+        ".mp4": "video/mp4",
+        ".m4v": "video/mp4",
+        ".webm": "video/webm",
+        ".mov": "video/quicktime",
+    },
+    "document": {
+        ".pdf": "application/pdf",
+        ".txt": "text/plain",
+        ".doc": "application/msword",
+        ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    },
+}
+
+
+def normalize_media_content_type(file: UploadFile, media_type: MediaType) -> str:
+    raw_content_type = (file.content_type or "").split(";")[0].strip().lower()
+    normalized_content_type = MIME_TYPE_ALIASES.get(raw_content_type, raw_content_type)
+
+    if normalized_content_type in GENERIC_BINARY_MIME_TYPES:
+        extension = Path(file.filename or "").suffix.lower()
+        fallback_content_type = MIME_TYPE_FALLBACKS_BY_EXTENSION[media_type.value].get(extension)
+        if fallback_content_type:
+            return fallback_content_type
+
+    return normalized_content_type
+
+
+def validate_media_upload(
+    file: UploadFile,
+    media_type: MediaType,
+    *,
+    invalid_mime_status: int = status.HTTP_422_UNPROCESSABLE_ENTITY,
+) -> str:
+    if not file.filename:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Filename is required",
+        )
+
+    if not file.content_type:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Content type is required",
+        )
+
+    allowed_for_type = ALLOWED_MIME_TYPES[media_type.value]
+    normalized_content_type = normalize_media_content_type(file, media_type)
+    if normalized_content_type not in allowed_for_type:
+        raise HTTPException(
+            status_code=invalid_mime_status,
+            detail=f"Unsupported mime type '{normalized_content_type}' for media type '{media_type.value}'",
+        )
+
+    return normalized_content_type
+
+
+async def read_uploaded_file_content(file: UploadFile) -> bytes:
+    file_bytes = await file.read()
+    if not file_bytes:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Uploaded file is empty",
+        )
+
+    if len(file_bytes) > MAX_MEDIA_UPLOAD_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"File size exceeds {MAX_MEDIA_UPLOAD_BYTES} bytes",
+        )
+
+    return file_bytes

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -32,6 +32,7 @@ from app.models.story import (
     StorySaveResponse,
     StoryUpdateRequest,
 )
+from app.services.media_validation import read_uploaded_file_content, validate_media_upload
 from app.services.storage import (
     build_public_object_url,
     delete_object,
@@ -39,63 +40,6 @@ from app.services.storage import (
     upload_bytes,
 )
 from app.services.transcription_service import transcribe_media_file
-
-MAX_MEDIA_UPLOAD_BYTES = 20 * 1024 * 1024  # 20 MB
-
-ALLOWED_MIME_TYPES = {
-    "image": {"image/jpeg", "image/png", "image/webp", "image/gif"},
-    "audio": {"audio/mpeg", "audio/wav", "audio/ogg", "audio/mp4", "audio/webm"},
-    "video": {"video/mp4", "video/webm", "video/quicktime"},
-    "document": {
-        "application/pdf",
-        "text/plain",
-        "application/msword",
-        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-    },
-}
-
-MIME_TYPE_ALIASES = {
-    "image/jpg": "image/jpeg",
-    "audio/x-wav": "audio/wav",
-    "audio/wave": "audio/wav",
-    "audio/vnd.wave": "audio/wav",
-    "audio/x-m4a": "audio/mp4",
-    "audio/m4a": "audio/mp4",
-    "video/x-m4v": "video/mp4",
-    "application/x-pdf": "application/pdf",
-}
-
-GENERIC_BINARY_MIME_TYPES = {"application/octet-stream", "binary/octet-stream"}
-
-MIME_TYPE_FALLBACKS_BY_EXTENSION = {
-    "image": {
-        ".jpg": "image/jpeg",
-        ".jpeg": "image/jpeg",
-        ".png": "image/png",
-        ".webp": "image/webp",
-        ".gif": "image/gif",
-    },
-    "audio": {
-        ".mp3": "audio/mpeg",
-        ".wav": "audio/wav",
-        ".ogg": "audio/ogg",
-        ".m4a": "audio/mp4",
-        ".mp4": "audio/mp4",
-        ".webm": "audio/webm",
-    },
-    "video": {
-        ".mp4": "video/mp4",
-        ".m4v": "video/mp4",
-        ".webm": "video/webm",
-        ".mov": "video/quicktime",
-    },
-    "document": {
-        ".pdf": "application/pdf",
-        ".txt": "text/plain",
-        ".doc": "application/msword",
-        ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-    },
-}
 
 
 def _map_story_rows(rows: list[tuple[Story, str]]) -> StoryListResponse:
@@ -180,43 +124,6 @@ def _map_comment_row(comment: StoryComment, author: User) -> CommentResponse:
         created_at=comment.created_at,
         updated_at=comment.updated_at,
     )
-
-
-def _normalize_media_content_type(file: UploadFile, payload: MediaUploadRequest) -> str:
-    raw_content_type = (file.content_type or "").split(";")[0].strip().lower()
-    normalized_content_type = MIME_TYPE_ALIASES.get(raw_content_type, raw_content_type)
-
-    if normalized_content_type in GENERIC_BINARY_MIME_TYPES:
-        extension = Path(file.filename or "").suffix.lower()
-        fallback_content_type = MIME_TYPE_FALLBACKS_BY_EXTENSION[payload.media_type.value].get(extension)
-        if fallback_content_type:
-            return fallback_content_type
-
-    return normalized_content_type
-
-
-def _validate_media_upload(file: UploadFile, payload: MediaUploadRequest) -> str:
-    if not file.filename:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Filename is required",
-        )
-
-    if not file.content_type:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Content type is required",
-        )
-
-    allowed_for_type = ALLOWED_MIME_TYPES[payload.media_type.value]
-    normalized_content_type = _normalize_media_content_type(file, payload)
-    if normalized_content_type not in allowed_for_type:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=(f"Unsupported mime type '{normalized_content_type}' for media type '{payload.media_type.value}'"),
-        )
-
-    return normalized_content_type
 
 
 def _build_media_storage_key(story_id: uuid.UUID, filename: str) -> str:
@@ -668,7 +575,7 @@ async def upload_media_for_story(
     payload: MediaUploadRequest,
     background_tasks: BackgroundTasks | None = None,
 ) -> MediaUploadResponse:
-    normalized_content_type = _validate_media_upload(file, payload)
+    normalized_content_type = validate_media_upload(file, payload.media_type)
 
     story_result = await db.execute(select(Story).where(Story.id == story_id, Story.deleted_at.is_(None)))
     story = story_result.scalar_one_or_none()
@@ -678,19 +585,8 @@ async def upload_media_for_story(
             detail="Story not found",
         )
 
-    file_bytes = await file.read()
-    if not file_bytes:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Uploaded file is empty",
-        )
-
+    file_bytes = await read_uploaded_file_content(file)
     file_size = len(file_bytes)
-    if file_size > MAX_MEDIA_UPLOAD_BYTES:
-        raise HTTPException(
-            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
-            detail=f"File size exceeds {MAX_MEDIA_UPLOAD_BYTES} bytes",
-        )
 
     bucket_name = get_bucket_for_media_type(payload.media_type)
     storage_key = _build_media_storage_key(story_id, file.filename)

--- a/backend/app/services/transcription_service.py
+++ b/backend/app/services/transcription_service.py
@@ -5,12 +5,14 @@ import uuid
 from functools import lru_cache
 from tempfile import NamedTemporaryFile
 
+from fastapi import UploadFile, status
 from sqlalchemy import select
 
 from app.core.config import settings
 from app.db.enums import MediaType
 from app.db.media_file import MediaFile
 from app.db.session import AsyncSessionLocal
+from app.services.media_validation import read_uploaded_file_content, validate_media_upload
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +65,20 @@ async def transcribe_audio_content(
     except Exception:
         logger.exception("Audio transcription failed for %s", filename)
         return None
+
+
+async def preview_audio_transcription(file: UploadFile) -> str | None:
+    normalized_content_type = validate_media_upload(
+        file,
+        MediaType.AUDIO,
+        invalid_mime_status=status.HTTP_400_BAD_REQUEST,
+    )
+    file_bytes = await read_uploaded_file_content(file)
+    return await transcribe_audio_content(
+        filename=file.filename,
+        content=file_bytes,
+        mime_type=normalized_content_type,
+    )
 
 
 async def _transcribe_with_whisper(

--- a/backend/tests/api/test_transcription_api.py
+++ b/backend/tests/api/test_transcription_api.py
@@ -1,0 +1,103 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+class TestTranscriptionPreviewAPI:
+    async def _create_user_and_token(self, client):
+        await client.post(
+            "/auth/register",
+            json={
+                "username": "previewuser",
+                "email": "preview@example.com",
+                "password": "PreviewPass1!",
+            },
+        )
+        login_resp = await client.post(
+            "/auth/login",
+            json={
+                "email": "preview@example.com",
+                "password": "PreviewPass1!",
+            },
+        )
+        return login_resp.json()["access_token"]
+
+    async def test_preview_transcription_success(self, client):
+        token = await self._create_user_and_token(client)
+
+        with patch(
+            "app.services.transcription_service.transcribe_audio_content",
+            new=AsyncMock(return_value="Preview transcript"),
+        ) as mock_transcribe:
+            resp = await client.post(
+                "/transcription/preview",
+                headers={"Authorization": f"Bearer {token}"},
+                files={"file": ("recorded-audio.webm", b"audio-bytes", "audio/webm;codecs=opus")},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json() == {"transcript": "Preview transcript"}
+        mock_transcribe.assert_awaited_once()
+
+    async def test_preview_transcription_returns_null_when_transcriber_fails_gracefully(self, client):
+        token = await self._create_user_and_token(client)
+
+        with patch(
+            "app.services.transcription_service.transcribe_audio_content",
+            new=AsyncMock(return_value=None),
+        ):
+            resp = await client.post(
+                "/transcription/preview",
+                headers={"Authorization": f"Bearer {token}"},
+                files={"file": ("recorded-audio.webm", b"audio-bytes", "audio/webm")},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json() == {"transcript": None}
+
+    async def test_preview_transcription_rejects_invalid_file_type(self, client):
+        token = await self._create_user_and_token(client)
+
+        resp = await client.post(
+            "/transcription/preview",
+            headers={"Authorization": f"Bearer {token}"},
+            files={"file": ("photo.png", b"png-bytes", "image/png")},
+        )
+
+        assert resp.status_code == 400
+        assert "Unsupported mime type" in resp.json()["detail"]
+
+    async def test_preview_transcription_rejects_empty_file(self, client):
+        token = await self._create_user_and_token(client)
+
+        resp = await client.post(
+            "/transcription/preview",
+            headers={"Authorization": f"Bearer {token}"},
+            files={"file": ("empty.webm", b"", "audio/webm")},
+        )
+
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Uploaded file is empty"
+
+    async def test_preview_transcription_rejects_oversized_file(self, client, monkeypatch):
+        token = await self._create_user_and_token(client)
+        monkeypatch.setattr("app.services.media_validation.MAX_MEDIA_UPLOAD_BYTES", 4)
+
+        resp = await client.post(
+            "/transcription/preview",
+            headers={"Authorization": f"Bearer {token}"},
+            files={"file": ("large.webm", b"12345", "audio/webm")},
+        )
+
+        assert resp.status_code == 413
+        assert resp.json()["detail"] == "File size exceeds 4 bytes"
+
+    async def test_preview_transcription_requires_authentication(self, client):
+        resp = await client.post(
+            "/transcription/preview",
+            files={"file": ("recorded-audio.webm", b"audio-bytes", "audio/webm")},
+        )
+
+        assert resp.status_code == 401
+        assert resp.json()["detail"] == "Not authenticated"

--- a/backend/tests/unit/test_deps.py
+++ b/backend/tests/unit/test_deps.py
@@ -40,6 +40,16 @@ def _make_user(user_id: uuid.UUID):
 
 @pytest.mark.asyncio
 class TestGetCurrentUser:
+    async def test_rejects_missing_credentials(self):
+        db = AsyncMock()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(credentials=None, db=db)
+
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.detail == "Not authenticated"
+        db.execute.assert_not_awaited()
+
     async def test_returns_user_for_valid_token(self):
         user_id = uuid.uuid4()
         token = _make_token(sub=str(user_id))

--- a/backend/tests/unit/test_transcription_service.py
+++ b/backend/tests/unit/test_transcription_service.py
@@ -1,11 +1,14 @@
+from io import BytesIO
 import uuid
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from fastapi import HTTPException
+from starlette.datastructures import Headers, UploadFile
 
 from app.db.enums import MediaType
-from app.services.transcription_service import transcribe_audio_content, transcribe_media_file
+from app.services.transcription_service import preview_audio_transcription, transcribe_audio_content, transcribe_media_file
 
 
 class _SessionContextManager:
@@ -117,3 +120,39 @@ class TestTranscribeMediaFile:
 
         assert media.transcript is None
         db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+class TestPreviewAudioTranscription:
+    async def test_transcribes_valid_audio_upload(self):
+        upload = UploadFile(
+            file=BytesIO(b"audio-bytes"),
+            filename="audio.webm",
+            headers=Headers({"content-type": "audio/webm;codecs=opus"}),
+        )
+
+        with patch(
+            "app.services.transcription_service.transcribe_audio_content",
+            new=AsyncMock(return_value="Preview transcript"),
+        ) as mock_transcribe:
+            result = await preview_audio_transcription(upload)
+
+        assert result == "Preview transcript"
+        mock_transcribe.assert_awaited_once_with(
+            filename="audio.webm",
+            content=b"audio-bytes",
+            mime_type="audio/webm",
+        )
+
+    async def test_rejects_invalid_upload_type_with_400(self):
+        upload = UploadFile(
+            file=BytesIO(b"png-bytes"),
+            filename="photo.png",
+            headers=Headers({"content-type": "image/png"}),
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await preview_audio_transcription(upload)
+
+        assert exc_info.value.status_code == 400
+        assert "Unsupported mime type" in exc_info.value.detail

--- a/backend/tests/unit/test_transcription_service.py
+++ b/backend/tests/unit/test_transcription_service.py
@@ -1,5 +1,5 @@
-from io import BytesIO
 import uuid
+from io import BytesIO
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -8,7 +8,11 @@ from fastapi import HTTPException
 from starlette.datastructures import Headers, UploadFile
 
 from app.db.enums import MediaType
-from app.services.transcription_service import preview_audio_transcription, transcribe_audio_content, transcribe_media_file
+from app.services.transcription_service import (
+    preview_audio_transcription,
+    transcribe_audio_content,
+    transcribe_media_file,
+)
 
 
 class _SessionContextManager:


### PR DESCRIPTION
## Description
Adds a backend-only transcription preview flow for recorded story audio before publish.

This PR introduces an authenticated `POST /transcription/preview` endpoint that accepts an audio file, reuses the existing transcription pipeline, returns `{ "transcript": string | null }`, and does not persist anything to the database. It also extracts shared media validation so the preview endpoint enforces the same audio type and 20 MB size rules as story media uploads.

Suggested labels: `feature`, `backend`

## Related Issue(s)
- Closes #315

## Changes

| File | Change |
|------|--------|
| `backend/app/main.py` | Registered the new transcription router. |
| `backend/app/core/deps.py` | Adjusted auth dependency handling so missing bearer credentials return `401 Not authenticated`. |
| `backend/app/routers/transcription.py` | Added the new authenticated `POST /transcription/preview` endpoint. |
| `backend/app/models/transcription.py` | Added the response model for preview transcription results. |
| `backend/app/services/transcription_service.py` | Added preview transcription logic that reuses the existing audio transcription pipeline without persistence. |
| `backend/app/services/media_validation.py` | Added shared upload validation helpers for MIME type normalization, file validation, and 20 MB size enforcement. |
| `backend/app/services/story_service.py` | Refactored story media upload to use the shared media validation helpers. |
| `backend/tests/api/test_transcription_api.py` | Added API tests for successful preview transcription, null transcript responses, auth, invalid file, empty file, and oversized file cases. |
| `backend/tests/unit/test_transcription_service.py` | Added unit tests for preview transcription validation and service behavior. |
| `backend/tests/unit/test_deps.py` | Added unit coverage for missing-auth handling in the auth dependency. |

## Checklist
- [x] All tests passed
- [x] I have self-reviewed my own code
- [x] I have requested at least 1 reviewer