### PR TITLE
Complete Google OAuth frontend handoff

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -29,6 +29,7 @@ JWT_EXPIRE_MINUTES=30
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_REDIRECT_URI=http://localhost:8000/auth/google/callback
+FRONTEND_GOOGLE_CALLBACK_URL=http://localhost:3000/oauth-callback.html
 
 # ── Speech-to-Text (faster-whisper) ───────────────────────────────────────────
 TRANSCRIPTION_MODEL=base

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -36,6 +36,7 @@ class Settings(BaseSettings):
     GOOGLE_CLIENT_ID: str = ""
     GOOGLE_CLIENT_SECRET: str = ""
     GOOGLE_REDIRECT_URI: str = "http://localhost:8000/auth/google/callback"
+    FRONTEND_GOOGLE_CALLBACK_URL: str = "http://localhost:3000/oauth-callback.html"
 
     # ── Speech-to-Text ───────────────────────────────────────────────────────
     TRANSCRIPTION_MODEL: str = "base"

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,9 +1,11 @@
 import secrets
+from urllib.parse import urlencode
 
 from fastapi import APIRouter, Cookie, Depends, File, HTTPException, Query, Response, UploadFile, status
 from fastapi.responses import RedirectResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.core.deps import get_current_user
 from app.db.session import get_db
 from app.db.user import User
@@ -103,7 +105,9 @@ async def google_callback(
 ):
     if not oauth_state or state != oauth_state:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid OAuth state")
-    return await google_oauth_login(db, code)
+    token = await google_oauth_login(db, code)
+    fragment = urlencode({"access_token": token.access_token, "token_type": token.token_type})
+    return RedirectResponse(url=f"{settings.FRONTEND_GOOGLE_CALLBACK_URL}#{fragment}")
 
 
 @router.get(

--- a/backend/tests/api/test_auth_api.py
+++ b/backend/tests/api/test_auth_api.py
@@ -448,3 +448,28 @@ class TestGoogleOAuthCallbackAPI:
             cookies={"oauth_state": "real-state"},
         )
         assert resp.status_code == 422
+
+    async def test_callback_redirects_to_frontend_with_token_fragment(self, client, monkeypatch):
+        from app.models.user import TokenResponse
+
+        async def fake_google_oauth_login(db, code):
+            assert code == "fake-code"
+            return TokenResponse(access_token="app-jwt-token")
+
+        monkeypatch.setattr("app.routers.auth.google_oauth_login", fake_google_oauth_login)
+        monkeypatch.setattr(
+            "app.routers.auth.settings.FRONTEND_GOOGLE_CALLBACK_URL",
+            "http://localhost:3000/oauth-callback.html",
+        )
+
+        resp = await client.get(
+            "/auth/google/callback?code=fake-code&state=real-state",
+            cookies={"oauth_state": "real-state"},
+            follow_redirects=False,
+        )
+
+        assert resp.status_code in (302, 307)
+        assert (
+            resp.headers["location"]
+            == "http://localhost:3000/oauth-callback.html#access_token=app-jwt-token&token_type=bearer"
+        )

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,6 +2,7 @@ FROM nginx:alpine
 
 COPY index.html /usr/share/nginx/html/index.html
 COPY forgot-password.html /usr/share/nginx/html/forgot-password.html
+COPY oauth-callback.html /usr/share/nginx/html/oauth-callback.html
 COPY register.html /usr/share/nginx/html/register.html
 COPY map.html /usr/share/nginx/html/map.html
 COPY story-create.html /usr/share/nginx/html/story-create.html

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -16,6 +16,7 @@ COPY profile.js /usr/share/nginx/html/profile.js
 COPY edit-profile.js /usr/share/nginx/html/edit-profile.js
 COPY login.js /usr/share/nginx/html/login.js
 COPY auth.js /usr/share/nginx/html/auth.js
