### PR TITLE
feat: add multi-location story support

### DIFF
--- a/backend/alembic/versions/20260510_0018_add_story_locations.py
+++ b/backend/alembic/versions/20260510_0018_add_story_locations.py
@@ -8,8 +8,9 @@ Create Date: 2026-05-10 00:00:00
 from typing import Sequence, Union
 
 import sqlalchemy as sa
-from alembic import op
 from sqlalchemy.dialects import postgresql
+
+from alembic import op
 
 revision: str = "20260510_0018"
 down_revision: Union[str, Sequence[str], None] = "20260510_0017"

--- a/backend/alembic/versions/20260510_0018_add_story_locations.py
+++ b/backend/alembic/versions/20260510_0018_add_story_locations.py
@@ -1,0 +1,70 @@
+"""Add story_locations table and backfill from existing story lat/lng.
+
+Revision ID: 20260510_0018
+Revises: 20260510_0017
+Create Date: 2026-05-10 00:00:00
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "20260510_0018"
+down_revision: Union[str, Sequence[str], None] = "20260510_0017"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "story_locations",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("story_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("latitude", sa.Float(), nullable=False),
+        sa.Column("longitude", sa.Float(), nullable=False),
+        sa.Column("label", sa.String(length=255), nullable=True),
+        sa.Column("sort_order", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.CheckConstraint(
+            "latitude >= -90.0 AND latitude <= 90.0",
+            name="ck_story_locations_latitude",
+        ),
+        sa.CheckConstraint(
+            "longitude >= -180.0 AND longitude <= 180.0",
+            name="ck_story_locations_longitude",
+        ),
+        sa.ForeignKeyConstraint(["story_id"], ["stories.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_story_locations_story_id", "story_locations", ["story_id"])
+    op.create_index("ix_story_locations_coords", "story_locations", ["latitude", "longitude"])
+
+    # Backfill: copy existing primary lat/lng from stories into story_locations as sort_order=0.
+    # gen_random_uuid() is available in PostgreSQL 13+ via pgcrypto (enabled by default).
+    op.execute(
+        """
+        INSERT INTO story_locations (id, story_id, latitude, longitude, label, sort_order, created_at, updated_at)
+        SELECT gen_random_uuid(), id, latitude, longitude, place_name, 0, now(), now()
+        FROM stories
+        WHERE latitude IS NOT NULL AND longitude IS NOT NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_story_locations_coords", table_name="story_locations")
+    op.drop_index("ix_story_locations_story_id", table_name="story_locations")
+    op.drop_table("story_locations")

--- a/backend/alembic/versions/20260510_0018_add_story_locations.py
+++ b/backend/alembic/versions/20260510_0018_add_story_locations.py
@@ -1,7 +1,7 @@
 """Add story_locations table and backfill from existing story lat/lng.
 
 Revision ID: 20260510_0018
-Revises: 20260510_0017
+Revises: 20260510_0019
 Create Date: 2026-05-10 00:00:00
 """
 
@@ -13,7 +13,7 @@ from sqlalchemy.dialects import postgresql
 from alembic import op
 
 revision: str = "20260510_0018"
-down_revision: Union[str, Sequence[str], None] = "20260510_0017"
+down_revision: Union[str, Sequence[str], None] = "20260510_0019"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/app/db/__init__.py
+++ b/backend/app/db/__init__.py
@@ -2,7 +2,8 @@ from app.db.badge import Badge, UserBadge
 from app.db.base import Base
 from app.db.media_file import MediaFile
 from app.db.story import Story
+from app.db.story_location import StoryLocation
 from app.db.tag import Tag
 from app.db.user import User
 
-__all__ = ["Badge", "Base", "MediaFile", "Story", "Tag", "UserBadge", "User"]
+__all__ = ["Badge", "Base", "MediaFile", "Story", "StoryLocation", "Tag", "UserBadge", "User"]

--- a/backend/app/db/story.py
+++ b/backend/app/db/story.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from app.db.notification import Notification
     from app.db.story_comment import StoryComment
     from app.db.story_like import StoryLike
+    from app.db.story_location import StoryLocation
     from app.db.story_report import StoryReport
     from app.db.story_save import StorySave
     from app.db.tag import Tag
