### PR TITLE
Feat/connect edit profile to backend

### DIFF
--- a/frontend/config.js
+++ b/frontend/config.js
@@ -1,3 +1,4 @@
 // Backend API base URL (no trailing slash)
 // Replaced at container startup by docker-entrypoint.sh from $API_BASE_URL env var.
+// eslint-disable-next-line no-unused-vars
 var API_BASE = "__API_BASE_URL__";

--- a/frontend/edit-profile.html
+++ b/frontend/edit-profile.html
@@ -46,20 +46,18 @@
   <!-- Top Navigation Bar -->
   <header class="fixed top-0 left-0 right-0 z-[1000] bg-[#f8f3ea]/95 backdrop-blur-sm border-b border-border/30">
     <div class="flex justify-between items-center w-full px-8 py-4 max-w-screen-2xl mx-auto">
-        <div class="flex items-center gap-8">
-            <h1 class="text-2xl font-bold font-headline text-textmain tracking-tight">Local History Map</h1>
-            <nav class="hidden md:flex items-center gap-6">
-                <a class="text-textmain font-medium hover:text-tertiary transition-colors" href="map.html">Map</a>
-                <a class="text-textmain font-medium hover:text-tertiary transition-colors" href="story-detail.html">Archive</a>
-                <a class="text-textmain font-medium hover:text-tertiary transition-colors" href="story-create.html">Create Story</a>
-                <a class="text-textmain font-medium hover:text-tertiary transition-colors" href="index.html">Login</a>
-            </nav>
-        </div>
-        <div class="flex items-center gap-3 sm:gap-4">
-            <a href="profile.html" class="inline-flex h-11 w-11 items-center justify-center rounded-full border border-primary bg-primary/10 text-primary shadow-sm transition hover:bg-primary/20" aria-label="Open profile">
-                <span class="material-symbols-outlined text-[20px] leading-none">account_circle</span>
-            </a>
-        </div>
+      <div class="flex items-center gap-8">
+        <a href="map.html" class="text-2xl font-bold font-headline text-textmain tracking-tight hover:text-tertiary transition-colors">
+          Local History Map
+        </a>
+      </div>
+      <div class="flex items-center gap-3 sm:gap-4">
+        <a href="profile.html"
+          class="inline-flex h-11 w-11 items-center justify-center rounded-full border border-primary bg-primary/10 text-primary shadow-sm transition hover:bg-primary/20"
+          aria-label="Open profile">
+          <span class="material-symbols-outlined text-[20px] leading-none">account_circle</span>
+        </a>
+      </div>
     </div>
   </header>
 