+COPY oauth-callback.js /usr/share/nginx/html/oauth-callback.js
 COPY config.js /usr/share/nginx/html/config.js
 COPY saves.js /usr/share/nginx/html/saves.js
 COPY saved.js /usr/share/nginx/html/saved.js

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -16,6 +16,7 @@ COPY profile.js /usr/share/nginx/html/profile.js
 COPY edit-profile.js /usr/share/nginx/html/edit-profile.js
 COPY login.js /usr/share/nginx/html/login.js
 COPY auth.js /usr/share/nginx/html/auth.js
+COPY oauth-button.js /usr/share/nginx/html/oauth-button.js
 COPY oauth-callback.js /usr/share/nginx/html/oauth-callback.js
 COPY config.js /usr/share/nginx/html/config.js
 COPY saves.js /usr/share/nginx/html/saves.js

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -46,6 +46,40 @@
       background-position: center;
       background-attachment: fixed;
     }
+
+    .google-auth-button {
+      align-items: center;
+      background: #ffffff;
+      border: 1px solid #747775;
+      border-radius: 4px;
+      color: #1f1f1f;
+      display: inline-flex;
+      font-family: "Roboto", Arial, sans-serif;
+      font-size: 14px;
+      font-weight: 500;
+      gap: 12px;
+      height: 40px;
+      justify-content: center;
+      padding: 0 12px;
+      transition: background-color 0.2s, box-shadow 0.2s;
+      width: 100%;
+    }
+
+    .google-auth-button:hover {
+      background: #f8fafd;
+      box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);
+    }
+
+    .google-auth-button:focus-visible {
+      outline: 2px solid #1a73e8;
+      outline-offset: 2px;
+    }
+
+    .google-auth-button svg {
+      flex: 0 0 auto;
+      height: 18px;
+      width: 18px;
+    }
   </style>
 </head>
 
@@ -147,9 +181,14 @@
           </div>
 
           <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <a href="story-detail.html"
-              class="inline-flex items-center justify-center rounded-xl border border-border bg-white px-4 py-3 text-sm font-medium hover:bg-gray-50 transition">
-              Continue with Google
+            <a id="google-auth-button" data-testid="login-google" href="/auth/google/login" class="google-auth-button">
+              <svg aria-hidden="true" viewBox="0 0 18 18">
+                <path fill="#4285F4" d="M17.64 9.2c0-.64-.06-1.25-.16-1.84H9v3.48h4.84a4.14 4.14 0 0 1-1.8 2.72v2.26h2.9c1.7-1.56 2.7-3.86 2.7-6.62z" />
+                <path fill="#34A853" d="M9 18c2.43 0 4.47-.8 5.96-2.18l-2.9-2.26c-.8.54-1.84.86-3.06.86-2.35 0-4.34-1.59-5.05-3.72H.96v2.33A9 9 0 0 0 9 18z" />
+                <path fill="#FBBC05" d="M3.95 10.7A5.41 5.41 0 0 1 3.67 9c0-.59.1-1.16.28-1.7V4.97H.96A9 9 0 0 0 0 9c0 1.45.35 2.82.96 4.03l2.99-2.33z" />
+                <path fill="#EA4335" d="M9 3.58c1.32 0 2.5.45 3.44 1.35l2.58-2.58C13.46.89 11.42 0 9 0A9 9 0 0 0 .96 4.97L3.95 7.3C4.66 5.17 6.65 3.58 9 3.58z" />
+              </svg>
+              <span>Sign in with Google</span>
             </a>
             <button id="register-button" type="button"
               class="inline-flex items-center justify-center rounded-xl border border-border bg-white px-4 py-3 text-sm font-medium hover:bg-gray-50 transition">
@@ -174,6 +213,14 @@
   <script src="config.js"></script>
   <script src="auth.js"></script>
   <script src="login.js"></script>
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      var googleAuthButton = document.getElementById("google-auth-button");
+      if (googleAuthButton && typeof API_BASE !== "undefined") {
+        googleAuthButton.href = API_BASE + "/auth/google/login";
+      }
+    });
+  </script>
 </body>
 
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -213,14 +213,7 @@
   <script src="config.js"></script>
   <script src="auth.js"></script>
   <script src="login.js"></script>
