### PR TITLE
Add mobile Appium E2E skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ android-sdk/
 playwright-report/
 test-results/
 uat-report.xml
+
+# Appium
+frontend/tests/mobile-e2e/reports/

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -93,6 +93,23 @@ module.exports = [
         },
     },
     {
+        files: ["tests/mobile-e2e/**/*.js"],
+        languageOptions: {
+            sourceType: "commonjs",
+            globals: {
+                require: "readonly",
+                exports: "readonly",
+                module: "readonly",
+                process: "readonly",
+                __dirname: "readonly",
+                describe: "readonly",
+                it: "readonly",
+                expect: "readonly",
+                browser: "readonly",
+            },
+        },
+    },
+    {
         files: ["**/*.mjs"],
         languageOptions: {
             sourceType: "module",

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
     testEnvironment: "jsdom",
-    testPathIgnorePatterns: ["/node_modules/", "/tests/uat/"],
+    testPathIgnorePatterns: ["/node_modules/", "/tests/uat/", "/tests/mobile-e2e/"],
     reporters: [
         "default",
         ["jest-html-reporter", { outputPath: "test-report.html", pageTitle: "Frontend Unit Tests" }],

--- a/frontend/tests/mobile-e2e/.env.example
+++ b/frontend/tests/mobile-e2e/.env.example
@@ -1,0 +1,4 @@
+ANDROID_APP_PATH=../../android/app/build/outputs/apk/debug/app-debug.apk
+APPIUM_SERVER_URL=http://127.0.0.1:4723
+MOBILE_API_BASE_URL=http://10.0.2.2:8000
+ANDROID_DEVICE_NAME=Pixel_6_API_35

--- a/frontend/tests/mobile-e2e/README.md
+++ b/frontend/tests/mobile-e2e/README.md
@@ -1,0 +1,66 @@
+# Mobile E2E Testing
+
+This directory contains the local-only Appium skeleton for Android APK E2E tests. It is intentionally small: one smoke test verifies that Appium can launch the APK, and the Lab 9/web UAT scenarios are represented as skipped placeholders until each flow is ready to automate.
+
+## Frameworks
+
+- Appium 2
+- WebdriverIO
+- Mocha
+- UiAutomator2 Android driver
+
+## Environment
+
+Copy `.env.example` to `.env` and adjust the values for your machine:
+
+```text
+ANDROID_APP_PATH=../../android/app/build/outputs/apk/debug/app-debug.apk
+APPIUM_SERVER_URL=http://127.0.0.1:4723
+MOBILE_API_BASE_URL=http://10.0.2.2:8000
+ANDROID_DEVICE_NAME=Pixel_6_API_35
+```
+
+`MOBILE_API_BASE_URL` is used when preparing Capacitor web assets before the APK is built. Android emulators should usually call the host machine through `10.0.2.2`.
+
+## Local Run
+
+From `frontend/tests/mobile-e2e`:
+
+```powershell
+npm install
+npm run appium:install-driver
+npm run appium
+npm test
+```
+
+In another terminal, prepare and build the APK before running the tests:
+
+```powershell
+cd frontend
+$env:MOBILE_API_BASE_URL="http://10.0.2.2:8000"
+npm run capacitor:sync
+cd android
+.\gradlew.bat assembleDebug
+```
+
+Start the Android emulator named by `ANDROID_DEVICE_NAME` before running `npm test`.
+
+## Scope
+
+The first mobile E2E scope mirrors the Lab 9/current web UAT scenarios:
+
+- `TC_AUTH_1` - user registration and login baseline
+- `TC_AUTH_2` - Google OAuth login
+- `TC_TAG_1` - keyword tagging on story creation
+- `TC_MEDIA_2` - audio transcription review before posting
+- `TC_TAG_2` - keyword tagging UI during story creation
+- `TC_STORY_5` - anonymous story sharing
+- `TC_MAP_2` - multi-location story display on map
+- `TC_DASH_1` - user dashboard view count
+- `TC_BADGE_1` - first post badge awarded
+
+Keep unstable or dependency-blocked flows skipped until the related app behavior is available on `dev`.
+
+## Selector Strategy
+
+Prefer shared `data-testid` selectors in the Capacitor WebView when the same UI exists on web and mobile. Use native selectors only for Android system UI or native permission flows.

--- a/frontend/tests/mobile-e2e/helpers/context.js
+++ b/frontend/tests/mobile-e2e/helpers/context.js
@@ -1,0 +1,24 @@
+async function getAvailableContexts() {
+  if (typeof browser.getContexts !== 'function') {
+    return [];
+  }
+
+  return browser.getContexts();
+}
+
+async function switchToFirstWebviewContext() {
+  const contexts = await getAvailableContexts();
+  const webviewContext = contexts.find((contextName) => String(contextName).startsWith('WEBVIEW'));
+
+  if (!webviewContext) {
+    return null;
+  }
+
+  await browser.switchContext(webviewContext);
+  return webviewContext;
+}
+
+module.exports = {
+  getAvailableContexts,
+  switchToFirstWebviewContext,
+};

--- a/frontend/tests/mobile-e2e/helpers/env.js
+++ b/frontend/tests/mobile-e2e/helpers/env.js
@@ -1,0 +1,42 @@
+const path = require('node:path');
+
+require('dotenv').config({ path: path.resolve(__dirname, '..', '.env') });
+
+const requiredEnv = [
+  'ANDROID_APP_PATH',
+  'APPIUM_SERVER_URL',
+  'MOBILE_API_BASE_URL',
+  'ANDROID_DEVICE_NAME',
+];
+
+function requireEnv(name) {
+  const value = process.env[name];
+
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+
+  return value;
+}
+
+function resolveAppPath(appPath) {
+  if (path.isAbsolute(appPath)) {
+    return appPath;
+  }
+
+  return path.resolve(__dirname, '..', appPath);
+}
+
+function getMobileEnv() {
+  const env = Object.fromEntries(requiredEnv.map((name) => [name, requireEnv(name)]));
+
+  return {
+    ...env,
+    ANDROID_APP_PATH: resolveAppPath(env.ANDROID_APP_PATH),
+  };
+}
+
+module.exports = {
+  getMobileEnv,
+  requiredEnv,
+};

--- a/frontend/tests/mobile-e2e/package.json
+++ b/frontend/tests/mobile-e2e/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "local-history-mobile-e2e",
+  "private": true,
+  "description": "Local-only Appium E2E skeleton for the Local History Story Map Android APK.",
+  "scripts": {
+    "test": "wdio run wdio.conf.js",
+    "test:smoke": "wdio run wdio.conf.js --spec specs/smoke.spec.js",
+    "appium": "appium",
+    "appium:install-driver": "appium driver install uiautomator2"
+  },
+  "devDependencies": {
+    "@wdio/cli": "^9.20.0",
+    "@wdio/junit-reporter": "^9.20.0",
+    "@wdio/local-runner": "^9.20.0",
+    "@wdio/mocha-framework": "^9.20.0",
+    "@wdio/spec-reporter": "^9.20.0",
+    "appium": "^2.19.0",
+    "appium-uiautomator2-driver": "^4.2.9",
+    "dotenv": "^17.2.3",
+    "webdriverio": "^9.20.0"
+  }
+}

--- a/frontend/tests/mobile-e2e/specs/lab9-placeholders.spec.js
+++ b/frontend/tests/mobile-e2e/specs/lab9-placeholders.spec.js
@@ -1,0 +1,19 @@
+describe('Lab 9 mobile E2E scenario placeholders', () => {
+  it.skip('TC_AUTH_1 - user registration and login baseline', async () => {});
+
+  it.skip('TC_AUTH_2 - Google OAuth login', async () => {});
+
+  it.skip('TC_TAG_1 - keyword tagging on story creation', async () => {});
+
+  it.skip('TC_MEDIA_2 - audio transcription review before posting', async () => {});
+
+  it.skip('TC_TAG_2 - keyword tagging UI during story creation', async () => {});
+
+  it.skip('TC_STORY_5 - anonymous story sharing', async () => {});
+
+  it.skip('TC_MAP_2 - multi-location story display on map', async () => {});
+
+  it.skip('TC_DASH_1 - user dashboard view count', async () => {});
+
+  it.skip('TC_BADGE_1 - first post badge awarded', async () => {});
+});

--- a/frontend/tests/mobile-e2e/specs/smoke.spec.js
+++ b/frontend/tests/mobile-e2e/specs/smoke.spec.js
@@ -1,0 +1,23 @@
+const assert = require('node:assert/strict');
+const { getAvailableContexts, switchToFirstWebviewContext } = require('../helpers/context');
+
+describe('TC_MOBILE_SMOKE - Android APK launch', () => {
+  it('opens the app and exposes at least one automation context', async () => {
+    const contexts = await getAvailableContexts();
+
+    assert.ok(Array.isArray(contexts), 'Appium should return automation contexts');
+    assert.ok(contexts.length > 0, 'expected at least one native or webview context');
+  });
+
+  it('can switch to the Capacitor WebView when it is available', async function () {
+    const webviewContext = await switchToFirstWebviewContext();
+
+    if (!webviewContext) {
+      return this.skip();
+    }
+
+    const title = await browser.getTitle();
+
+    assert.equal(typeof title, 'string');
+  });
+});

--- a/frontend/tests/mobile-e2e/wdio.conf.js
+++ b/frontend/tests/mobile-e2e/wdio.conf.js
@@ -1,0 +1,46 @@
+const { getMobileEnv } = require('./helpers/env');
+
+const mobileEnv = getMobileEnv();
+const appiumUrl = new URL(mobileEnv.APPIUM_SERVER_URL);
+
+exports.config = {
+  runner: 'local',
+  hostname: appiumUrl.hostname,
+  port: Number(appiumUrl.port || 4723),
+  path: appiumUrl.pathname === '/' ? '/' : appiumUrl.pathname,
+
+  specs: ['./specs/**/*.spec.js'],
+  exclude: [],
+  maxInstances: 1,
+
+  capabilities: [
+    {
+      platformName: 'Android',
+      'appium:automationName': 'UiAutomator2',
+      'appium:deviceName': mobileEnv.ANDROID_DEVICE_NAME,
+      'appium:app': mobileEnv.ANDROID_APP_PATH,
+      'appium:autoGrantPermissions': true,
+      'appium:newCommandTimeout': 120,
+    },
+  ],
+
+  logLevel: 'info',
+  bail: 0,
+  waitforTimeout: 10_000,
+  connectionRetryTimeout: 120_000,
+  connectionRetryCount: 1,
+
+  framework: 'mocha',
+  reporters: [
+    'spec',
+    ['junit', {
+      outputDir: './reports',
+      outputFileFormat: () => 'mobile-e2e-report.xml',
+    }],
+  ],
+
+  mochaOpts: {
+    ui: 'bdd',
+    timeout: 60_000,
+  },
+};


### PR DESCRIPTION
## Summary

- add local-only Appium/WebdriverIO skeleton under frontend/tests/mobile-e2e
- add env example, helper modules, smoke test, and skipped Lab 9 scenario placeholders
- document local APK/emulator/Appium setup and ignore generated mobile E2E reports

## Related issue

- Depends on #318

## Verification

- node --check frontend/tests/mobile-e2e/wdio.conf.js
- node --check frontend/tests/mobile-e2e/helpers/env.js
- node --check frontend/tests/mobile-e2e/helpers/context.js
- node --check frontend/tests/mobile-e2e/specs/smoke.spec.js
- node --check frontend/tests/mobile-e2e/specs/lab9-placeholders.spec.js
- parsed frontend/tests/mobile-e2e/package.json successfully

Appium tests were not run because the APK, emulator, and Appium server are local-only prerequisites.