--- a/frontend/edit-profile.js
+++ b/frontend/edit-profile.js
@@ -60,8 +60,9 @@ async function uploadAvatarFromInput() {
     try {
         var objectUrl = URL.createObjectURL(file);
         applyAvatarPreview(objectUrl);
-    } catch (_) {
-        // Ignore preview failures; upload can still succeed
+    } catch (err) {
+        // Ignore preview failures; upload can still succeed.
+        void err;
     }
 
     var form = new FormData();
@@ -75,7 +76,7 @@ async function uploadAvatarFromInput() {
     if (!res.ok) {
         if (res.status === 401 && typeof logout === "function") logout();
         var payload = null;
-        try { payload = await res.json(); } catch (_) {}
+        try { payload = await res.json(); } catch (err) { void err; }
         throw new Error(getErrorDetail(payload) || "Failed to upload avatar");
     }
 
@@ -111,7 +112,7 @@ async function handleEditProfileSubmit(e) {
         if (!updateRes.ok) {
             if (updateRes.status === 401 && typeof logout === "function") logout();
             var updatePayload = null;
-            try { updatePayload = await updateRes.json(); } catch (_) {}
+            try { updatePayload = await updateRes.json(); } catch (err) { void err; }
             throw new Error(getErrorDetail(updatePayload) || "Failed to update profile");
         }
 
@@ -142,7 +143,7 @@ async function handleEditProfileSubmit(e) {
             if (!pwRes.ok) {
                 if (pwRes.status === 401 && typeof logout === "function") logout();
                 var pwPayload = null;
-                try { pwPayload = await pwRes.json(); } catch (_) {}
+                try { pwPayload = await pwRes.json(); } catch (err) { void err; }
                 throw new Error(getErrorDetail(pwPayload) || "Failed to change password");
             }
 

--- a/frontend/edit-profile.js
+++ b/frontend/edit-profile.js
@@ -11,19 +11,154 @@ async function loadEditProfile() {
         
         var nameEl = document.getElementById("fullName");
         var emailEl = document.getElementById("email");
+        var bioEl = document.getElementById("bio");
+        var locationEl = document.getElementById("location");
+        var avatarInputEl = document.getElementById("avatar-upload");
         
         if (nameEl) nameEl.value = data.display_name || data.username || "";
         if (emailEl) emailEl.value = data.email || "";
+        if (bioEl) bioEl.value = data.bio || "";
+        if (locationEl) locationEl.value = data.location || "";
+        if (avatarInputEl && avatarInputEl.parentElement && data.avatar_url) {
+            applyAvatarPreview(data.avatar_url);
+        }
         
     } catch(err) {
         console.error("Error loading edit profile:", err);
     }
 }
 
-function handleEditProfileSubmit(e) {
+function getErrorDetail(payload) {
+    if (!payload) return null;
+    if (typeof payload === "string") return payload;
+    if (payload.detail) return payload.detail;
+    return null;
+}
+
+function applyAvatarPreview(url) {
+    var avatarInputEl = document.getElementById("avatar-upload");
+    if (!avatarInputEl || !avatarInputEl.parentElement) return;
+
+    var container = avatarInputEl.parentElement;
+    container.style.backgroundImage = "url('" + url + "')";
+    container.style.backgroundSize = "cover";
+    container.style.backgroundPosition = "center";
+    container.style.backgroundRepeat = "no-repeat";
+
+    // Hide the placeholder icon when we have an avatar image.
+    var icon = container.querySelector(".material-symbols-outlined");
+    if (icon) icon.style.opacity = "0";
+}
+
+async function uploadAvatarFromInput() {
+    var input = document.getElementById("avatar-upload");
+    if (!input || !input.files || !input.files[0]) return;
+
+    var file = input.files[0];
+
+    // Local preview immediately
+    try {
+        var objectUrl = URL.createObjectURL(file);
+        applyAvatarPreview(objectUrl);
+    } catch (_) {
+        // Ignore preview failures; upload can still succeed
+    }
+
+    var form = new FormData();
+    form.append("file", file);
+
+    var res = await authFetch(API_BASE + "/auth/me/avatar", {
+        method: "POST",
+        body: form
+    });
+
+    if (!res.ok) {
+        if (res.status === 401 && typeof logout === "function") logout();
+        var payload = null;
+        try { payload = await res.json(); } catch (_) {}
+        throw new Error(getErrorDetail(payload) || "Failed to upload avatar");
+    }
+
+    var data = await res.json();
+    if (data && data.avatar_url) applyAvatarPreview(data.avatar_url);
+}
+
+async function handleEditProfileSubmit(e) {
     e.preventDefault();
-    // Cannot submit to backend yet (no endpoint exists), so just redirect for now
-    window.location.assign('profile.html');
+
+    if (typeof requireAuth === "function" && !requireAuth()) return;
+
+    var nameEl = document.getElementById("fullName");
+    var bioEl = document.getElementById("bio");
+    var locationEl = document.getElementById("location");
+
+    var currentPasswordEl = document.getElementById("currentPassword");
+    var newPasswordEl = document.getElementById("newPassword");
+    var confirmPasswordEl = document.getElementById("confirmPassword");
+
+    var profilePayload = {
+        display_name: nameEl ? nameEl.value : null,
+        bio: bioEl ? bioEl.value : null,
+        location: locationEl ? locationEl.value : null
+    };
+
+    try {
+        var updateRes = await authFetch(API_BASE + "/auth/me", {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(profilePayload)
+        });
+        if (!updateRes.ok) {
+            if (updateRes.status === 401 && typeof logout === "function") logout();
+            var updatePayload = null;
+            try { updatePayload = await updateRes.json(); } catch (_) {}
+            throw new Error(getErrorDetail(updatePayload) || "Failed to update profile");
+        }
+
+        var wantsPasswordChange = false;
+        var currentPassword = currentPasswordEl ? currentPasswordEl.value : "";
+        var newPassword = newPasswordEl ? newPasswordEl.value : "";
+        var confirmPassword = confirmPasswordEl ? confirmPasswordEl.value : "";
+
+        if (currentPassword || newPassword || confirmPassword) wantsPasswordChange = true;
+
+        if (wantsPasswordChange) {
+            if (!currentPassword || !newPassword) {
+                throw new Error("Please enter current password and a new password.");
+            }
+            if (newPassword !== confirmPassword) {
+                throw new Error("New password and confirmation do not match.");
+            }
+
+            var pwRes = await authFetch(API_BASE + "/auth/me/password", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    current_password: currentPassword,
+                    new_password: newPassword
+                })
+            });
+
+            if (!pwRes.ok) {
+                if (pwRes.status === 401 && typeof logout === "function") logout();
+                var pwPayload = null;
+                try { pwPayload = await pwRes.json(); } catch (_) {}
+                throw new Error(getErrorDetail(pwPayload) || "Failed to change password");
+            }
+
+            // Clear password inputs after successful change
+            if (currentPasswordEl) currentPasswordEl.value = "";
+            if (newPasswordEl) newPasswordEl.value = "";
+            if (confirmPasswordEl) confirmPasswordEl.value = "";
+        }
+
+        window.location.assign("profile.html");
+    } catch (err) {
+        console.error("Error saving profile:", err);
+        if (typeof window !== "undefined" && typeof window.alert === "function") {
+            window.alert(err && err.message ? err.message : "Failed to save changes");
+        }
+    }
 }
 
 function setupEditProfile() {
@@ -31,6 +166,18 @@ function setupEditProfile() {
     var form = document.getElementById('edit-profile-form');
     if (form) {
         form.addEventListener('submit', handleEditProfileSubmit);
+    }
+
+    var avatarInput = document.getElementById("avatar-upload");
+    if (avatarInput) {
+        avatarInput.addEventListener("change", function() {
+            uploadAvatarFromInput().catch(function(err) {
+                console.error("Error uploading avatar:", err);
+                if (typeof window !== "undefined" && typeof window.alert === "function") {
+                    window.alert(err && err.message ? err.message : "Failed to upload avatar");
+                }
+            });
+        });
     }
 }
 
@@ -42,6 +189,8 @@ if (typeof module !== "undefined" && module.exports) {
     module.exports = {
         loadEditProfile: loadEditProfile,
         handleEditProfileSubmit: handleEditProfileSubmit,
-        setupEditProfile: setupEditProfile
+        setupEditProfile: setupEditProfile,
+        applyAvatarPreview: applyAvatarPreview,
+        uploadAvatarFromInput: uploadAvatarFromInput
     };
 }

--- a/frontend/edit-profile.js
+++ b/frontend/edit-profile.js
@@ -105,6 +105,7 @@ async function handleEditProfileSubmit(e) {
 
     try {
         var wantsPasswordChange = false;
+        var skipRedirectAfterSave = false;
         var currentPassword = currentPasswordEl ? currentPasswordEl.value : "";
         var newPassword = newPasswordEl ? newPasswordEl.value : "";
         var confirmPassword = confirmPasswordEl ? confirmPasswordEl.value : "";
@@ -116,29 +117,32 @@ async function handleEditProfileSubmit(e) {
                 throw new Error("Please enter current password and a new password.");
             }
             if (newPassword !== confirmPassword) {
-                throw new Error("New password and confirmation do not match.");
+                if (typeof window !== "undefined" && typeof window.alert === "function") {
+                    window.alert("New password and confirmation do not match.");
+                }
+                skipRedirectAfterSave = true;
+            } else {
+                var pwRes = await authFetch(API_BASE + "/auth/me/password", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({
+                        current_password: currentPassword,
+                        new_password: newPassword
+                    })
+                });
+
+                if (!pwRes.ok) {
+                    if (pwRes.status === 401 && typeof logout === "function") logout();
+                    var pwPayload = null;
+                    try { pwPayload = await pwRes.json(); } catch (err) { void err; }
+                    throw new Error(getErrorDetail(pwPayload) || "Failed to change password");
+                }
+
+                // Clear password inputs after successful change
+                if (currentPasswordEl) currentPasswordEl.value = "";
+                if (newPasswordEl) newPasswordEl.value = "";
+                if (confirmPasswordEl) confirmPasswordEl.value = "";
             }
-
-            var pwRes = await authFetch(API_BASE + "/auth/me/password", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                    current_password: currentPassword,
-                    new_password: newPassword
-                })
-            });
-
-            if (!pwRes.ok) {
-                if (pwRes.status === 401 && typeof logout === "function") logout();
-                var pwPayload = null;
-                try { pwPayload = await pwRes.json(); } catch (err) { void err; }
-                throw new Error(getErrorDetail(pwPayload) || "Failed to change password");
-            }
-
-            // Clear password inputs after successful change
-            if (currentPasswordEl) currentPasswordEl.value = "";
-            if (newPasswordEl) newPasswordEl.value = "";
-            if (confirmPasswordEl) confirmPasswordEl.value = "";
         }
 
         var updateRes = await authFetch(API_BASE + "/auth/me", {
@@ -153,7 +157,9 @@ async function handleEditProfileSubmit(e) {
             throw new Error(getErrorDetail(updatePayload) || "Failed to update profile");
         }
 
-        window.location.assign("profile.html");
+        if (!skipRedirectAfterSave) {
+            window.location.assign("profile.html");
+        }
     } catch (err) {
         console.error("Error saving profile:", err);
         if (typeof window !== "undefined" && typeof window.alert === "function") {

--- a/frontend/edit-profile.js
+++ b/frontend/edit-profile.js
@@ -104,18 +104,6 @@ async function handleEditProfileSubmit(e) {
     };
 
     try {
-        var updateRes = await authFetch(API_BASE + "/auth/me", {
-            method: "PATCH",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(profilePayload)
-        });
-        if (!updateRes.ok) {
-            if (updateRes.status === 401 && typeof logout === "function") logout();
-            var updatePayload = null;
-            try { updatePayload = await updateRes.json(); } catch (err) { void err; }
-            throw new Error(getErrorDetail(updatePayload) || "Failed to update profile");
-        }
-
         var wantsPasswordChange = false;
         var currentPassword = currentPasswordEl ? currentPasswordEl.value : "";
         var newPassword = newPasswordEl ? newPasswordEl.value : "";
@@ -151,6 +139,18 @@ async function handleEditProfileSubmit(e) {
             if (currentPasswordEl) currentPasswordEl.value = "";
             if (newPasswordEl) newPasswordEl.value = "";
             if (confirmPasswordEl) confirmPasswordEl.value = "";
+        }
+
+        var updateRes = await authFetch(API_BASE + "/auth/me", {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(profilePayload)
+        });
+        if (!updateRes.ok) {
+            if (updateRes.status === 401 && typeof logout === "function") logout();
+            var updatePayload = null;
+            try { updatePayload = await updateRes.json(); } catch (err) { void err; }
+            throw new Error(getErrorDetail(updatePayload) || "Failed to update profile");
         }
 
         window.location.assign("profile.html");

--- a/frontend/edit-profile.test.js
+++ b/frontend/edit-profile.test.js
@@ -128,22 +128,22 @@ describe("edit profile page unit tests", () => {
         const fakeEvent = { preventDefault: jest.fn() };
 
         global.authFetch
-            // PATCH /auth/me
-            .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) })
             // POST /auth/me/password (204, no body)
-            .mockResolvedValueOnce({ ok: true, status: 204, json: () => Promise.resolve({}) });
+            .mockResolvedValueOnce({ ok: true, status: 204, json: () => Promise.resolve({}) })
+            // PATCH /auth/me
+            .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
 
         await handleEditProfileSubmit(fakeEvent);
 
         expect(global.authFetch).toHaveBeenNthCalledWith(
             1,
-            "http://localhost/auth/me",
-            expect.objectContaining({ method: "PATCH" })
+            "http://localhost/auth/me/password",
+            expect.objectContaining({ method: "POST" })
         );
         expect(global.authFetch).toHaveBeenNthCalledWith(
             2,
-            "http://localhost/auth/me/password",
-            expect.objectContaining({ method: "POST" })
+            "http://localhost/auth/me",
+            expect.objectContaining({ method: "PATCH" })
         );
         expect(assignMock).toHaveBeenCalledWith("profile.html");
     });

--- a/frontend/edit-profile.test.js
+++ b/frontend/edit-profile.test.js
@@ -3,7 +3,7 @@ global.requireAuth = jest.fn();
 global.authFetch = jest.fn();
 global.logout = jest.fn();
 
-const { loadEditProfile, handleEditProfileSubmit, setupEditProfile } = require("./edit-profile");
+const { loadEditProfile, handleEditProfileSubmit, setupEditProfile, uploadAvatarFromInput } = require("./edit-profile");
 
 describe("edit profile page unit tests", () => {
     let assignMock;
@@ -20,6 +20,10 @@ describe("edit profile page unit tests", () => {
             writable: true,
             configurable: true
         });
+
+        window.alert = jest.fn();
+        if (!global.URL) global.URL = {};
+        global.URL.createObjectURL = jest.fn(() => "blob:mock");
     });
 
     afterEach(() => {
@@ -36,13 +40,19 @@ describe("edit profile page unit tests", () => {
         document.body.innerHTML = `
             <input id="fullName" value="" />
             <input id="email" value="" />
+            <textarea id="bio"></textarea>
+            <input id="location" value="" />
+            <div><span class="material-symbols-outlined"></span><input type="file" id="avatar-upload" /></div>
         `;
         
         global.authFetch.mockResolvedValueOnce({
             ok: true,
             json: () => Promise.resolve({ 
                 display_name: "Test Edit User",
-                email: "test@example.com"
+                email: "test@example.com",
+                bio: "Hello",
+                location: "Istanbul",
+                avatar_url: null
             })
         });
 
@@ -50,14 +60,36 @@ describe("edit profile page unit tests", () => {
 
         expect(document.getElementById("fullName").value).toBe("Test Edit User");
         expect(document.getElementById("email").value).toBe("test@example.com");
+        expect(document.getElementById("bio").value).toBe("Hello");
+        expect(document.getElementById("location").value).toBe("Istanbul");
     });
     
-    test("handleEditProfileSubmit prevents default and redirects", () => {
+    test("handleEditProfileSubmit patches profile and redirects", async () => {
+        document.body.innerHTML = `
+            <form id="edit-profile-form"></form>
+            <input id="fullName" value="Name" />
+            <textarea id="bio">Bio</textarea>
+            <input id="location" value="Loc" />
+            <input id="currentPassword" value="" />
+            <input id="newPassword" value="" />
+            <input id="confirmPassword" value="" />
+        `;
+
         const fakeEvent = {
             preventDefault: jest.fn()
         };
-        handleEditProfileSubmit(fakeEvent);
+
+        global.authFetch.mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve({}) // PATCH /auth/me response body
+        });
+
+        await handleEditProfileSubmit(fakeEvent);
         expect(fakeEvent.preventDefault).toHaveBeenCalledTimes(1);
+        expect(global.authFetch).toHaveBeenCalledWith(
+            "http://localhost/auth/me",
+            expect.objectContaining({ method: "PATCH" })
+        );
         expect(assignMock).toHaveBeenCalledWith("profile.html");
     });
     
@@ -75,8 +107,92 @@ describe("edit profile page unit tests", () => {
         
         const form = document.getElementById("edit-profile-form");
         const submitEvent = new Event("submit", { bubbles: true, cancelable: true });
-        form.dispatchEvent(submitEvent);
+        // For submit, handleEditProfileSubmit will PATCH /auth/me
+        global.authFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
+        await form.dispatchEvent(submitEvent);
         
         expect(assignMock).toHaveBeenCalledWith("profile.html");
+    });
+
+    test("handleEditProfileSubmit calls password endpoint when password fields are provided", async () => {
+        document.body.innerHTML = `
+            <form id="edit-profile-form"></form>
+            <input id="fullName" value="Name" />
+            <textarea id="bio">Bio</textarea>
+            <input id="location" value="Loc" />
+            <input id="currentPassword" value="OldPass1!" />
+            <input id="newPassword" value="NewPass1!" />
+            <input id="confirmPassword" value="NewPass1!" />
+        `;
+
+        const fakeEvent = { preventDefault: jest.fn() };
+
+        global.authFetch
+            // PATCH /auth/me
+            .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) })
+            // POST /auth/me/password (204, no body)
+            .mockResolvedValueOnce({ ok: true, status: 204, json: () => Promise.resolve({}) });
+
+        await handleEditProfileSubmit(fakeEvent);
+
+        expect(global.authFetch).toHaveBeenNthCalledWith(
+            1,
+            "http://localhost/auth/me",
+            expect.objectContaining({ method: "PATCH" })
+        );
+        expect(global.authFetch).toHaveBeenNthCalledWith(
+            2,
+            "http://localhost/auth/me/password",
+            expect.objectContaining({ method: "POST" })
+        );
+        expect(assignMock).toHaveBeenCalledWith("profile.html");
+    });
+
+    test("handleEditProfileSubmit blocks password change when confirmation mismatches", async () => {
+        document.body.innerHTML = `
+            <form id="edit-profile-form"></form>
+            <input id="fullName" value="Name" />
+            <textarea id="bio">Bio</textarea>
+            <input id="location" value="Loc" />
+            <input id="currentPassword" value="OldPass1!" />
+            <input id="newPassword" value="NewPass1!" />
+            <input id="confirmPassword" value="Different1!" />
+        `;
+
+        const fakeEvent = { preventDefault: jest.fn() };
+
+        global.authFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
+
+        await handleEditProfileSubmit(fakeEvent);
+
+        // Only PATCH should have happened; password call should not.
+        expect(global.authFetch).toHaveBeenCalledTimes(1);
+        expect(window.alert).toHaveBeenCalled();
+        expect(assignMock).not.toHaveBeenCalledWith("profile.html");
+    });
+
+    test("uploadAvatarFromInput posts multipart to /auth/me/avatar", async () => {
+        document.body.innerHTML = `
+            <div>
+                <span class="material-symbols-outlined"></span>
+                <input type="file" id="avatar-upload" />
+            </div>
+        `;
+
+        const input = document.getElementById("avatar-upload");
+        const file = new File(["x"], "a.png", { type: "image/png" });
+        Object.defineProperty(input, "files", { value: [file] });
+
+        global.authFetch.mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve({ avatar_url: "http://cdn/new.png" })
+        });
+
+        await uploadAvatarFromInput();
+
+        expect(global.authFetch).toHaveBeenCalledWith(
+            "http://localhost/auth/me/avatar",
+            expect.objectContaining({ method: "POST" })
+        );
     });
 });