-  <script>
-    document.addEventListener("DOMContentLoaded", function () {
-      var googleAuthButton = document.getElementById("google-auth-button");
-      if (googleAuthButton && typeof API_BASE !== "undefined") {
-        googleAuthButton.href = API_BASE + "/auth/google/login";
-      }
-    });
-  </script>
+  <script src="oauth-button.js"></script>
 </body>
 
 </html>

--- a/frontend/oauth-button.js
+++ b/frontend/oauth-button.js
@@ -1,0 +1,26 @@
+function googleAuthLoginUrl(apiBase) {
+    return String(apiBase || "").replace(/\/$/, "") + "/auth/google/login";
+}
+
+function configureGoogleAuthButton(doc, apiBase) {
+    var googleAuthButton = doc.getElementById("google-auth-button");
+    if (!googleAuthButton || typeof apiBase === "undefined") {
+        return false;
+    }
+
+    googleAuthButton.href = googleAuthLoginUrl(apiBase);
+    return true;
+}
+
+if (typeof document !== "undefined") {
+    document.addEventListener("DOMContentLoaded", function () {
+        configureGoogleAuthButton(document, typeof API_BASE === "undefined" ? undefined : API_BASE);
+    });
+}
+
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = {
+        configureGoogleAuthButton: configureGoogleAuthButton,
+        googleAuthLoginUrl: googleAuthLoginUrl,
+    };
+}

--- a/frontend/oauth-button.test.js
+++ b/frontend/oauth-button.test.js
@@ -1,0 +1,37 @@
+const {
+    configureGoogleAuthButton,
+    googleAuthLoginUrl,
+} = require("./oauth-button");
+
+describe("Google OAuth button wiring", () => {
+    beforeEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    test("builds backend Google login URL from API base", () => {
+        expect(googleAuthLoginUrl("http://localhost:8000")).toBe("http://localhost:8000/auth/google/login");
+        expect(googleAuthLoginUrl("http://localhost:8000/")).toBe("http://localhost:8000/auth/google/login");
+    });
+
+    test("sets login page Google button href to backend endpoint", () => {
+        document.body.innerHTML = '<a id="google-auth-button" data-testid="login-google" href="/auth/google/login"></a>';
+
+        const configured = configureGoogleAuthButton(document, "http://api.test");
+
+        expect(configured).toBe(true);
+        expect(document.getElementById("google-auth-button").href).toBe("http://api.test/auth/google/login");
+    });
+
+    test("sets register page Google button href to backend endpoint", () => {
+        document.body.innerHTML = '<a id="google-auth-button" data-testid="register-google" href="/auth/google/login"></a>';
+
+        const configured = configureGoogleAuthButton(document, "http://api.test");
+
+        expect(configured).toBe(true);
+        expect(document.querySelector('[data-testid="register-google"]').href).toBe("http://api.test/auth/google/login");
+    });
+
+    test("does nothing when Google button is absent", () => {
+        expect(configureGoogleAuthButton(document, "http://api.test")).toBe(false);
+    });
+});