@@ -106,4 +107,9 @@ class Story(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     tags: Mapped[list["Tag"]] = relationship(
         secondary=story_tags_table,
         back_populates="stories",
+    )
+    locations: Mapped[list["StoryLocation"]] = relationship(
+        back_populates="story",
+        cascade="all, delete-orphan",
+        order_by="StoryLocation.sort_order",
     )

--- a/backend/app/db/story_location.py
+++ b/backend/app/db/story_location.py
@@ -1,0 +1,40 @@
+import uuid
+from typing import TYPE_CHECKING
+
+from sqlalchemy import CheckConstraint, Float, ForeignKey, Index, Integer, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+from app.db.mixins import TimestampMixin, UUIDPrimaryKeyMixin
+
+if TYPE_CHECKING:
+    from app.db.story import Story
+
+
+class StoryLocation(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "story_locations"
+    __table_args__ = (
+        Index("ix_story_locations_story_id", "story_id"),
+        Index("ix_story_locations_coords", "latitude", "longitude"),
+        CheckConstraint(
+            "latitude >= -90.0 AND latitude <= 90.0",
+            name="ck_story_locations_latitude",
+        ),
+        CheckConstraint(
+            "longitude >= -180.0 AND longitude <= 180.0",
+            name="ck_story_locations_longitude",
+        ),
+    )
+
+    story_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("stories.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    latitude: Mapped[float] = mapped_column(Float, nullable=False)
+    longitude: Mapped[float] = mapped_column(Float, nullable=False)
+    label: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    sort_order: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+    story: Mapped["Story"] = relationship(back_populates="locations")

--- a/backend/app/models/story.py
+++ b/backend/app/models/story.py
@@ -85,6 +85,12 @@ class StoryDateInput(BaseModel):
         return self.date_start, end_date, DatePrecision.DATE
 
 
+class LocationInput(BaseModel):
+    latitude: float = Field(ge=-90.0, le=90.0)
+    longitude: float = Field(ge=-180.0, le=180.0)
+    label: str | None = Field(default=None, max_length=255)
+
+
 class StoryCreateRequest(StoryDateInput):
     title: str = Field(min_length=1, max_length=255)
     content: str = Field(min_length=1)
@@ -94,6 +100,7 @@ class StoryCreateRequest(StoryDateInput):
     longitude: float = Field(ge=-180.0, le=180.0)
     place_name: str | None = Field(default=None, max_length=255)
     is_anonymous: bool = False
+    locations: list[LocationInput] | None = None
 
 
 class StoryUpdateRequest(StoryDateInput):
@@ -105,6 +112,7 @@ class StoryUpdateRequest(StoryDateInput):
     longitude: float = Field(ge=-180.0, le=180.0)
     place_name: str | None = Field(default=None, max_length=255)
     is_anonymous: bool | None = None
+    locations: list[LocationInput] | None = None
 
 
 class StoryBoundsFilter(BaseModel):
@@ -143,6 +151,16 @@ class StoryDateRangeFilter(BaseModel):
         ).normalize_date_range()
 
 
+class LocationResponse(BaseModel):
+    id: uuid.UUID
+    latitude: float
+    longitude: float
+    label: str | None
+    sort_order: int
+
+    model_config = {"from_attributes": True}
+
+
 class StoryResponse(BaseModel):
     id: uuid.UUID
     title: str
@@ -154,6 +172,7 @@ class StoryResponse(BaseModel):
     place_name: str | None
     latitude: float | None
     longitude: float | None
+    locations: list[LocationResponse] = Field(default_factory=list)
     date_start: date | None
     date_end: date | None
     date_precision: DatePrecision | None
@@ -178,6 +197,20 @@ class StoryResponse(BaseModel):
 
         return [tag.name for tag in tags_attr.loaded_value]
 
+    @staticmethod
+    def _extract_loaded_locations(story: object) -> list[LocationResponse]:
+        try:
+            inspected_story = sa_inspect(story)
+        except NoInspectionAvailable:
+            locs = getattr(story, "locations", [])
+            return [LocationResponse.model_validate(loc, from_attributes=True) for loc in locs]
+
+        locations_attr = inspected_story.attrs.locations
+        if locations_attr.loaded_value is NO_VALUE:
+            return []
+
+        return [LocationResponse.model_validate(loc, from_attributes=True) for loc in locations_attr.loaded_value]
+
     @classmethod
     def from_orm_with_author(cls, story: object, author_username: str) -> "StoryResponse":
         date_start = getattr(story, "date_start", None)
@@ -201,6 +234,7 @@ class StoryResponse(BaseModel):
 
         is_anonymous = getattr(story, "is_anonymous", False)
         tags = cls._extract_loaded_tag_names(story)
+        locations = cls._extract_loaded_locations(story)
 
         return cls(
             id=story.id,
@@ -213,6 +247,7 @@ class StoryResponse(BaseModel):
             place_name=story.place_name,
             latitude=story.latitude,
             longitude=story.longitude,
+            locations=locations,
             date_start=date_start,
             date_end=date_end,
             date_precision=date_precision,

--- a/backend/app/services/location_service.py
+++ b/backend/app/services/location_service.py
@@ -1,0 +1,39 @@
+import uuid
+
+from fastapi import HTTPException, status
+
+from app.db.story import Story
+from app.db.story_location import StoryLocation
+from app.models.story import LocationInput
+
+
+def validate_location_list(locations: list[LocationInput]) -> None:
+    seen: set[tuple[float, float]] = set()
+    for loc in locations:
+        key = (loc.latitude, loc.longitude)
+        if key in seen:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Duplicate coordinates in locations list: ({loc.latitude}, {loc.longitude})",
+            )
+        seen.add(key)
+
+
+def build_story_locations(story_id: uuid.UUID, locations: list[LocationInput]) -> list[StoryLocation]:
+    return [
+        StoryLocation(
+            story_id=story_id,
+            latitude=loc.latitude,
+            longitude=loc.longitude,
+            label=loc.label.strip() if loc.label else None,
+            sort_order=i,
+        )
+        for i, loc in enumerate(locations)
+    ]
+
+
+def replace_story_locations(story: Story, locations: list[LocationInput]) -> None:
+    validate_location_list(locations)
+    story.locations.clear()
+    new_locs = build_story_locations(story.id, locations)
+    story.locations.extend(new_locs)

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -3,7 +3,7 @@ from datetime import date, datetime, timezone
 from pathlib import Path
 
 from fastapi import BackgroundTasks, HTTPException, UploadFile, status
-from sqlalchemy import func, select
+from sqlalchemy import and_, exists, func, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -14,6 +14,7 @@ from app.db.notification import Notification
 from app.db.story import Story
 from app.db.story_comment import StoryComment
 from app.db.story_like import StoryLike
+from app.db.story_location import StoryLocation
 from app.db.story_report import StoryReport
 from app.db.story_save import StorySave
 from app.db.user import User
@@ -33,6 +34,7 @@ from app.models.story import (
     StoryUpdateRequest,
 )
 from app.services.badge_service import check_and_award_story_badges
+from app.services.location_service import build_story_locations, replace_story_locations, validate_location_list
 from app.services.media_validation import read_uploaded_file_content, validate_media_upload
 from app.services.storage import (
     build_public_object_url,
@@ -182,7 +184,7 @@ async def list_available_stories(
     stmt = (
         select(Story, User.username)
         .join(User, Story.user_id == User.id)
-        .options(selectinload(Story.tags))
+        .options(selectinload(Story.tags), selectinload(Story.locations))
         .where(
             Story.status == StoryStatus.PUBLISHED,
             Story.visibility == StoryVisibility.PUBLIC,
@@ -193,12 +195,25 @@ async def list_available_stories(
 
     if all(v is not None for v in (min_lat, max_lat, min_lng, max_lng)):
         stmt = stmt.where(
-            Story.latitude.is_not(None),
-            Story.longitude.is_not(None),
-            Story.latitude >= min_lat,
-            Story.latitude <= max_lat,
-            Story.longitude >= min_lng,
-            Story.longitude <= max_lng,
+            or_(
+                and_(
+                    Story.latitude.is_not(None),
+                    Story.longitude.is_not(None),
+                    Story.latitude >= min_lat,
+                    Story.latitude <= max_lat,
+                    Story.longitude >= min_lng,
+                    Story.longitude <= max_lng,
+                ),
+                exists(
+                    select(StoryLocation.id).where(
+                        StoryLocation.story_id == Story.id,
+                        StoryLocation.latitude >= min_lat,
+                        StoryLocation.latitude <= max_lat,
+                        StoryLocation.longitude >= min_lng,
+                        StoryLocation.longitude <= max_lng,
+                    )
+                ),
+            )
         )
 
     if query_start is not None and query_end is not None:
@@ -224,7 +239,7 @@ async def search_available_stories_by_place(
     stmt = (
         select(Story, User.username)
         .join(User, Story.user_id == User.id)
-        .options(selectinload(Story.tags))
+        .options(selectinload(Story.tags), selectinload(Story.locations))
         .where(
             Story.status == StoryStatus.PUBLISHED,
             Story.visibility == StoryVisibility.PUBLIC,
@@ -256,7 +271,7 @@ async def get_story_detail_by_id(
         select(Story, User.username)
         .join(User, Story.user_id == User.id)
         .where(Story.id == story_id, Story.deleted_at.is_(None))
-        .options(selectinload(Story.media_files), selectinload(Story.tags))
+        .options(selectinload(Story.media_files), selectinload(Story.tags), selectinload(Story.locations))
     )
 
     result = await db.execute(stmt)
@@ -411,7 +426,7 @@ async def list_saved_stories_for_user(
         select(Story, User.username)
         .join(StorySave, StorySave.story_id == Story.id)
         .join(User, Story.user_id == User.id)
-        .options(selectinload(Story.tags))
+        .options(selectinload(Story.tags), selectinload(Story.locations))
         .where(
             StorySave.user_id == current_user.id,
             Story.status == StoryStatus.PUBLISHED,
@@ -457,6 +472,22 @@ async def create_story_with_location(
     )
 
     db.add(story)
+
+    if payload.locations:
+        validate_location_list(payload.locations)
+        for loc in build_story_locations(story.id, payload.locations):
+            db.add(loc)
+    else:
+        db.add(
+            StoryLocation(
+                story_id=story.id,
+                latitude=payload.latitude,
+                longitude=payload.longitude,
+                label=place_name,
+                sort_order=0,
+            )
+        )
+
     await db.commit()
     await db.refresh(story)
 
@@ -475,7 +506,9 @@ async def update_story_with_location_and_dates(
     payload: StoryUpdateRequest,
 ) -> StoryDetailResponse:
     story_result = await db.execute(
-        select(Story).where(
+        select(Story)
+        .options(selectinload(Story.locations))
+        .where(
             Story.id == story_id,
             Story.user_id == current_user.id,
             Story.deleted_at.is_(None),
@@ -508,6 +541,9 @@ async def update_story_with_location_and_dates(
     story.date_precision = normalized_date_precision
     if payload.is_anonymous is not None:
         story.is_anonymous = payload.is_anonymous
+
+    if payload.locations is not None:
+        replace_story_locations(story, payload.locations)
 
     await db.commit()
     await db.refresh(story)
@@ -676,7 +712,7 @@ async def get_nearby_stories(
     stmt = (
         select(Story, User.username)
         .join(User, Story.user_id == User.id)
-        .options(selectinload(Story.tags))
+        .options(selectinload(Story.tags), selectinload(Story.locations))
         .where(
             Story.status == StoryStatus.PUBLISHED,
             Story.visibility == StoryVisibility.PUBLIC,

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -476,7 +476,7 @@ async def create_story_with_location(
 
     db.add(story)
 
-    if payload.locations:
+    if payload.locations is not None:
         validate_location_list(payload.locations)
         for loc in build_story_locations(story_id, payload.locations):
             db.add(loc)

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -455,7 +455,10 @@ async def create_story_with_location(
 
     normalized_date_start, normalized_date_end, normalized_date_precision = payload.normalize_date_range()
 
+    # Pre-generate the PK so StoryLocation FK is available before the first flush.
+    story_id = uuid.uuid4()
     story = Story(
+        id=story_id,
         user_id=current_user.id,
         title=payload.title,
         summary=payload.summary,
@@ -475,12 +478,12 @@ async def create_story_with_location(
 
     if payload.locations:
         validate_location_list(payload.locations)
-        for loc in build_story_locations(story.id, payload.locations):
+        for loc in build_story_locations(story_id, payload.locations):
             db.add(loc)
     else:
         db.add(
             StoryLocation(
-                story_id=story.id,
+                story_id=story_id,
                 latitude=payload.latitude,
                 longitude=payload.longitude,
                 label=place_name,

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -492,14 +492,9 @@ async def create_story_with_location(
         )
 
     await db.commit()
-    await db.refresh(story)
-
     await check_and_award_story_badges(db, current_user.id)
     await db.commit()
-
-    story_response = StoryResponse.from_orm_with_author(story, current_user.username)
-    like_count = await _get_story_like_count(db, story.id)
-    return StoryDetailResponse(**story_response.model_dump(), media_files=[], like_count=like_count)
+    return await get_story_detail_by_id(db, story_id)
 
 
 async def update_story_with_location_and_dates(
@@ -549,11 +544,7 @@ async def update_story_with_location_and_dates(
         replace_story_locations(story, payload.locations)
 
     await db.commit()
-    await db.refresh(story)
-
-    story_response = StoryResponse.from_orm_with_author(story, current_user.username)
-    like_count = await _get_story_like_count(db, story.id)
-    return StoryDetailResponse(**story_response.model_dump(), media_files=[], like_count=like_count)
+    return await get_story_detail_by_id(db, story.id)
 
 
 async def like_story(

--- a/backend/tests/integration/test_story_location_flow.py
+++ b/backend/tests/integration/test_story_location_flow.py
@@ -181,7 +181,7 @@ class TestStoryLocationFlow:
 
         # Search bounds that only cover Izmir (secondary location), not Istanbul (primary)
         search_resp = await client.get(
-            "/stories/search",
+            "/stories",
             params={
                 "min_lat": 37.0,
                 "max_lat": 39.5,

--- a/backend/tests/integration/test_story_location_flow.py
+++ b/backend/tests/integration/test_story_location_flow.py
@@ -1,0 +1,194 @@
+import pytest
+
+
+@pytest.mark.asyncio
+class TestStoryLocationFlow:
+    """Integration tests for multi-location story support. Covers #231."""
+
+    async def _register_and_login(self, client, username: str, email: str, password: str = "Locate1!A") -> str:
+        await client.post(
+            "/auth/register",
+            json={"username": username, "email": email, "password": password},
+        )
+        login_resp = await client.post(
+            "/auth/login",
+            json={"email": email, "password": password},
+        )
+        return login_resp.json()["access_token"]
+
+    async def test_create_story_with_locations_returns_locations_in_detail(self, client):
+        token = await self._register_and_login(client, "loccreator", "loccreator@example.com")
+
+        resp = await client.post(
+            "/stories",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "title": "Silk Road Journey",
+                "content": "A journey along the ancient Silk Road.",
+                "summary": "Multi-stop trade route story.",
+                "place_name": "Samarkand",
+                "latitude": 39.6542,
+                "longitude": 66.9597,
+                "date_start": 1200,
+                "date_end": 1300,
+                "locations": [
+                    {"latitude": 39.6542, "longitude": 66.9597, "label": "Samarkand"},
+                    {"latitude": 41.2995, "longitude": 69.2401, "label": "Tashkent"},
+                    {"latitude": 37.9601, "longitude": 58.3261, "label": "Merv"},
+                ],
+            },
+        )
+
+        assert resp.status_code == 201
+        data = resp.json()
+        story_id = data["id"]
+
+        detail_resp = await client.get(f"/stories/{story_id}")
+        assert detail_resp.status_code == 200
+        detail = detail_resp.json()
+
+        assert len(detail["locations"]) == 3
+        labels = [loc["label"] for loc in detail["locations"]]
+        assert labels == ["Samarkand", "Tashkent", "Merv"]
+
+        coords = [(loc["latitude"], loc["longitude"]) for loc in detail["locations"]]
+        assert (39.6542, 66.9597) in coords
+        assert (41.2995, 69.2401) in coords
+
+        for i, loc in enumerate(detail["locations"]):
+            assert loc["sort_order"] == i
+
+    async def test_create_story_without_locations_defaults_to_primary(self, client):
+        token = await self._register_and_login(client, "locdefault", "locdefault@example.com")
+
+        resp = await client.post(
+            "/stories",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "title": "Single Point Story",
+                "content": "Story with only the primary location.",
+                "summary": "One place story.",
+                "place_name": "Istanbul",
+                "latitude": 41.0082,
+                "longitude": 28.9784,
+            },
+        )
+
+        assert resp.status_code == 201
+        story_id = resp.json()["id"]
+
+        detail_resp = await client.get(f"/stories/{story_id}")
+        assert detail_resp.status_code == 200
+        detail = detail_resp.json()
+
+        assert len(detail["locations"]) == 1
+        loc = detail["locations"][0]
+        assert loc["latitude"] == 41.0082
+        assert loc["longitude"] == 28.9784
+        assert loc["sort_order"] == 0
+
+    async def test_update_story_replaces_locations(self, client):
+        token = await self._register_and_login(client, "locupdater", "locupdater@example.com")
+
+        create_resp = await client.post(
+            "/stories",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "title": "Updateable Story",
+                "content": "Initial content.",
+                "summary": "Initial summary.",
+                "place_name": "Ankara",
+                "latitude": 39.9334,
+                "longitude": 32.8597,
+                "locations": [
+                    {"latitude": 39.9334, "longitude": 32.8597, "label": "Ankara"},
+                ],
+            },
+        )
+        assert create_resp.status_code == 201
+        story_id = create_resp.json()["id"]
+
+        update_resp = await client.put(
+            f"/stories/{story_id}",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "title": "Updateable Story",
+                "content": "Updated content.",
+                "summary": "Updated summary.",
+                "place_name": "Ankara",
+                "latitude": 39.9334,
+                "longitude": 32.8597,
+                "locations": [
+                    {"latitude": 39.9334, "longitude": 32.8597, "label": "Ankara"},
+                    {"latitude": 40.1826, "longitude": 29.0665, "label": "Bursa"},
+                ],
+            },
+        )
+        assert update_resp.status_code == 200
+
+        detail_resp = await client.get(f"/stories/{story_id}")
+        assert detail_resp.status_code == 200
+        detail = detail_resp.json()
+
+        assert len(detail["locations"]) == 2
+        labels = [loc["label"] for loc in detail["locations"]]
+        assert "Ankara" in labels
+        assert "Bursa" in labels
+
+    async def test_create_story_with_duplicate_locations_returns_422(self, client):
+        token = await self._register_and_login(client, "locduplicate", "locduplicate@example.com")
+
+        resp = await client.post(
+            "/stories",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "title": "Duplicate Locations Story",
+                "content": "Some content.",
+                "summary": "Should fail.",
+                "place_name": "Istanbul",
+                "latitude": 41.0082,
+                "longitude": 28.9784,
+                "locations": [
+                    {"latitude": 41.0082, "longitude": 28.9784, "label": "Istanbul"},
+                    {"latitude": 41.0082, "longitude": 28.9784, "label": "Istanbul Again"},
+                ],
+            },
+        )
+
+        assert resp.status_code == 422
+
+    async def test_bounds_filter_matches_story_via_secondary_location(self, client):
+        token = await self._register_and_login(client, "locbounds", "locbounds@example.com")
+
+        create_resp = await client.post(
+            "/stories",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "title": "Route Through Izmir",
+                "content": "A story that passes through Izmir.",
+                "summary": "Multi-city route.",
+                "place_name": "Istanbul",
+                "latitude": 41.0082,
+                "longitude": 28.9784,
+                "locations": [
+                    {"latitude": 41.0082, "longitude": 28.9784, "label": "Istanbul"},
+                    {"latitude": 38.4192, "longitude": 27.1287, "label": "Izmir"},
+                ],
+            },
+        )
+        assert create_resp.status_code == 201
+        story_id = create_resp.json()["id"]
+
+        # Search bounds that only cover Izmir (secondary location), not Istanbul (primary)
+        search_resp = await client.get(
+            "/stories/search",
+            params={
+                "min_lat": 37.0,
+                "max_lat": 39.5,
+                "min_lng": 26.0,
+                "max_lng": 28.5,
+            },
+        )
+        assert search_resp.status_code == 200
+        ids = [s["id"] for s in search_resp.json()["stories"]]
+        assert story_id in ids

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -1168,12 +1168,13 @@ class TestCreateStoryWithLocationService:
             SimpleNamespace(scalar_one=lambda: 0),
         ]
 
-        result = await create_story_with_location(db, current_user, payload)
+        with patch("app.services.story_service.check_and_award_story_badges", new_callable=AsyncMock):
+            result = await create_story_with_location(db, current_user, payload)
 
         # Only the Story is added; no auto-created StoryLocation for an explicit empty list
         assert result.title == "New Story"
         assert db.add.call_count == 1
-        db.commit.assert_awaited_once()
+        assert db.commit.await_count == 2
         db.refresh.assert_not_awaited()
 
     async def test_create_story_rejects_missing_place_name(self):

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -1116,6 +1116,37 @@ class TestCreateStoryWithLocationService:
         assert db.commit.await_count == 2
         db.refresh.assert_awaited_once()
 
+    async def test_create_story_with_empty_locations_list_adds_no_story_locations(self):
+        payload = StoryCreateRequest(
+            title="New Story",
+            content="Story content",
+            summary="Summary",
+            place_name="Istanbul",
+            latitude=41.0082,
+            longitude=28.9784,
+            locations=[],
+        )
+        current_user = SimpleNamespace(id=uuid.uuid4(), username="authoruser")
+
+        db = AsyncMock()
+        db.add = MagicMock()
+
+        async def _refresh_side_effect(story_obj):
+            story_obj.id = uuid.uuid4()
+            story_obj.created_at = datetime.now(timezone.utc)
+            story_obj.status = StoryStatus.PUBLISHED
+            story_obj.visibility = StoryVisibility.PUBLIC
+
+        db.refresh.side_effect = _refresh_side_effect
+        db.execute.return_value.scalar_one = lambda: 0
+
+        result = await create_story_with_location(db, current_user, payload)
+
+        # Only the Story is added; no auto-created StoryLocation for an explicit empty list
+        assert result.title == "New Story"
+        assert db.add.call_count == 1
+        db.commit.assert_awaited_once()
+
     async def test_create_story_rejects_missing_place_name(self):
         payload = StoryCreateRequest(
             title="New Story",

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -1112,7 +1112,7 @@ class TestCreateStoryWithLocationService:
         assert result.visibility == StoryVisibility.PUBLIC
         assert result.media_files == []
         assert result.like_count == 0
-        db.add.assert_called_once()
+        assert db.add.call_count == 2  # Story + auto-created StoryLocation
         assert db.commit.await_count == 2
         db.refresh.assert_awaited_once()
 
@@ -1501,8 +1501,8 @@ class TestAnonymousStoryService:
 
         assert result.is_anonymous is True
         assert result.author is None
-        db.add.assert_called_once()
-        added_story = db.add.call_args.args[0]
+        assert db.add.call_count == 2
+        added_story = db.add.call_args_list[0].args[0]
         assert added_story.is_anonymous is True
 
     async def test_update_story_sets_is_anonymous_and_masks_author(self):

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -1085,17 +1085,31 @@ class TestCreateStoryWithLocationService:
         )
         current_user = SimpleNamespace(id=uuid.uuid4(), username="authoruser")
 
+        mock_story = SimpleNamespace(
+            id=uuid.uuid4(),
+            title="New Story",
+            content="Story content",
+            summary="Summary",
+            place_name="Istanbul",
+            latitude=41.0082,
+            longitude=28.9784,
+            date_start=date(1453, 1, 1),
+            date_end=date(1453, 12, 31),
+            date_precision=DatePrecision.YEAR,
+            status=StoryStatus.PUBLISHED,
+            visibility=StoryVisibility.PUBLIC,
+            is_anonymous=False,
+            created_at=datetime.now(timezone.utc),
+            media_files=[],
+            story_likes=[],
+        )
+
         db = AsyncMock()
         db.add = MagicMock()
-
-        async def _refresh_side_effect(story_obj):
-            story_obj.id = uuid.uuid4()
-            story_obj.created_at = datetime.now(timezone.utc)
-            story_obj.status = StoryStatus.PUBLISHED
-            story_obj.visibility = StoryVisibility.PUBLIC
-
-        db.refresh.side_effect = _refresh_side_effect
-        db.execute.return_value.scalar_one = lambda: 0
+        db.execute.side_effect = [
+            SimpleNamespace(one_or_none=lambda: (mock_story, "authoruser")),
+            SimpleNamespace(scalar_one=lambda: 0),
+        ]
 
         with patch("app.services.story_service.check_and_award_story_badges", new_callable=AsyncMock):
             result = await create_story_with_location(db, current_user, payload)
@@ -1114,7 +1128,7 @@ class TestCreateStoryWithLocationService:
         assert result.like_count == 0
         assert db.add.call_count == 2  # Story + auto-created StoryLocation
         assert db.commit.await_count == 2
-        db.refresh.assert_awaited_once()
+        db.refresh.assert_not_awaited()
 
     async def test_create_story_with_empty_locations_list_adds_no_story_locations(self):
         payload = StoryCreateRequest(
@@ -1128,17 +1142,31 @@ class TestCreateStoryWithLocationService:
         )
         current_user = SimpleNamespace(id=uuid.uuid4(), username="authoruser")
 
+        mock_story = SimpleNamespace(
+            id=uuid.uuid4(),
+            title="New Story",
+            content="Story content",
+            summary="Summary",
+            place_name="Istanbul",
+            latitude=41.0082,
+            longitude=28.9784,
+            date_start=None,
+            date_end=None,
+            date_precision=None,
+            status=StoryStatus.PUBLISHED,
+            visibility=StoryVisibility.PUBLIC,
+            is_anonymous=False,
+            created_at=datetime.now(timezone.utc),
+            media_files=[],
+            story_likes=[],
+        )
+
         db = AsyncMock()
         db.add = MagicMock()
-
-        async def _refresh_side_effect(story_obj):
-            story_obj.id = uuid.uuid4()
-            story_obj.created_at = datetime.now(timezone.utc)
-            story_obj.status = StoryStatus.PUBLISHED
-            story_obj.visibility = StoryVisibility.PUBLIC
-
-        db.refresh.side_effect = _refresh_side_effect
-        db.execute.return_value.scalar_one = lambda: 0
+        db.execute.side_effect = [
+            SimpleNamespace(one_or_none=lambda: (mock_story, "authoruser")),
+            SimpleNamespace(scalar_one=lambda: 0),
+        ]
 
         result = await create_story_with_location(db, current_user, payload)
 
@@ -1146,6 +1174,7 @@ class TestCreateStoryWithLocationService:
         assert result.title == "New Story"
         assert db.add.call_count == 1
         db.commit.assert_awaited_once()
+        db.refresh.assert_not_awaited()
 
     async def test_create_story_rejects_missing_place_name(self):
         payload = StoryCreateRequest(
@@ -1185,9 +1214,29 @@ class TestUpdateStoryWithLocationAndDatesService:
         )
         current_user = SimpleNamespace(id=story.user_id, username="authoruser")
 
+        mock_story_updated = SimpleNamespace(
+            id=story_id,
+            title="Updated Story",
+            content="Updated content",
+            summary="Updated summary",
+            place_name="Ankara",
+            latitude=39.9334,
+            longitude=32.8597,
+            date_start=date(1920, 1, 1),
+            date_end=date(1923, 12, 31),
+            date_precision=DatePrecision.YEAR,
+            status=StoryStatus.PUBLISHED,
+            visibility=StoryVisibility.PUBLIC,
+            is_anonymous=False,
+            created_at=story.created_at,
+            media_files=[],
+            story_likes=[],
+        )
+
         db = AsyncMock()
         db.execute.side_effect = [
             SimpleNamespace(scalar_one_or_none=lambda: story),
+            SimpleNamespace(one_or_none=lambda: (mock_story_updated, "authoruser")),
             SimpleNamespace(scalar_one=lambda: 4),
         ]
 
@@ -1207,7 +1256,7 @@ class TestUpdateStoryWithLocationAndDatesService:
         assert result.like_count == 4
         assert result.media_files == []
         db.commit.assert_awaited_once()
-        db.refresh.assert_awaited_once_with(story)
+        db.refresh.assert_not_awaited()
 
     async def test_update_story_not_found(self):
         payload = StoryUpdateRequest(
@@ -1515,17 +1564,31 @@ class TestAnonymousStoryService:
         )
         current_user = SimpleNamespace(id=uuid.uuid4(), username="realauthor")
 
+        mock_story = SimpleNamespace(
+            id=uuid.uuid4(),
+            title="Anonymous Story",
+            content="Content",
+            summary="Summary",
+            place_name="Istanbul",
+            latitude=41.0082,
+            longitude=28.9784,
+            date_start=None,
+            date_end=None,
+            date_precision=None,
+            status=StoryStatus.PUBLISHED,
+            visibility=StoryVisibility.PUBLIC,
+            is_anonymous=True,
+            created_at=datetime.now(timezone.utc),
+            media_files=[],
+            story_likes=[],
+        )
+
         db = AsyncMock()
         db.add = MagicMock()
-
-        async def _refresh_side_effect(story_obj):
-            story_obj.id = uuid.uuid4()
-            story_obj.created_at = datetime.now(timezone.utc)
-            story_obj.status = StoryStatus.PUBLISHED
-            story_obj.visibility = StoryVisibility.PUBLIC
-
-        db.refresh.side_effect = _refresh_side_effect
-        db.execute.return_value.scalar_one = lambda: 0
+        db.execute.side_effect = [
+            SimpleNamespace(one_or_none=lambda: (mock_story, "realauthor")),
+            SimpleNamespace(scalar_one=lambda: 0),
+        ]
 
         with patch("app.services.story_service.check_and_award_story_badges", new_callable=AsyncMock):
             result = await create_story_with_location(db, current_user, payload)
@@ -1535,6 +1598,7 @@ class TestAnonymousStoryService:
         assert db.add.call_count == 2
         added_story = db.add.call_args_list[0].args[0]
         assert added_story.is_anonymous is True
+        db.refresh.assert_not_awaited()
 
     async def test_update_story_sets_is_anonymous_and_masks_author(self):
         story_id = uuid.uuid4()
@@ -1551,9 +1615,29 @@ class TestAnonymousStoryService:
             is_anonymous=True,
         )
 
+        mock_story_updated = SimpleNamespace(
+            id=story_id,
+            title="Updated Story",
+            content="Updated content",
+            summary="Summary",
+            place_name="Istanbul",
+            latitude=41.0082,
+            longitude=28.9784,
+            date_start=None,
+            date_end=None,
+            date_precision=None,
+            status=StoryStatus.PUBLISHED,
+            visibility=StoryVisibility.PUBLIC,
+            is_anonymous=True,
+            created_at=story.created_at,
+            media_files=[],
+            story_likes=[],
+        )
+
         db = AsyncMock()
         db.execute.side_effect = [
             SimpleNamespace(scalar_one_or_none=lambda: story),
+            SimpleNamespace(one_or_none=lambda: (mock_story_updated, "realauthor")),
             SimpleNamespace(scalar_one=lambda: 0),
         ]
 
@@ -1579,9 +1663,29 @@ class TestAnonymousStoryService:
             # is_anonymous intentionally omitted
         )
 
+        mock_story_updated = SimpleNamespace(
+            id=story_id,
+            title="Updated Story",
+            content="Updated content",
+            summary="Updated summary",
+            place_name="Istanbul",
+            latitude=41.0082,
+            longitude=28.9784,
+            date_start=None,
+            date_end=None,
+            date_precision=None,
+            status=StoryStatus.PUBLISHED,
+            visibility=StoryVisibility.PUBLIC,
+            is_anonymous=True,
+            created_at=story.created_at,
+            media_files=[],
+            story_likes=[],
+        )
+
         db = AsyncMock()
         db.execute.side_effect = [
             SimpleNamespace(scalar_one_or_none=lambda: story),
+            SimpleNamespace(one_or_none=lambda: (mock_story_updated, "realauthor")),
             SimpleNamespace(scalar_one=lambda: 0),
         ]
 


### PR DESCRIPTION
## Description

Adds backend support for associating multiple geographic locations with a single story (issue #231). Stories can now carry an ordered list of `StoryLocation` rows in addition to their primary `latitude`/`longitude` columns.

## Related Issue(s)

Closes #231

## Changes

| Area | Change |
|------|--------|
| `app/db/story_location.py` | New ORM model (`StoryLocation`) for the `story_locations` table |
| `app/db/story.py` | Added `locations` one-to-many relationship with `cascade="all, delete-orphan"` |
| `app/db/__init__.py` | Registered `StoryLocation` in the package |
| `alembic/versions/20260510_0018_...` | Migration: creates `story_locations` table, backfills from existing story lat/lng |
| `app/models/story.py` | Added `LocationInput`, `LocationResponse`; extended `StoryCreateRequest`, `StoryUpdateRequest`, `StoryResponse` |
| `app/services/location_service.py` | New service: duplicate-coordinate validation, location list builder, replace helper |
| `app/services/story_service.py` | Wired location creation/replacement into create and update flows; updated bounds filter to OR across primary and secondary locations; added `selectinload(Story.locations)` to all list queries |
| `tests/unit/test_story_service.py` | Updated `db.add` count assertions; extended anonymous story tests |
| `tests/integration/test_story_location_flow.py` | New integration tests covering create, default single-location, update-replace, duplicate validation, and bounds filter via secondary location |

## Checklist
- [ ] All tests passed
- [x] I have self-reviewed my own code
- [x] I have requested at least 1 reviewer