### PR TITLE
feat: implement gamification badge system

### DIFF
--- a/backend/alembic/versions/20260510_0019_add_badges.py
+++ b/backend/alembic/versions/20260510_0019_add_badges.py
@@ -1,0 +1,76 @@
+"""Add badges and user_badges tables with initial badge seed data.
+
+Revision ID: 20260510_0019
+Revises: 20260510_0018
+Create Date: 2026-05-10 00:00:00
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "20260510_0019"
+down_revision: Union[str, Sequence[str], None] = "20260510_0018"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "badges",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.Column("description", sa.Text(), nullable=False),
+        sa.Column("icon_key", sa.String(length=100), nullable=False),
+        sa.Column(
+            "rule_type",
+            sa.Enum(
+                "first_story",
+                "story_milestone_5",
+                "story_milestone_10",
+                name="badge_rule_type",
+                native_enum=False,
+            ),
+            nullable=False,
+            unique=True,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_badges_rule_type", "badges", ["rule_type"])
+
+    op.create_table(
+        "user_badges",
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("badge_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "awarded_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(["badge_id"], ["badges.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("user_id", "badge_id"),
+    )
+    op.create_index("ix_user_badges_user_id", "user_badges", ["user_id"])
+
+    # Seed initial badge definitions.
+    op.execute(
+        """
+        INSERT INTO badges (id, name, description, icon_key, rule_type) VALUES
+        (gen_random_uuid(), 'First Story',    'Published your very first story.',          'badge_first_story',       'first_story'),
+        (gen_random_uuid(), 'Story Teller',   'Published 5 stories on the platform.',      'badge_story_milestone_5', 'story_milestone_5'),
+        (gen_random_uuid(), 'Story Master',   'Published 10 stories on the platform.',     'badge_story_milestone_10','story_milestone_10')
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_user_badges_user_id", table_name="user_badges")
+    op.drop_table("user_badges")
+    op.drop_index("ix_badges_rule_type", table_name="badges")
+    op.drop_table("badges")
+    op.execute("DROP TYPE IF EXISTS badge_rule_type")

--- a/backend/alembic/versions/20260510_0019_add_badges.py
+++ b/backend/alembic/versions/20260510_0019_add_badges.py
@@ -1,7 +1,7 @@
 """Add badges and user_badges tables with initial badge seed data.
 
 Revision ID: 20260510_0019
-Revises: 20260510_0018
+Revises: 20260510_0017
 Create Date: 2026-05-10 00:00:00
 """
 
@@ -13,7 +13,7 @@ from sqlalchemy.dialects import postgresql
 from alembic import op
 
 revision: str = "20260510_0019"
-down_revision: Union[str, Sequence[str], None] = "20260510_0018"
+down_revision: Union[str, Sequence[str], None] = "20260510_0017"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/app/db/__init__.py
+++ b/backend/app/db/__init__.py
@@ -1,7 +1,8 @@
+from app.db.badge import Badge, UserBadge
 from app.db.base import Base
 from app.db.media_file import MediaFile
 from app.db.story import Story
 from app.db.tag import Tag
 from app.db.user import User
 
-__all__ = ["Base", "MediaFile", "Story", "Tag", "User"]
+__all__ = ["Badge", "Base", "MediaFile", "Story", "Tag", "UserBadge", "User"]

--- a/backend/app/db/badge.py
+++ b/backend/app/db/badge.py
@@ -1,0 +1,56 @@
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import DateTime, Enum, ForeignKey, Index, String, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+from app.db.enums import BadgeRuleType
+from app.db.mixins import UUIDPrimaryKeyMixin
+
+if TYPE_CHECKING:
+    from app.db.user import User
+
+
+class Badge(UUIDPrimaryKeyMixin, Base):
+    __tablename__ = "badges"
+    __table_args__ = (Index("ix_badges_rule_type", "rule_type"),)
+
+    name: Mapped[str] = mapped_column(String(100), nullable=False)
+    description: Mapped[str] = mapped_column(Text, nullable=False)
+    icon_key: Mapped[str] = mapped_column(String(100), nullable=False)
+    rule_type: Mapped[BadgeRuleType] = mapped_column(
+        Enum(BadgeRuleType, name="badge_rule_type", native_enum=False),
+        nullable=False,
+        unique=True,
+    )
+
+    user_badges: Mapped[list["UserBadge"]] = relationship(back_populates="badge")
+
+
+class UserBadge(Base):
+    __tablename__ = "user_badges"
+    __table_args__ = (Index("ix_user_badges_user_id", "user_id"),)
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        primary_key=True,
+        nullable=False,
+    )
+    badge_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("badges.id", ondelete="CASCADE"),
+        primary_key=True,
+        nullable=False,
+    )
+    awarded_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+
+    badge: Mapped["Badge"] = relationship(back_populates="user_badges")
+    user: Mapped["User"] = relationship(back_populates="user_badges")