--- a/frontend/oauth-callback.html
+++ b/frontend/oauth-callback.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Completing Google Sign In</title>
+  <script src="https://cdn.tailwindcss.com?plugins=forms"></script>
+</head>
+
+<body class="min-h-screen bg-[#fef9f0] font-sans text-[#1d1c16]">
+  <main class="flex min-h-screen items-center justify-center px-6">
+    <section class="w-full max-w-md rounded-xl border border-[#e7e2d9] bg-white p-6 text-center shadow-sm">
+      <h1 class="text-xl font-semibold">Completing sign in...</h1>
+      <p id="oauth-status" class="mt-3 text-sm text-[#5f584c]">Please wait while we finish Google sign in.</p>
+      <a id="oauth-login-link" href="index.html"
+        class="mt-5 hidden rounded-md bg-[#775a19] px-4 py-2 text-sm font-semibold text-white">
+        Return to login
+      </a>
+    </section>
+  </main>
+
+  <script>
+    (function () {
+      var params = new URLSearchParams(window.location.hash.replace(/^#/, ""));
+      var token = params.get("access_token");
+      var status = document.getElementById("oauth-status");
+      var loginLink = document.getElementById("oauth-login-link");
+
+      if (!token) {
+        status.textContent = "Google sign in could not be completed.";
+        loginLink.classList.remove("hidden");
+        return;
+      }
+
+      localStorage.setItem("auth_token", token);
+      window.history.replaceState({}, document.title, window.location.pathname);
+      window.location.assign("map.html");
+    })();
+  </script>
+</body>
+
+</html>

--- a/frontend/oauth-callback.html
+++ b/frontend/oauth-callback.html
@@ -11,7 +11,7 @@
 <body class="min-h-screen bg-[#fef9f0] font-sans text-[#1d1c16]">
   <main class="flex min-h-screen items-center justify-center px-6">
     <section class="w-full max-w-md rounded-xl border border-[#e7e2d9] bg-white p-6 text-center shadow-sm">
-      <h1 class="text-xl font-semibold">Completing sign in...</h1>
+      <h1 id="oauth-title" class="text-xl font-semibold">Completing sign in...</h1>
       <p id="oauth-status" class="mt-3 text-sm text-[#5f584c]">Please wait while we finish Google sign in.</p>
       <a id="oauth-login-link" href="index.html"
         class="mt-5 hidden rounded-md bg-[#775a19] px-4 py-2 text-sm font-semibold text-white">
@@ -20,24 +20,7 @@
     </section>
   </main>
 
-  <script>
-    (function () {
-      var params = new URLSearchParams(window.location.hash.replace(/^#/, ""));
-      var token = params.get("access_token");
-      var status = document.getElementById("oauth-status");
-      var loginLink = document.getElementById("oauth-login-link");
-
-      if (!token) {
-        status.textContent = "Google sign in could not be completed.";
-        loginLink.classList.remove("hidden");
-        return;
-      }
-
-      localStorage.setItem("auth_token", token);
-      window.history.replaceState({}, document.title, window.location.pathname);
-      window.location.assign("map.html");
-    })();
-  </script>
+  <script src="oauth-callback.js"></script>
 </body>
 
 </html>

--- a/frontend/oauth-callback.js
+++ b/frontend/oauth-callback.js
@@ -1,0 +1,53 @@
+var OAUTH_ERROR_MESSAGE = "Something went wrong while signing you in. Please try again.";
+
+function getOAuthParams(win) {
+    var hashParams = new URLSearchParams((win.location.hash || "").replace(/^#/, ""));
+    var queryParams = new URLSearchParams(win.location.search || "");
+
+    return {
+        token: hashParams.get("access_token"),
+        error: hashParams.get("error") || queryParams.get("error") || queryParams.get("google_auth_error"),
+    };
+}
+
+function showOAuthError(doc) {
+    var title = doc.getElementById("oauth-title");
+    var status = doc.getElementById("oauth-status");
+    var loginLink = doc.getElementById("oauth-login-link");
+
+    if (title) title.textContent = "Sign in failed";
+    if (status) status.textContent = OAUTH_ERROR_MESSAGE;
+    if (loginLink) loginLink.classList.remove("hidden");
+}
+
+function completeOAuthSignIn(win, doc, storage) {
+    var params = getOAuthParams(win);
+
+    if (params.error || !params.token) {
+        showOAuthError(doc);
+        return false;
+    }
+
+    try {
+        storage.setItem("auth_token", params.token);
+        win.history.replaceState({}, doc.title, win.location.pathname);
+        win.location.assign("map.html");
+        return true;
+    } catch {
+        showOAuthError(doc);
+        return false;
+    }
+}
+
+if (typeof window !== "undefined" && typeof document !== "undefined") {
+    completeOAuthSignIn(window, document, localStorage);
+}
+
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = {
+        OAUTH_ERROR_MESSAGE: OAUTH_ERROR_MESSAGE,
+        completeOAuthSignIn: completeOAuthSignIn,
+        getOAuthParams: getOAuthParams,
+        showOAuthError: showOAuthError,
+    };
+}

--- a/frontend/oauth-callback.test.js
+++ b/frontend/oauth-callback.test.js
@@ -1,0 +1,78 @@
+const {
+    OAUTH_ERROR_MESSAGE,
+    completeOAuthSignIn,
+    getOAuthParams,
+} = require("./oauth-callback");
+
+function setupDom() {
+    document.body.innerHTML = `
+      <h1 id="oauth-title">Completing sign in...</h1>
+      <p id="oauth-status">Please wait while we finish Google sign in.</p>
+      <a id="oauth-login-link" class="hidden" href="index.html">Return to login</a>
+    `;
+}
+
+function makeWindow(hash, search) {
+    return {
+        location: {
+            hash: hash || "",
+            search: search || "",
+            pathname: "/oauth-callback.html",
+            assign: jest.fn(),
+        },
+        history: {
+            replaceState: jest.fn(),
+        },
+    };
+}
+
+describe("oauth callback handling", () => {
+    beforeEach(() => {
+        setupDom();
+    });
+
+    test("stores token and redirects to map on successful callback", () => {
+        const win = makeWindow("#access_token=test-token&token_type=bearer");
+        const storage = { setItem: jest.fn() };
+
+        const result = completeOAuthSignIn(win, document, storage);
+
+        expect(result).toBe(true);
+        expect(storage.setItem).toHaveBeenCalledWith("auth_token", "test-token");
+        expect(win.history.replaceState).toHaveBeenCalledWith({}, document.title, "/oauth-callback.html");
+        expect(win.location.assign).toHaveBeenCalledWith("map.html");
+    });
+
+    test("shows friendly error when token is missing", () => {
+        const win = makeWindow("");
+        const storage = { setItem: jest.fn() };
+
+        const result = completeOAuthSignIn(win, document, storage);
+
+        expect(result).toBe(false);
+        expect(document.getElementById("oauth-title").textContent).toBe("Sign in failed");
+        expect(document.getElementById("oauth-status").textContent).toBe(OAUTH_ERROR_MESSAGE);
+        expect(document.getElementById("oauth-login-link").classList.contains("hidden")).toBe(false);
+        expect(storage.setItem).not.toHaveBeenCalled();
+    });
+
+    test("shows friendly error when callback includes an error", () => {
+        const win = makeWindow("", "?error=access_denied");
+        const storage = { setItem: jest.fn() };
+
+        const result = completeOAuthSignIn(win, document, storage);
+
+        expect(result).toBe(false);
+        expect(document.getElementById("oauth-status").textContent).toBe(OAUTH_ERROR_MESSAGE);
+        expect(win.location.assign).not.toHaveBeenCalled();
+    });
+
+    test("reads oauth error from frontend-friendly query parameter", () => {
+        const win = makeWindow("", "?google_auth_error=1");
+
+        expect(getOAuthParams(win)).toEqual({
+            token: null,
+            error: "1",
+        });
+    });
+});

--- a/frontend/register.html
+++ b/frontend/register.html
@@ -46,6 +46,40 @@
             background-position: center;
             background-attachment: fixed;
         }
+
+        .google-auth-button {
+            align-items: center;
+            background: #ffffff;
+            border: 1px solid #747775;
+            border-radius: 4px;
+            color: #1f1f1f;
+            display: inline-flex;
+            font-family: "Roboto", Arial, sans-serif;
+            font-size: 14px;
+            font-weight: 500;
+            gap: 12px;
+            height: 40px;
+            justify-content: center;
+            padding: 0 12px;
+            transition: background-color 0.2s, box-shadow 0.2s;
+            width: 100%;
+        }
+
+        .google-auth-button:hover {
+            background: #f8fafd;
+            box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);
+        }
+
+        .google-auth-button:focus-visible {
+            outline: 2px solid #1a73e8;
+            outline-offset: 2px;
+        }
+
+        .google-auth-button svg {
+            flex: 0 0 auto;
+            height: 18px;
+            width: 18px;
+        }
     </style>
 </head>
 
@@ -178,10 +212,16 @@
                         </div>
                     </div>
 
-                    <button
-                        class="w-full inline-flex items-center justify-center rounded-xl border border-border bg-white px-4 py-3 text-sm font-medium hover:bg-gray-50 transition">
-                        Sign up with Google
-                    </button>
+                    <a id="google-auth-button" data-testid="register-google" href="/auth/google/login"
+                        class="google-auth-button">
+                        <svg aria-hidden="true" viewBox="0 0 18 18">
+                            <path fill="#4285F4" d="M17.64 9.2c0-.64-.06-1.25-.16-1.84H9v3.48h4.84a4.14 4.14 0 0 1-1.8 2.72v2.26h2.9c1.7-1.56 2.7-3.86 2.7-6.62z" />
+                            <path fill="#34A853" d="M9 18c2.43 0 4.47-.8 5.96-2.18l-2.9-2.26c-.8.54-1.84.86-3.06.86-2.35 0-4.34-1.59-5.05-3.72H.96v2.33A9 9 0 0 0 9 18z" />
+                            <path fill="#FBBC05" d="M3.95 10.7A5.41 5.41 0 0 1 3.67 9c0-.59.1-1.16.28-1.7V4.97H.96A9 9 0 0 0 0 9c0 1.45.35 2.82.96 4.03l2.99-2.33z" />
+                            <path fill="#EA4335" d="M9 3.58c1.32 0 2.5.45 3.44 1.35l2.58-2.58C13.46.89 11.42 0 9 0A9 9 0 0 0 .96 4.97L3.95 7.3C4.66 5.17 6.65 3.58 9 3.58z" />
+                        </svg>
+                        <span>Sign up with Google</span>
+                    </a>
 
                     <p class="mt-6 text-sm text-textmuted text-center">
                         Already have an account?
@@ -282,8 +322,12 @@
 
         document.addEventListener("DOMContentLoaded", function () {
             const form = document.getElementById("register-form");
+            const googleAuthButton = document.getElementById("google-auth-button");
             if (form) {
                 form.addEventListener("submit", handleRegister);
+            }
+            if (googleAuthButton && typeof API_BASE !== "undefined") {
+                googleAuthButton.href = API_BASE + "/auth/google/login";
             }
         });
     </script>

--- a/frontend/register.html
+++ b/frontend/register.html
@@ -322,15 +322,12 @@
 
         document.addEventListener("DOMContentLoaded", function () {
             const form = document.getElementById("register-form");
-            const googleAuthButton = document.getElementById("google-auth-button");
             if (form) {
                 form.addEventListener("submit", handleRegister);
             }
-            if (googleAuthButton && typeof API_BASE !== "undefined") {
-                googleAuthButton.href = API_BASE + "/auth/google/login";
-            }
         });
     </script>
+    <script src="oauth-button.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- replace Google auth placeholders with Google-branded buttons wired to the backend OAuth entrypoint
- redirect successful Google OAuth callbacks back to a frontend callback page
- store the returned app JWT in localStorage and continue to the map page
- document the frontend callback URL env setting and add callback redirect coverage

## Notes
- Real Google OAuth still requires valid backend Google env vars and Google Cloud redirect URI configuration.

## Tests
- python -m py_compile backend/app/core/config.py backend/app/routers/auth.py
- focused pytest was attempted but blocked by the existing local test DB credential/import-path setup