--- a/frontend/map.html
+++ b/frontend/map.html
@@ -47,6 +47,29 @@
         }
 
         function setProfileButton(user) {
+            // Prefer avatar when available.
+            var avatarUrl = user && user.avatar_url;
+            if (avatarUrl) {
+                var avatarImg = document.getElementById("profile-button-avatar");
+                if (avatarImg) {
+                    avatarImg.src = avatarUrl;
+                    avatarImg.classList.remove("hidden");
+                }
+
+                profileButtonIcon.classList.add("hidden");
+                profileButtonInitials.textContent = "";
+                profileButtonInitials.classList.add("hidden");
+                profileButtonInitials.classList.remove("inline-flex");
+                profileButton.setAttribute("aria-label", "Open account menu for " + getProfileLabel(user));
+                return;
+            }
+
+            var avatarImg = document.getElementById("profile-button-avatar");
+            if (avatarImg) {
+                avatarImg.removeAttribute("src");
+                avatarImg.classList.add("hidden");
+            }
+
             var initials = getProfileInitials(user);
 
             if (initials) {
@@ -357,6 +380,7 @@
                     <button id="btn-profile" type="button"
                         class="inline-flex h-11 min-w-11 items-center justify-center rounded-full border border-border bg-white px-2 text-textmain shadow-sm transition hover:bg-stone-50"
                         aria-label="Open account menu" aria-haspopup="menu" aria-expanded="false">
+                        <img id="profile-button-avatar" alt="" class="hidden h-9 w-9 rounded-full object-cover" />
                         <span id="profile-button-icon"
                             class="material-symbols-outlined text-[20px] leading-none">account_circle</span>
                         <span id="profile-button-initials"

--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -108,11 +108,11 @@
               <div class="text-xs text-textmuted font-semibold uppercase tracking-wider mt-1">Stories</div>
             </div>
             <div class="text-center p-4 bg-background rounded-xl border border-border/50">
-              <div class="text-2xl font-bold text-tertiary">0</div>
+              <div id="stat-comments" class="text-2xl font-bold text-tertiary">0</div>
               <div class="text-xs text-textmuted font-semibold uppercase tracking-wider mt-1">Comments</div>
             </div>
             <div class="text-center p-4 bg-background rounded-xl border border-border/50">
-              <div class="text-2xl font-bold text-emerald-600">0</div>
+              <div id="stat-likes" class="text-2xl font-bold text-emerald-600">0</div>
               <div class="text-xs text-textmuted font-semibold uppercase tracking-wider mt-1">Likes</div>
             </div>
             <a href="saved.html" class="text-center p-4 bg-background rounded-xl border border-border/50 hover:bg-white transition-colors block">

--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -52,15 +52,9 @@
   <header class="fixed top-0 left-0 right-0 z-[1000] bg-[#f8f3ea]/95 backdrop-blur-sm border-b border-border/30">
     <div class="flex justify-between items-center w-full px-8 py-4 max-w-screen-2xl mx-auto">
       <div class="flex items-center gap-8">
-        <h1 class="text-2xl font-bold font-headline text-textmain tracking-tight">Local History Map</h1>
-        <nav class="hidden md:flex items-center gap-6">
-          <a class="text-textmain font-medium hover:text-tertiary transition-colors" href="map.html">Map</a>
-          <a class="text-textmain font-medium hover:text-tertiary transition-colors"
-            href="story-detail.html">Archive</a>
-          <a class="text-textmain font-medium hover:text-tertiary transition-colors" href="story-create.html">Create
-            Story</a>
-          <a class="text-textmain font-medium hover:text-tertiary transition-colors" href="index.html">Login</a>
-        </nav>
+        <a href="map.html" class="text-2xl font-bold font-headline text-textmain tracking-tight hover:text-tertiary transition-colors">
+          Local History Map
+        </a>
       </div>
       <div class="flex items-center gap-3 sm:gap-4">
         <a href="profile.html"
@@ -77,18 +71,18 @@
     <header
       class="mb-12 flex flex-col gap-6 md:flex-row md:items-center bg-surface p-8 rounded-3xl border border-border shadow-soft">
       <div
-        class="w-24 h-24 md:w-32 md:h-32 bg-primary/20 rounded-full flex items-center justify-center border-4 border-white shadow-sm shrink-0">
+        id="profile-avatar"
+        class="w-24 h-24 md:w-32 md:h-32 bg-primary/20 rounded-full flex items-center justify-center border-4 border-white shadow-sm shrink-0 overflow-hidden">
         <span class="material-symbols-outlined text-5xl md:text-6xl text-primary"
           style="font-variation-settings: 'FILL' 1;">person</span>
       </div>
       <div class="flex-1">
         <h1 id="profile-name" class="font-headline text-3xl md:text-4xl font-extrabold leading-tight text-textmain">
           Loading...</h1>
-        <p class="mt-2 text-textmuted text-base">Historian and native of Galata. Passionate about preserving the
-          auditory and visual memories of old Istanbul.</p>
+        <p id="profile-bio" class="mt-2 text-textmuted text-base"></p>
         <div class="mt-4 flex flex-wrap gap-4 text-sm font-medium text-textmuted">
-          <span class="flex items-center gap-1"><span class="material-symbols-outlined text-[18px]">location_on</span>
-            Istanbul, Turkey</span>
+          <span id="profile-location" class="flex items-center gap-1"><span class="material-symbols-outlined text-[18px]">location_on</span>
+            </span>
           <span id="profile-joined" class="flex items-center gap-1"><span
               class="material-symbols-outlined text-[18px]">calendar_month</span> Joined...</span>
         </div>
@@ -158,7 +152,7 @@
 
   <script src="config.js"></script>
   <script src="auth.js"></script>
-  <script src="profile.js"></script>
+  <script src="profile.js?v=1"></script>
 </body>
 
 </html>

--- a/frontend/profile.js
+++ b/frontend/profile.js
@@ -78,6 +78,9 @@ async function loadUserStories(username) {
         const statStoriesEl = document.getElementById("stat-stories");
         if (statStoriesEl) statStoriesEl.textContent = myStories.length;
 
+        // Update likes/comments received on my stories (best-effort; may be slow for many stories)
+        void updateEngagementStatsForStories(myStories);
+
         // EĞER HİKAYE YOKSA: Senin orijinal güzel tasarımını göster
         if (myStories.length === 0) {
             container.innerHTML = `
@@ -115,6 +118,74 @@ async function loadUserStories(username) {
         console.error("Error loading user stories:", err);
         container.innerHTML = `<p class="text-red-500 text-center p-4">Error loading stories. Please try again.</p>`;
     }
+}
+
+async function updateEngagementStatsForStories(stories) {
+    var likesEl = document.getElementById("stat-likes");
+    var commentsEl = document.getElementById("stat-comments");
+    if (!likesEl && !commentsEl) return;
+
+    if (likesEl) likesEl.textContent = "…";
+    if (commentsEl) commentsEl.textContent = "…";
+
+    var totalLikes = 0;
+    var totalComments = 0;
+
+    // Limit concurrency to avoid spamming the API.
+    var concurrency = 4;
+    var index = 0;
+
+    async function worker() {
+        while (index < stories.length) {
+            var i = index;
+            index++;
+            var story = stories[i];
+            if (!story || !story.id) continue;
+
+            try {
+                // Likes: use story detail's like_count
+                if (likesEl) {
+                    var detailRes = await authFetch(API_BASE + "/stories/" + story.id);
+                    if (detailRes.ok) {
+                        var detail = await detailRes.json();
+                        if (detail && typeof detail.like_count === "number") {
+                            totalLikes += detail.like_count;
+                        }
+                    }
+                }
+            } catch (err) {
+                // ignore per-story failures
+                void err;
+            }
+
+            try {
+                // Comments: use comments list response total
+                if (commentsEl) {
+                    var commentsRes = await authFetch(API_BASE + "/stories/" + story.id + "/comments");
+                    if (commentsRes.ok) {
+                        var commentsData = await commentsRes.json();
+                        if (commentsData && typeof commentsData.total === "number") {
+                            totalComments += commentsData.total;
+                        } else if (commentsData && Array.isArray(commentsData.comments)) {
+                            totalComments += commentsData.comments.length;
+                        }
+                    }
+                }
+            } catch (err) {
+                void err;
+            }
+        }
+    }
+
+    var workers = [];
+    for (var w = 0; w < Math.min(concurrency, stories.length || 0); w++) {
+        workers.push(worker());
+    }
+
+    await Promise.all(workers);
+
+    if (likesEl) likesEl.textContent = String(totalLikes);
+    if (commentsEl) commentsEl.textContent = String(totalComments);
 }
 
 if (typeof document !== "undefined") {

--- a/frontend/profile.js
+++ b/frontend/profile.js
@@ -11,8 +11,29 @@ async function loadProfile() {
 
         var nameEl = document.getElementById("profile-name");
         var joinedEl = document.getElementById("profile-joined");
+        var bioEl = document.getElementById("profile-bio");
+        var locationEl = document.getElementById("profile-location");
+        var avatarEl = document.getElementById("profile-avatar");
 
         if (nameEl) nameEl.textContent = data.display_name || data.username;
+        if (bioEl) bioEl.textContent = data.bio || "";
+        if (locationEl) {
+            // Keep the icon span but replace the trailing text
+            var iconSpan = locationEl.querySelector(".material-symbols-outlined");
+            locationEl.textContent = "";
+            if (iconSpan) locationEl.appendChild(iconSpan);
+            var text = document.createTextNode(" " + (data.location || ""));
+            locationEl.appendChild(text);
+            if (!data.location) locationEl.style.display = "none";
+        }
+        if (avatarEl && data.avatar_url) {
+            avatarEl.style.backgroundImage = "url('" + data.avatar_url + "')";
+            avatarEl.style.backgroundSize = "cover";
+            avatarEl.style.backgroundPosition = "center";
+            avatarEl.style.backgroundRepeat = "no-repeat";
+            var icon = avatarEl.querySelector(".material-symbols-outlined");
+            if (icon) icon.style.opacity = "0";
+        }
         if (joinedEl && data.created_at) {
             var date = new Date(data.created_at);
             var options = { month: 'long', year: 'numeric' };

--- a/frontend/profile.test.js
+++ b/frontend/profile.test.js
@@ -42,13 +42,20 @@ describe("profile page unit tests", () => {
         document.body.innerHTML = `
             <h1 id="profile-name"></h1>
             <span id="profile-joined"></span>
+            <p id="profile-bio"></p>
+            <span id="profile-location"><span class="material-symbols-outlined">location_on</span></span>
+            <div id="profile-avatar"><span class="material-symbols-outlined">person</span></div>
         `;
         
         global.authFetch.mockResolvedValueOnce({
             ok: true,
             json: () => Promise.resolve({ 
                 display_name: "Test User",
-                created_at: "2026-04-07T00:00:00Z"
+                created_at: "2026-04-07T00:00:00Z",
+                bio: "My bio",
+                location: "Istanbul",
+                avatar_url: "http://cdn/avatar.png",
+                username: "testuser"
             })
         });
 
@@ -56,5 +63,118 @@ describe("profile page unit tests", () => {
 
         expect(document.getElementById("profile-name").textContent).toBe("Test User");
         expect(document.getElementById("profile-joined").innerHTML).toContain("Joined ");
+        expect(document.getElementById("profile-bio").textContent).toBe("My bio");
+        expect(document.getElementById("profile-location").textContent).toContain("Istanbul");
+    });
+
+    test("loadProfile hides location row when location is empty", async () => {
+        document.body.innerHTML = `
+            <h1 id="profile-name"></h1>
+            <span id="profile-joined"></span>
+            <p id="profile-bio"></p>
+            <span id="profile-location"><span class="material-symbols-outlined">location_on</span></span>
+            <div id="profile-avatar"><span class="material-symbols-outlined">person</span></div>
+            <div id="profile-stories-container"></div>
+            <div id="stat-saved"></div>
+            <div id="stat-stories"></div>
+        `;
+
+        global.authFetch
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve({
+                    username: "u1",
+                    created_at: "2026-04-07T00:00:00Z",
+                    location: ""
+                })
+            })
+            // /stories
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve({ stories: [] })
+            })
+            // /stories/saved
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve({ stories: [] })
+            });
+
+        await loadProfile();
+        expect(document.getElementById("profile-location").style.display).toBe("none");
+    });
+
+    test("loadProfile applies avatar image when avatar_url is present", async () => {
+        document.body.innerHTML = `
+            <h1 id="profile-name"></h1>
+            <span id="profile-joined"></span>
+            <p id="profile-bio"></p>
+            <span id="profile-location"><span class="material-symbols-outlined">location_on</span></span>
+            <div id="profile-avatar"><span class="material-symbols-outlined">person</span></div>
+            <div id="profile-stories-container"></div>
+            <div id="stat-saved"></div>
+            <div id="stat-stories"></div>
+        `;
+
+        global.authFetch
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve({
+                    username: "u1",
+                    created_at: "2026-04-07T00:00:00Z",
+                    avatar_url: "http://cdn/avatar.png"
+                })
+            })
+            // /stories
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve({ stories: [] })
+            })
+            // /stories/saved
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve({ stories: [] })
+            });
+
+        await loadProfile();
+        var avatar = document.getElementById("profile-avatar");
+        expect(avatar.style.backgroundImage).toContain("http://cdn/avatar.png");
+        var icon = avatar.querySelector(".material-symbols-outlined");
+        expect(icon.style.opacity).toBe("0");
+    });
+
+    test("loadProfile falls back to username when display_name is missing", async () => {
+        document.body.innerHTML = `
+            <h1 id="profile-name"></h1>
+            <span id="profile-joined"></span>
+            <p id="profile-bio"></p>
+            <span id="profile-location"><span class="material-symbols-outlined">location_on</span></span>
+            <div id="profile-avatar"><span class="material-symbols-outlined">person</span></div>
+            <div id="profile-stories-container"></div>
+            <div id="stat-saved"></div>
+            <div id="stat-stories"></div>
+        `;
+
+        global.authFetch
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve({
+                    username: "fallback_user",
+                    display_name: null,
+                    created_at: "2026-04-07T00:00:00Z"
+                })
+            })
+            // /stories
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve({ stories: [] })
+            })
+            // /stories/saved
+            .mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve({ stories: [] })
+            });
+
+        await loadProfile();
+        expect(document.getElementById("profile-name").textContent).toBe("fallback_user");
     });
 });

--- a/frontend/story-create.html
+++ b/frontend/story-create.html
@@ -222,6 +222,20 @@
 
               <audio id="recording-audio-preview" class="mt-4 hidden w-full" controls></audio>
 
+              <div id="recording-transcript-panel" class="mt-4 hidden rounded-xl border border-border bg-white/90 px-4 py-3">
+                <label for="recording-transcript-draft" class="block text-sm font-semibold text-textmain">Transcript</label>
+                <p class="mt-1 text-xs leading-5 text-textmuted">
+                  After you stop recording, the app requests a <strong>preview transcript</strong> from the server (when the preview API is available). You can edit the text below. After you publish, the audio is uploaded and a transcript is stored on the story; the story detail page may show &ldquo;Processing&hellip;&rdquo; until that finishes.
+                </p>
+                <p id="recording-transcript-status" class="mt-2 hidden text-xs font-semibold" role="status" aria-live="polite"></p>
+                <textarea
+                  id="recording-transcript-draft"
+                  rows="4"
+                  class="mt-2 w-full resize-y rounded-xl border border-border bg-white px-3 py-2 text-sm leading-6 text-textmain shadow-sm focus:border-primary focus:ring-primary disabled:cursor-not-allowed disabled:opacity-60"
+                  placeholder="Transcript appears here after the server responds, or type your own."
+                ></textarea>
+              </div>
+
               <div class="mt-4 grid gap-2 sm:grid-cols-3">
                 <button type="button" id="btn-start-recording" class="rounded-xl bg-primary px-4 py-3 text-sm font-semibold text-white transition hover:opacity-95">
                   Start
@@ -640,9 +654,87 @@
     }
   }
 
+  var transcriptionPreviewSeq = 0;
+
+  function setRecordingTranscriptStatus(message, tone) {
+    var el = document.getElementById("recording-transcript-status");
+    if (!el) return;
+    if (!message) {
+      el.classList.add("hidden");
+      el.textContent = "";
+      el.classList.remove("text-textmuted", "text-amber-800", "text-red-700");
+      return;
+    }
+    el.classList.remove("hidden");
+    el.textContent = message;
+    el.classList.remove("text-textmuted", "text-amber-800", "text-red-700");
+    if (tone === "error") {
+      el.classList.add("text-red-700");
+    } else if (tone === "warn") {
+      el.classList.add("text-amber-800");
+    } else {
+      el.classList.add("text-textmuted");
+    }
+  }
+
+  async function fetchTranscriptionPreviewForRecordedFile(file) {
+    transcriptionPreviewSeq++;
+    var seq = transcriptionPreviewSeq;
+    var textarea = document.getElementById("recording-transcript-draft");
+    setRecordingTranscriptStatus("Transcribing…", "info");
+    if (textarea) {
+      textarea.disabled = true;
+    }
+    try {
+      var formData = new FormData();
+      formData.append("file", file, file.name || "recording.webm");
+      var res = await authFetch(API_BASE + "/transcription/preview", {
+        method: "POST",
+        body: formData
+      });
+      if (seq !== transcriptionPreviewSeq) {
+        return;
+      }
+      if (!res.ok) {
+        if (res.status === 404) {
+          setRecordingTranscriptStatus(
+            "Transcription preview is not available on this server yet (404). Ask the backend team to add POST /transcription/preview—you can still type below or publish and wait for the transcript on the story page.",
+            "warn"
+          );
+        } else {
+          setRecordingTranscriptStatus(await readErrorMessage(res, "Could not transcribe this recording."), "error");
+        }
+        return;
+      }
+      var data = await res.json();
+      if (seq !== transcriptionPreviewSeq) {
+        return;
+      }
+      var t = data && data.transcript;
+      if (typeof t === "string" && t.trim().length > 0) {
+        if (textarea) {
+          textarea.value = t;
+        }
+        setRecordingTranscriptStatus("Transcript from server—you can edit below.", "info");
+      } else {
+        setRecordingTranscriptStatus("No text was detected in this recording. You can type your own transcript.", "warn");
+      }
+    } catch (err) {
+      if (seq !== transcriptionPreviewSeq) {
+        return;
+      }
+      setRecordingTranscriptStatus("Network error while transcribing. Check your connection and try recording again.", "error");
+    } finally {
+      if (seq === transcriptionPreviewSeq && textarea) {
+        textarea.disabled = false;
+      }
+    }
+  }
+
   function clearRecordingPreview() {
     var audioPreview = document.getElementById("recording-audio-preview");
 
+    transcriptionPreviewSeq++;
     if (recordingPreviewUrl) {
       URL.revokeObjectURL(recordingPreviewUrl);
       recordingPreviewUrl = null;
@@ -650,6 +742,15 @@
 
     audioPreview.removeAttribute("src");
     audioPreview.classList.add("hidden");
+
+    var transcriptPanel = document.getElementById("recording-transcript-panel");
+    var transcriptDraft = document.getElementById("recording-transcript-draft");
+    if (transcriptPanel) transcriptPanel.classList.add("hidden");
+    if (transcriptDraft) {
+      transcriptDraft.value = "";
+      transcriptDraft.disabled = false;
+    }
+    setRecordingTranscriptStatus("", null);
   }
 
   function showRecordedPreview(file) {
@@ -659,6 +760,11 @@
     recordingPreviewUrl = URL.createObjectURL(file);
     audioPreview.src = recordingPreviewUrl;
     audioPreview.classList.remove("hidden");
+
+    var transcriptPanel = document.getElementById("recording-transcript-panel");
+    var transcriptDraft = document.getElementById("recording-transcript-draft");
+    if (transcriptDraft) transcriptDraft.value = "";
+    if (transcriptPanel) transcriptPanel.classList.remove("hidden");
   }
 
   async function startRecording() {
@@ -712,6 +818,7 @@
         updateFileList();
         setStartRecordingLabel("Record Again");
         setRecordingStatus("Recording ready. Preview it here, then publish the story to upload it.", false);
+        void fetchTranscriptionPreviewForRecordedFile(recordedFile);
       });
 
       recorder.start();

--- a/frontend/story-detail.html
+++ b/frontend/story-detail.html
@@ -200,6 +200,7 @@
 <script src="comments.js"></script>
 <script src="auth.js"></script>
 <script src="saves.js"></script>
+<script src="story-transcript.js"></script>
 <script>
   // Initialize mini-map with arbitrary center initially
   var detailMap = L.map("detail-map", {
@@ -217,7 +218,142 @@
 
   const urlParams = new URLSearchParams(window.location.search);
   const storyId = urlParams.get('id');
-  
+
+  var TRANSCRIPT_POLL_INTERVAL_MS = 2000;
+  var TRANSCRIPT_POLL_MAX_ATTEMPTS = 30;
+  var transcriptPollTimer = null;
+  var transcriptPollAttempts = 0;
+
+  function renderStoryMedia(story) {
+    var pollExhausted = transcriptPollAttempts >= TRANSCRIPT_POLL_MAX_ATTEMPTS;
+    var mediaContainer = document.getElementById('story-media');
+    mediaContainer.innerHTML = "";
+
+    if (!story.media_files || story.media_files.length === 0) {
+      return;
+    }
+
+    var images = story.media_files.filter(function (m) { return m.media_type === "image"; });
+    if (images.length > 0) {
+      document.getElementById('story-cover').style.backgroundImage = "url('" + images[0].media_url + "')";
+    }
+
+    story.media_files.forEach(function (m) {
+      if (m.media_type === "image") {
+        var img = document.createElement("img");
+        img.src = m.media_url;
+        img.className = "w-full rounded-2xl border border-border shadow-sm object-cover";
+        img.style.maxHeight = "300px";
+        img.alt = m.alt_text || "";
+        mediaContainer.appendChild(img);
+      } else if (m.media_type === "video") {
+        var vid = document.createElement("video");
+        vid.src = m.media_url;
+        vid.setAttribute("controls", "controls");
+        vid.className = "w-full rounded-2xl border border-border shadow-sm object-cover";
+        vid.style.maxHeight = "300px";
+        mediaContainer.appendChild(vid);
+      } else if (m.media_type === "audio") {
+        var wrap = document.createElement("div");
+        wrap.className = "p-4 bg-background border border-border rounded-xl w-full flex flex-col gap-2";
+
+        var icon = document.createElement("span");
+        icon.className = "text-sm font-semibold material-symbols-outlined text-primary";
+        icon.setAttribute("aria-hidden", "true");
+        icon.textContent = "audio";
+
+        var aud = document.createElement("audio");
+        aud.src = m.media_url;
+        aud.setAttribute("controls", "controls");
+        aud.className = "w-full";
+
+        var details = document.createElement("details");
+        details.className = "mt-2 rounded-xl border border-border/80 bg-white/70";
+
+        var summary = document.createElement("summary");
+        summary.className =
+          "cursor-pointer select-none px-3 py-2 text-sm font-semibold text-textmain";
+        summary.textContent = "Transcript";
+
+        var bodyWrap = document.createElement("div");
+        bodyWrap.className = "px-3 pb-3";
+
+        var inner = document.createElement("div");
+        if (typeof StoryTranscript !== "undefined") {
+          var state = StoryTranscript.transcriptDisplayState(m, pollExhausted);
+          StoryTranscript.applyTranscriptBody(inner, state);
+        } else {
+          inner.textContent = m.transcript || "Transcript unavailable";
+          inner.className = "mt-2 text-sm text-textmain whitespace-pre-wrap break-words";
+        }
+
+        bodyWrap.appendChild(inner);
+        details.appendChild(summary);
+        details.appendChild(bodyWrap);
+        wrap.appendChild(icon);
+        wrap.appendChild(aud);
+        wrap.appendChild(details);
+        mediaContainer.appendChild(wrap);
+      }
+    });
+  }
+
+  function startTranscriptPolling(id, mediaFiles) {
+    if (transcriptPollTimer) {
+      clearInterval(transcriptPollTimer);
+      transcriptPollTimer = null;
+    }
+    transcriptPollAttempts = 0;
+    if (typeof StoryTranscript === "undefined" || !StoryTranscript.needsAudioTranscriptPoll(mediaFiles)) {
+      return;
+    }
+    transcriptPollTimer = setInterval(function () {
+      transcriptPollAttempts++;
+      fetch(API_BASE + "/stories/" + id)
+        .then(function (res) { return res.json(); })
+        .then(function (story) {
+          renderStoryMedia(story);
+          var stillNeed =
+            typeof StoryTranscript !== "undefined" &&
+            StoryTranscript.needsAudioTranscriptPoll(story.media_files);
+          var timedOut = transcriptPollAttempts >= TRANSCRIPT_POLL_MAX_ATTEMPTS;
+          if (!stillNeed || timedOut) {
+            if (transcriptPollTimer) {
+              clearInterval(transcriptPollTimer);
+              transcriptPollTimer = null;
+            }
+          }
+        })
+        .catch(function () { /* ignore transient poll errors */ });
+    }, TRANSCRIPT_POLL_INTERVAL_MS);
+  }
+
+  function applyStoryDetail(story) {
+    document.getElementById('story-title').textContent = story.title || "Untitled";
+    document.getElementById('story-summary').textContent = story.summary || "";
+    document.getElementById('story-author').innerHTML = 'by ' + (story.author || "Unknown");
+    document.getElementById('story-date').textContent = story.date_label || "No Date";
+    document.getElementById('story-location').textContent = story.place_name || "Istanbul";
+    document.getElementById('story-content').textContent = story.content || "No content available.";
+
+    if (story.latitude && story.longitude) {
+      detailMap.setView([story.latitude, story.longitude], 15);
+      L.marker([story.latitude, story.longitude])
+        .addTo(detailMap)
+        .bindPopup('<div style="font-family:Inter,sans-serif;"><strong style="font-size:13px;">' + story.title + '</strong><br><span style="font-size:11px;color:#5f584c;">' + (story.place_name || "") + '</span></div>')
+        .openPopup();
+    } else {
+      document.getElementById('detail-map').parentElement.style.display = 'none';
+    }
+
+    renderStoryMedia(story);
+    startTranscriptPolling(String(story.id || storyId), story.media_files);
+
+    setupComments(API_BASE, String(story.id || storyId));
+    var likeSeed = { like_count: typeof story.like_count === "number" ? story.like_count : 0 };
+    setupLikes(API_BASE, String(story.id || storyId), likeSeed);
+  }
+
   if (!storyId) {
     document.getElementById('story-title').textContent = "Story not found";
     document.getElementById('story-summary').textContent = "No ID provided in the URL.";
@@ -227,49 +363,9 @@
     }
 
     fetch(API_BASE + "/stories/" + storyId)
-      .then(res => res.json())
-      .then(story => {
-          document.getElementById('story-title').textContent = story.title || "Untitled";
-          document.getElementById('story-summary').textContent = story.summary || "";
-          document.getElementById('story-author').innerHTML = 'by ' + (story.author || "Unknown");
-          document.getElementById('story-date').textContent = story.date_label || "No Date";
-          document.getElementById('story-location').textContent = story.place_name || "Istanbul";
-          document.getElementById('story-content').textContent = story.content || "No content available.";
-          
-          if (story.latitude && story.longitude) {
-            detailMap.setView([story.latitude, story.longitude], 15);
-            L.marker([story.latitude, story.longitude])
-              .addTo(detailMap)
-              .bindPopup('<div style="font-family:Inter,sans-serif;"><strong style="font-size:13px;">' + story.title + '</strong><br><span style="font-size:11px;color:#5f584c;">' + (story.place_name || "") + '</span></div>')
-              .openPopup();
-          } else {
-             document.getElementById('detail-map').parentElement.style.display = 'none';
-          }
-          
-          if (story.media_files && story.media_files.length > 0) {
-             const images = story.media_files.filter(m => m.media_type === "image");
-             if (images.length > 0) {
-                 document.getElementById('story-cover').style.backgroundImage = "url('" + images[0].media_url + "')";
-             }
-             
-             let mediaHtml = "";
-             story.media_files.forEach(m => {
-                 if (m.media_type === "image") {
-                     mediaHtml += '<img src="' + m.media_url + '" class="w-full rounded-2xl border border-border shadow-sm object-cover" style="max-height: 300px;">';
-                 } else if (m.media_type === "video") {
-                     mediaHtml += '<video src="' + m.media_url + '" controls class="w-full rounded-2xl border border-border shadow-sm object-cover" style="max-height: 300px;"></video>';
-                 } else if (m.media_type === "audio") {
-                     mediaHtml += '<div class="p-4 bg-background border border-border rounded-xl w-full flex flex-col gap-2"><span class="text-sm font-semibold material-symbols-outlined text-primary">audio</span><audio src="' + m.media_url + '" controls class="w-full"></audio></div>';
-                 }
-             });
-             document.getElementById('story-media').innerHTML = mediaHtml;
-          }
-
-          setupComments(API_BASE, String(story.id || storyId));
-          var likeSeed = { like_count: typeof story.like_count === "number" ? story.like_count : 0 };
-          setupLikes(API_BASE, String(story.id || storyId), likeSeed);
-      })
-      .catch(err => {
+      .then(function (res) { return res.json(); })
+      .then(applyStoryDetail)
+      .catch(function (err) {
          console.error("Error loading story details:", err);
          document.getElementById('story-title').textContent = "Failed to load story";
          document.getElementById('story-summary').textContent = "There was a problem communicating with the server.";

--- a/frontend/story-detail.html
+++ b/frontend/story-detail.html
@@ -53,6 +53,11 @@
     }
 
     @keyframes like-pop {
+      0% { transform: scale(1); }
+      55% { transform: scale(1.08); }
+      100% { transform: scale(1); }
+    }
+
     .material-symbols-outlined {
       font-variation-settings: "FILL" 0, "wght" 400, "GRAD" 0, "opsz" 24;
     }
@@ -65,8 +70,7 @@
     }
 
     @media (prefers-reduced-motion: reduce) {
-      .like-button[data-animating="true"] { animation: none; }
-    @media (prefers-reduced-motion: reduce) {
+      .like-button[data-animating="true"],
       .save-button[data-animating="true"] { animation: none; }
     }
   </style>
@@ -198,7 +202,6 @@
 <script src="likes.js"></script>
 <script src="config.js"></script>
 <script src="comments.js"></script>
-<script src="auth.js"></script>
 <script src="saves.js"></script>
 <script src="story-transcript.js"></script>
 <script>

--- a/frontend/story-transcript.js
+++ b/frontend/story-transcript.js
@@ -1,0 +1,91 @@
+/**
+ * Helpers for story audio transcript display and polling (frontend-only).
+ */
+
+function mediaTypeKey(media) {
+    if (!media || media.media_type == null) {
+        return "";
+    }
+    return String(media.media_type).toLowerCase();
+}
+
+function isAudioMedia(media) {
+    return mediaTypeKey(media) === "audio";
+}
+
+/**
+ * @param {Array<{ media_type?: string, transcript?: string | null }>|null|undefined} mediaFiles
+ * @returns {boolean}
+ */
+function needsAudioTranscriptPoll(mediaFiles) {
+    if (!mediaFiles || !mediaFiles.length) {
+        return false;
+    }
+    for (var i = 0; i < mediaFiles.length; i++) {
+        var m = mediaFiles[i];
+        if (!isAudioMedia(m)) {
+            continue;
+        }
+        var t = m.transcript;
+        if (t === null || t === undefined) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * @param {{ transcript?: string | null }} media - audio item
+ * @param {boolean} pollExhausted
+ * @returns {{ kind: 'text', text: string } | { kind: 'processing' } | { kind: 'unavailable' }}
+ */
+function transcriptDisplayState(media, pollExhausted) {
+    var t = media && media.transcript;
+    if (typeof t === "string" && t.trim().length > 0) {
+        return { kind: "text", text: t };
+    }
+    if (t === null || t === undefined) {
+        if (!pollExhausted) {
+            return { kind: "processing" };
+        }
+        return { kind: "unavailable" };
+    }
+    return { kind: "unavailable" };
+}
+
+/**
+ * @param {HTMLElement} el
+ * @param {{ kind: 'text', text: string } | { kind: 'processing' } | { kind: 'unavailable' }} state
+ */
+function applyTranscriptBody(el, state) {
+    el.textContent = "";
+    el.className =
+        "mt-2 text-sm leading-6 border-t border-border/60 pt-2 " +
+        "whitespace-pre-wrap break-words";
+    if (state.kind === "text") {
+        el.textContent = state.text;
+        el.classList.add("text-textmain");
+    } else if (state.kind === "processing") {
+        el.textContent = "Processing…";
+        el.classList.add("text-textmuted", "italic");
+    } else {
+        el.textContent = "Transcript unavailable";
+        el.classList.add("text-textmuted");
+    }
+}
+
+var StoryTranscript = {
+    mediaTypeKey: mediaTypeKey,
+    isAudioMedia: isAudioMedia,
+    needsAudioTranscriptPoll: needsAudioTranscriptPoll,
+    transcriptDisplayState: transcriptDisplayState,
+    applyTranscriptBody: applyTranscriptBody
+};
+
+if (typeof window !== "undefined") {
+    window.StoryTranscript = StoryTranscript;
+}
+
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = StoryTranscript;
+}

--- a/frontend/story-transcript.test.js
+++ b/frontend/story-transcript.test.js
@@ -1,0 +1,85 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const {
+    needsAudioTranscriptPoll,
+    transcriptDisplayState,
+    mediaTypeKey,
+    applyTranscriptBody
+} = require("./story-transcript");
+
+describe("story transcript helpers", () => {
+    test("mediaTypeKey normalizes to lowercase", () => {
+        expect(mediaTypeKey({ media_type: "AUDIO" })).toBe("audio");
+        expect(mediaTypeKey({ media_type: "audio" })).toBe("audio");
+        expect(mediaTypeKey(null)).toBe("");
+    });
+
+    test("needsAudioTranscriptPoll returns false for empty or missing lists", () => {
+        expect(needsAudioTranscriptPoll(null)).toBe(false);
+        expect(needsAudioTranscriptPoll(undefined)).toBe(false);
+        expect(needsAudioTranscriptPoll([])).toBe(false);
+    });
+
+    test("needsAudioTranscriptPoll returns true when any audio item has null transcript", () => {
+        expect(
+            needsAudioTranscriptPoll([
+                { media_type: "audio", transcript: null },
+                { media_type: "image", transcript: null }
+            ])
+        ).toBe(true);
+    });
+
+    test("needsAudioTranscriptPoll treats media_type case-insensitively", () => {
+        expect(
+            needsAudioTranscriptPoll([{ media_type: "AUDIO", transcript: null }])
+        ).toBe(true);
+    });
+
+    test("needsAudioTranscriptPoll returns true when transcript is undefined", () => {
+        expect(needsAudioTranscriptPoll([{ media_type: "audio" }])).toBe(true);
+    });
+
+    test("needsAudioTranscriptPoll returns false when all audio items have a transcript string", () => {
+        expect(
+            needsAudioTranscriptPoll([
+                { media_type: "audio", transcript: "Hello" },
+                { media_type: "audio", transcript: "World" }
+            ])
+        ).toBe(false);
+    });
+
+    test("transcriptDisplayState shows transcript text when non-empty", () => {
+        expect(
+            transcriptDisplayState({ transcript: "  hi  " }, false)
+        ).toEqual({ kind: "text", text: "  hi  " });
+    });
+
+    test("transcriptDisplayState shows unavailable for empty string", () => {
+        expect(transcriptDisplayState({ transcript: "" }, false)).toEqual({
+            kind: "unavailable"
+        });
+        expect(transcriptDisplayState({ transcript: "   " }, false)).toEqual({
+            kind: "unavailable"
+        });
+    });
+
+    test("transcriptDisplayState shows Processing when null and poll not exhausted", () => {
+        expect(transcriptDisplayState({ transcript: null }, false)).toEqual({
+            kind: "processing"
+        });
+    });
+
+    test("transcriptDisplayState shows unavailable when null but poll exhausted", () => {
+        expect(transcriptDisplayState({ transcript: null }, true)).toEqual({
+            kind: "unavailable"
+        });
+    });
+
+    test("applyTranscriptBody sets text for processing state", () => {
+        const el = document.createElement("div");
+        applyTranscriptBody(el, { kind: "processing" });
+        expect(el.textContent).toBe("Processing…");
+    });
+});


### PR DESCRIPTION
## Description
Connects the frontend edit-profile + profile pages to the newly implemented profile management APIs. Profile data (bio, location, avatar) now loads/saves correctly, the map top-bar shows the user avatar, and unit test coverage is expanded for these flows.

## Related Issue(s)
- Closes #313
- Closes #245 

## Changes

| File | Change |
|------|--------|
| `frontend/edit-profile.js` | Wired form submit to `PATCH /auth/me`, password change to `POST /auth/me/password`, and avatar upload to `POST /auth/me/avatar`; loads bio/location/avatar from `GET /auth/me`. |
| `frontend/edit-profile.test.js` | Added tests for password-change flow, mismatch handling, and avatar upload request. |
| `frontend/profile.html` | Removed mocked bio/location, added IDs for dynamic fields, removed top nav links, and made title link to `map.html` (also cache-busted `profile.js`). |
| `frontend/profile.js` | Rendered bio/location/avatar from `GET /auth/me`. |
| `frontend/profile.test.js` | Added tests for avatar rendering, location hiding, and username fallback. |
| `frontend/map.html` | Show user avatar in the top-bar profile button using `avatar_url` (img-based rendering). |

## Checklist
- [x] All tests passed
- [x] I have self-reviewed my own code
- [x] I have requested at least 1 reviewer