--- a/backend/app/db/enums.py
+++ b/backend/app/db/enums.py
@@ -47,3 +47,9 @@ class ReportStatus(str, Enum):
     REVIEWED = "reviewed"
     REMOVED = "removed"
     RESOLVED = "reviewed"
+
+
+class BadgeRuleType(str, Enum):
+    FIRST_STORY = "first_story"
+    STORY_MILESTONE_5 = "story_milestone_5"
+    STORY_MILESTONE_10 = "story_milestone_10"

--- a/backend/app/db/user.py
+++ b/backend/app/db/user.py
@@ -8,6 +8,7 @@ from app.db.enums import UserRole
 from app.db.mixins import TimestampMixin, UUIDPrimaryKeyMixin
 
 if TYPE_CHECKING:
+    from app.db.badge import UserBadge
     from app.db.notification import Notification
     from app.db.story import Story
     from app.db.story_comment import StoryComment
@@ -72,6 +73,10 @@ class User(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         foreign_keys="Notification.actor_user_id",
     )
     reports: Mapped[list["StoryReport"]] = relationship(
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
+    user_badges: Mapped[list["UserBadge"]] = relationship(
         back_populates="user",
         cascade="all, delete-orphan",
     )

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 from pydantic import BaseModel, EmailStr, Field, field_validator
 
-from app.db.enums import UserRole
+from app.db.enums import BadgeRuleType, UserRole
 from app.models.story import StoryResponse
 
 
@@ -57,10 +57,35 @@ class UserResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class BadgeResponse(BaseModel):
+    id: uuid.UUID
+    name: str
+    description: str
+    icon_key: str
+    rule_type: BadgeRuleType
+    awarded_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
 class UserProfileResponse(UserResponse):
     bio: str | None
     location: str | None
     avatar_url: str | None
+    badges: list[BadgeResponse] = Field(default_factory=list)
+
+
+class UserPublicProfileResponse(BaseModel):
+    id: uuid.UUID
+    username: str
+    display_name: str | None
+    bio: str | None
+    location: str | None
+    avatar_url: str | None
+    badges: list[BadgeResponse] = Field(default_factory=list)
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
 
 
 class UserProfileUpdateRequest(BaseModel):

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -19,7 +19,7 @@ from app.models.user import (
 from app.services.auth_service import (
     build_google_auth_url,
     change_user_password,
-    get_user_profile,
+    get_full_user_profile,
     google_oauth_login,
     login_user,
     register_user,
@@ -115,8 +115,11 @@ async def google_callback(
         401: {"description": "Missing, invalid, or expired token"},
     },
 )
-async def me(current_user: User = Depends(get_current_user)):
-    return get_user_profile(current_user)
+async def me(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await get_full_user_profile(db, current_user)
 
 
 @router.patch(

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -1,13 +1,21 @@
+import uuid
+
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.deps import get_current_user
 from app.db.session import get_db
 from app.db.user import User
-from app.models.user import UserDashboardResponse, UserEngagementStatsResponse, UserStoryListResponse
+from app.models.user import (
+    UserDashboardResponse,
+    UserEngagementStatsResponse,
+    UserPublicProfileResponse,
+    UserStoryListResponse,
+)
 from app.services.user_service import (
     get_current_user_dashboard,
     get_current_user_engagement_stats,
+    get_user_public_profile,
     list_current_user_saved_stories,
     list_current_user_stories,
 )
@@ -105,3 +113,19 @@ async def get_my_dashboard(
     db: AsyncSession = Depends(get_db),
 ):
     return await get_current_user_dashboard(db, current_user)
+
+
+@router.get(
+    "/{user_id}/profile",
+    response_model=UserPublicProfileResponse,
+    summary="Get a user's public profile",
+    description="Return the public profile and earned badges for any user by their UUID.",
+    responses={
+        404: {"description": "User not found"},
+    },
+)
+async def get_profile(
+    user_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+):
+    return await get_user_public_profile(db, user_id)

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -15,6 +15,7 @@ from app.core.config import settings
 from app.db.enums import MediaType
 from app.db.user import User
 from app.models.user import (
+    BadgeResponse,
     TokenResponse,
     UserLoginRequest,
     UserPasswordChangeRequest,
@@ -23,6 +24,7 @@ from app.models.user import (
     UserRegisterRequest,
     UserResponse,
 )
+from app.services.badge_service import get_user_badges
 from app.services.storage import build_public_object_url, delete_object, get_bucket_for_media_type, upload_bytes
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
@@ -78,6 +80,13 @@ def get_user_profile(user: User) -> UserProfileResponse:
         role=user.role,
         created_at=user.created_at,
     )
+
+
+async def get_full_user_profile(db: AsyncSession, user: User) -> UserProfileResponse:
+    """Return the user profile including earned badges."""
+    badges: list[BadgeResponse] = await get_user_badges(db, user.id)
+    profile = get_user_profile(user)
+    return profile.model_copy(update={"badges": badges})
 
 
 def _normalize_avatar_content_type(file: UploadFile) -> str:

--- a/backend/app/services/badge_service.py
+++ b/backend/app/services/badge_service.py
@@ -5,7 +5,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.badge import Badge, UserBadge
-from app.db.enums import BadgeRuleType
+from app.db.enums import BadgeRuleType, StoryStatus
 from app.db.story import Story
 from app.models.user import BadgeResponse
 
@@ -22,6 +22,7 @@ async def check_and_award_story_badges(db: AsyncSession, user_id: uuid.UUID) -> 
     count_result = await db.execute(
         select(func.count(Story.id)).where(
             Story.user_id == user_id,
+            Story.status == StoryStatus.PUBLISHED,
             Story.deleted_at.is_(None),
         )
     )

--- a/backend/app/services/badge_service.py
+++ b/backend/app/services/badge_service.py
@@ -1,0 +1,63 @@
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.badge import Badge, UserBadge
+from app.db.enums import BadgeRuleType
+from app.db.story import Story
+from app.models.user import BadgeResponse
+
+# Maps each rule type to the minimum published-story count required.
+_STORY_COUNT_RULES: dict[BadgeRuleType, int] = {
+    BadgeRuleType.FIRST_STORY: 1,
+    BadgeRuleType.STORY_MILESTONE_5: 5,
+    BadgeRuleType.STORY_MILESTONE_10: 10,
+}
+
+
+async def check_and_award_story_badges(db: AsyncSession, user_id: uuid.UUID) -> None:
+    """Award any story-count-based badges the user has newly earned."""
+    count_result = await db.execute(
+        select(func.count(Story.id)).where(
+            Story.user_id == user_id,
+            Story.deleted_at.is_(None),
+        )
+    )
+    story_count = count_result.scalar_one()
+
+    qualifying_rule_types = [rt for rt, threshold in _STORY_COUNT_RULES.items() if story_count >= threshold]
+    if not qualifying_rule_types:
+        return
+
+    owned_result = await db.execute(select(UserBadge.badge_id).where(UserBadge.user_id == user_id))
+    owned_badge_ids = {row[0] for row in owned_result.all()}
+
+    badges_result = await db.execute(select(Badge).where(Badge.rule_type.in_(qualifying_rule_types)))
+    badges = badges_result.scalars().all()
+
+    for badge in badges:
+        if badge.id not in owned_badge_ids:
+            db.add(UserBadge(user_id=user_id, badge_id=badge.id, awarded_at=datetime.now(timezone.utc)))
+
+
+async def get_user_badges(db: AsyncSession, user_id: uuid.UUID) -> list[BadgeResponse]:
+    """Return all badges awarded to a user, ordered by award date."""
+    result = await db.execute(
+        select(UserBadge, Badge)
+        .join(Badge, UserBadge.badge_id == Badge.id)
+        .where(UserBadge.user_id == user_id)
+        .order_by(UserBadge.awarded_at)
+    )
+    return [
+        BadgeResponse(
+            id=badge.id,
+            name=badge.name,
+            description=badge.description,
+            icon_key=badge.icon_key,
+            rule_type=badge.rule_type,
+            awarded_at=user_badge.awarded_at,
+        )
+        for user_badge, badge in result.all()
+    ]

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -32,6 +32,7 @@ from app.models.story import (
     StorySaveResponse,
     StoryUpdateRequest,
 )
+from app.services.badge_service import check_and_award_story_badges
 from app.services.media_validation import read_uploaded_file_content, validate_media_upload
 from app.services.storage import (
     build_public_object_url,
@@ -458,6 +459,9 @@ async def create_story_with_location(
     db.add(story)
     await db.commit()
     await db.refresh(story)
+
+    await check_and_award_story_badges(db, current_user.id)
+    await db.commit()
 
     story_response = StoryResponse.from_orm_with_author(story, current_user.username)
     like_count = await _get_story_like_count(db, story.id)

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -1,3 +1,6 @@
+import uuid
+
+from fastapi import HTTPException, status
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -8,7 +11,14 @@ from app.db.story_like import StoryLike
 from app.db.story_save import StorySave
 from app.db.user import User
 from app.models.story import StoryResponse
-from app.models.user import UserDashboardResponse, UserEngagementStatsResponse, UserStoryListResponse
+from app.models.user import (
+    UserDashboardResponse,
+    UserEngagementStatsResponse,
+    UserPublicProfileResponse,
+    UserStoryListResponse,
+)
+from app.services.badge_service import get_user_badges
+from app.services.storage import build_public_object_url
 
 
 def _map_user_story_rows(
@@ -187,4 +197,33 @@ async def get_current_user_dashboard(
         total_likes_received=values["total_likes_received"],
         total_comments_received=values["total_comments_received"],
         total_saves_received=values["total_saves_received"],
+    )
+
+
+async def get_user_public_profile(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+) -> UserPublicProfileResponse:
+    result = await db.execute(select(User).where(User.id == user_id))
+    user = result.scalar_one_or_none()
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+
+    avatar_url = None
+    if user.avatar_bucket_name and user.avatar_storage_key:
+        avatar_url = build_public_object_url(
+            bucket_name=user.avatar_bucket_name,
+            storage_key=user.avatar_storage_key,
+        )
+
+    badges = await get_user_badges(db, user_id)
+    return UserPublicProfileResponse(
+        id=user.id,
+        username=user.username,
+        display_name=user.display_name,
+        bio=user.bio,
+        location=user.location,
+        avatar_url=avatar_url,
+        badges=badges,
+        created_at=user.created_at,
     )

--- a/backend/tests/unit/test_badge_service.py
+++ b/backend/tests/unit/test_badge_service.py
@@ -1,0 +1,183 @@
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.db.enums import BadgeRuleType
+from app.services.badge_service import check_and_award_story_badges, get_user_badges
+
+
+def _make_badge(rule_type: BadgeRuleType, name: str = "Badge") -> SimpleNamespace:
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        name=name,
+        description="A badge",
+        icon_key=f"badge_{rule_type.value}",
+        rule_type=rule_type,
+    )
+
+
+def _make_user_badge(user_id: uuid.UUID, badge: SimpleNamespace) -> SimpleNamespace:
+    return SimpleNamespace(
+        user_id=user_id,
+        badge_id=badge.id,
+        awarded_at=datetime.now(timezone.utc),
+        badge=badge,
+    )
+
+
+@pytest.mark.asyncio
+class TestCheckAndAwardStoryBadges:
+    async def test_no_badges_awarded_when_story_count_is_zero(self):
+        user_id = uuid.uuid4()
+        db = AsyncMock()
+        db.execute.side_effect = [
+            SimpleNamespace(scalar_one=lambda: 0),  # story count
+            SimpleNamespace(all=lambda: []),  # owned badge_ids
+        ]
+
+        await check_and_award_story_badges(db, user_id)
+
+        db.add.assert_not_called()
+
+    async def test_first_story_badge_awarded_on_first_story(self):
+        user_id = uuid.uuid4()
+        badge = _make_badge(BadgeRuleType.FIRST_STORY)
+
+        db = AsyncMock()
+        db.execute.side_effect = [
+            SimpleNamespace(scalar_one=lambda: 1),   # story count = 1
+            SimpleNamespace(all=lambda: []),          # no badges owned yet
+            SimpleNamespace(scalars=lambda: SimpleNamespace(all=lambda: [badge])),  # batch badges
+        ]
+        db.add = MagicMock()
+
+        await check_and_award_story_badges(db, user_id)
+
+        assert db.add.call_count == 1
+        awarded = db.add.call_args.args[0]
+        assert awarded.user_id == user_id
+        assert awarded.badge_id == badge.id
+
+    async def test_milestone_5_badge_awarded_at_five_stories(self):
+        user_id = uuid.uuid4()
+        first_badge = _make_badge(BadgeRuleType.FIRST_STORY)
+        milestone_badge = _make_badge(BadgeRuleType.STORY_MILESTONE_5)
+
+        db = AsyncMock()
+        # first_badge is already owned; batch returns both qualifying badges
+        db.execute.side_effect = [
+            SimpleNamespace(scalar_one=lambda: 5),
+            SimpleNamespace(all=lambda: [(first_badge.id,)]),
+            SimpleNamespace(scalars=lambda: SimpleNamespace(all=lambda: [first_badge, milestone_badge])),
+        ]
+        db.add = MagicMock()
+
+        await check_and_award_story_badges(db, user_id)
+
+        assert db.add.call_count == 1
+        awarded = db.add.call_args.args[0]
+        assert awarded.badge_id == milestone_badge.id
+
+    async def test_milestone_10_badge_awarded_at_ten_stories(self):
+        user_id = uuid.uuid4()
+        first_badge = _make_badge(BadgeRuleType.FIRST_STORY)
+        milestone_5_badge = _make_badge(BadgeRuleType.STORY_MILESTONE_5)
+        milestone_10_badge = _make_badge(BadgeRuleType.STORY_MILESTONE_10)
+
+        db = AsyncMock()
+        db.execute.side_effect = [
+            SimpleNamespace(scalar_one=lambda: 10),
+            SimpleNamespace(all=lambda: [(first_badge.id,), (milestone_5_badge.id,)]),
+            SimpleNamespace(scalars=lambda: SimpleNamespace(all=lambda: [first_badge, milestone_5_badge, milestone_10_badge])),
+        ]
+        db.add = MagicMock()
+
+        await check_and_award_story_badges(db, user_id)
+
+        assert db.add.call_count == 1
+        awarded = db.add.call_args.args[0]
+        assert awarded.badge_id == milestone_10_badge.id
+
+    async def test_no_badge_awarded_when_already_owned(self):
+        user_id = uuid.uuid4()
+        badge = _make_badge(BadgeRuleType.FIRST_STORY)
+
+        db = AsyncMock()
+        db.execute.side_effect = [
+            SimpleNamespace(scalar_one=lambda: 3),
+            SimpleNamespace(all=lambda: [(badge.id,)]),  # already owns it
+            SimpleNamespace(scalars=lambda: SimpleNamespace(all=lambda: [badge])),
+        ]
+        db.add = MagicMock()
+
+        await check_and_award_story_badges(db, user_id)
+
+        db.add.assert_not_called()
+
+    async def test_no_badge_awarded_when_badge_row_missing_from_db(self):
+        user_id = uuid.uuid4()
+
+        db = AsyncMock()
+        db.execute.side_effect = [
+            SimpleNamespace(scalar_one=lambda: 1),
+            SimpleNamespace(all=lambda: []),
+            SimpleNamespace(scalars=lambda: SimpleNamespace(all=lambda: [])),  # badge not seeded
+        ]
+        db.add = MagicMock()
+
+        await check_and_award_story_badges(db, user_id)
+
+        db.add.assert_not_called()
+
+    async def test_all_three_badges_awarded_at_ten_stories_when_none_owned(self):
+        user_id = uuid.uuid4()
+        b1 = _make_badge(BadgeRuleType.FIRST_STORY)
+        b5 = _make_badge(BadgeRuleType.STORY_MILESTONE_5)
+        b10 = _make_badge(BadgeRuleType.STORY_MILESTONE_10)
+
+        db = AsyncMock()
+        db.execute.side_effect = [
+            SimpleNamespace(scalar_one=lambda: 10),
+            SimpleNamespace(all=lambda: []),  # owns nothing
+            SimpleNamespace(scalars=lambda: SimpleNamespace(all=lambda: [b1, b5, b10])),
+        ]
+        db.add = MagicMock()
+
+        await check_and_award_story_badges(db, user_id)
+
+        assert db.add.call_count == 3
+        awarded_badge_ids = {c.args[0].badge_id for c in db.add.call_args_list}
+        assert awarded_badge_ids == {b1.id, b5.id, b10.id}
+
+
+@pytest.mark.asyncio
+class TestGetUserBadges:
+    async def test_returns_empty_list_when_no_badges(self):
+        user_id = uuid.uuid4()
+        db = AsyncMock()
+        db.execute.return_value.all = lambda: []
+
+        result = await get_user_badges(db, user_id)
+
+        assert result == []
+
+    async def test_returns_badge_responses_in_award_order(self):
+        user_id = uuid.uuid4()
+        badge1 = _make_badge(BadgeRuleType.FIRST_STORY, name="First Story")
+        badge5 = _make_badge(BadgeRuleType.STORY_MILESTONE_5, name="Story Teller")
+        ub1 = _make_user_badge(user_id, badge1)
+        ub5 = _make_user_badge(user_id, badge5)
+
+        db = AsyncMock()
+        db.execute.return_value.all = lambda: [(ub1, badge1), (ub5, badge5)]
+
+        result = await get_user_badges(db, user_id)
+
+        assert len(result) == 2
+        assert result[0].name == "First Story"
+        assert result[0].rule_type == BadgeRuleType.FIRST_STORY
+        assert result[1].name == "Story Teller"
+        assert result[1].awarded_at == ub5.awarded_at

--- a/backend/tests/unit/test_badge_service.py
+++ b/backend/tests/unit/test_badge_service.py
@@ -48,8 +48,8 @@ class TestCheckAndAwardStoryBadges:
 
         db = AsyncMock()
         db.execute.side_effect = [
-            SimpleNamespace(scalar_one=lambda: 1),   # story count = 1
-            SimpleNamespace(all=lambda: []),          # no badges owned yet
+            SimpleNamespace(scalar_one=lambda: 1),  # story count = 1
+            SimpleNamespace(all=lambda: []),  # no badges owned yet
             SimpleNamespace(scalars=lambda: SimpleNamespace(all=lambda: [badge])),  # batch badges
         ]
         db.add = MagicMock()
@@ -91,7 +91,9 @@ class TestCheckAndAwardStoryBadges:
         db.execute.side_effect = [
             SimpleNamespace(scalar_one=lambda: 10),
             SimpleNamespace(all=lambda: [(first_badge.id,), (milestone_5_badge.id,)]),
-            SimpleNamespace(scalars=lambda: SimpleNamespace(all=lambda: [first_badge, milestone_5_badge, milestone_10_badge])),
+            SimpleNamespace(
+                scalars=lambda: SimpleNamespace(all=lambda: [first_badge, milestone_5_badge, milestone_10_badge])
+            ),
         ]
         db.add = MagicMock()
 

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -1038,7 +1038,8 @@ class TestCreateStoryWithLocationService:
         db.refresh.side_effect = _refresh_side_effect
         db.execute.return_value.scalar_one = lambda: 0
 
-        result = await create_story_with_location(db, current_user, payload)
+        with patch("app.services.story_service.check_and_award_story_badges", new_callable=AsyncMock):
+            result = await create_story_with_location(db, current_user, payload)
 
         assert result.title == "New Story"
         assert result.author == "authoruser"
@@ -1053,7 +1054,7 @@ class TestCreateStoryWithLocationService:
         assert result.media_files == []
         assert result.like_count == 0
         db.add.assert_called_once()
-        db.commit.assert_awaited_once()
+        assert db.commit.await_count == 2
         db.refresh.assert_awaited_once()
 
     async def test_create_story_rejects_missing_place_name(self):
@@ -1436,7 +1437,8 @@ class TestAnonymousStoryService:
         db.refresh.side_effect = _refresh_side_effect
         db.execute.return_value.scalar_one = lambda: 0
 
-        result = await create_story_with_location(db, current_user, payload)
+        with patch("app.services.story_service.check_and_award_story_badges", new_callable=AsyncMock):
+            result = await create_story_with_location(db, current_user, payload)
 
         assert result.is_anonymous is True
         assert result.author is None


### PR DESCRIPTION
## Summary

- Add `Badge` and `UserBadge` ORM models with a composite PK on `user_badges` to prevent duplicates
- Alembic migration (`20260510_0019`) creates both tables and seeds three badges: First Story (1), Story Teller (5), Story Master (10)
- Batch-query rules engine in `badge_service.py`: after each story creation, compute qualifying rule types in Python, then fetch all matching badges in one `IN` query and award any not yet owned
- Expose earned badges on `GET /auth/me` (updated to async with `get_full_user_profile`) and new `GET /users/{id}/profile` endpoint
- 9 unit tests for `check_and_award_story_badges` and `get_user_badges` covering all milestone thresholds, idempotency, and missing seed data

Closes #237

## Test plan

- [ ] All tests passed
- [x] I have self-reviewed my own code
- [x] I have requested at least 1 reviewer