### PR TITLE
feat: accept optional transcripts on story audio uploads

### DIFF
--- a/backend/app/models/story.py
+++ b/backend/app/models/story.py
@@ -2,9 +2,16 @@ import uuid
 from datetime import date, datetime
 from typing import Self
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from app.db.enums import DatePrecision, MediaType, ReportReason, ReportStatus, StoryStatus, StoryVisibility
+
+
+def _normalize_optional_text(value: str | None) -> str | None:
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
 
 
 class StoryDateInput(BaseModel):
@@ -203,7 +210,13 @@ class MediaUploadRequest(BaseModel):
     media_type: MediaType
     alt_text: str | None = Field(default=None, max_length=500)
     caption: str | None = Field(default=None, max_length=500)
+    transcript: str | None = None
     sort_order: int = Field(default=0, ge=0)
+
+    @field_validator("transcript", mode="before")
+    @classmethod
+    def normalize_transcript(cls, value: str | None) -> str | None:
+        return _normalize_optional_text(value)
 
 
 class MediaFileResponse(BaseModel):

--- a/backend/app/models/story.py
+++ b/backend/app/models/story.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import date, datetime
 from typing import Self
 
-from pydantic import BaseModel, Field, model_validator, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 from sqlalchemy import inspect as sa_inspect
 from sqlalchemy.exc import NoInspectionAvailable
 from sqlalchemy.orm.attributes import NO_VALUE

--- a/backend/app/routers/story.py
+++ b/backend/app/routers/story.py
@@ -408,6 +408,7 @@ async def upload_story_media(
     media_type: MediaType = Form(...),
     alt_text: str | None = Form(default=None),
     caption: str | None = Form(default=None),
+    transcript: str | None = Form(default=None),
     sort_order: int = Form(default=0),
     _current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
@@ -416,6 +417,7 @@ async def upload_story_media(
         media_type=media_type,
         alt_text=alt_text,
         caption=caption,
+        transcript=transcript,
         sort_order=sort_order,
     )
     return await upload_media_for_story(

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -604,6 +604,7 @@ async def upload_media_for_story(
             detail="Failed to upload media to storage",
         )
 
+    transcript = payload.transcript if payload.media_type == MediaType.AUDIO else None
     media = MediaFile(
         story_id=story_id,
         bucket_name=bucket_name,
@@ -615,6 +616,7 @@ async def upload_media_for_story(
         sort_order=payload.sort_order,
         alt_text=payload.alt_text,
         caption=payload.caption,
+        transcript=transcript,
     )
 
     try:
@@ -632,7 +634,7 @@ async def upload_media_for_story(
             detail="Failed to persist media metadata",
         )
 
-    if payload.media_type == MediaType.AUDIO and background_tasks is not None:
+    if payload.media_type == MediaType.AUDIO and transcript is None and background_tasks is not None:
         background_tasks.add_task(
             transcribe_media_file,
             media_file_id=media.id,

--- a/backend/tests/api/test_story_api.py
+++ b/backend/tests/api/test_story_api.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import date, datetime, timezone
+from unittest.mock import AsyncMock
 
 import pytest
 from sqlalchemy import func, select
@@ -299,6 +300,55 @@ class TestStoryMediaUploadAPI:
 
         assert resp.status_code == 422
         assert "Unsupported mime type" in resp.json()["detail"]
+
+    async def test_upload_audio_media_with_transcript_persists_and_skips_background_transcription(
+        self, client, db_session, monkeypatch
+    ):
+        token = await self._create_user_and_token(client)
+
+        user = User(
+            username="storyowner3",
+            email="storyowner3@example.com",
+            password_hash=hash_password("StoryOwner3!"),
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        story = Story(
+            user_id=user.id,
+            title="Story with transcripted audio",
+            summary="summary",
+            content="content",
+            status=StoryStatus.PUBLISHED,
+            visibility=StoryVisibility.PUBLIC,
+        )
+        db_session.add(story)
+        await db_session.commit()
+
+        monkeypatch.setattr("app.services.story_service.upload_bytes", lambda **kwargs: None)
+        transcribe_media_file = AsyncMock()
+        monkeypatch.setattr("app.services.story_service.transcribe_media_file", transcribe_media_file)
+
+        resp = await client.post(
+            f"/stories/{story.id}/media",
+            headers={"Authorization": f"Bearer {token}"},
+            data={
+                "media_type": "audio",
+                "transcript": "  Reviewed transcript  ",
+                "sort_order": "1",
+            },
+            files={"file": ("audio.webm", b"audio-bytes", "audio/webm")},
+        )
+
+        assert resp.status_code == 201
+        media = resp.json()["media"]
+        assert media["media_type"] == "audio"
+        assert media["transcript"] == "Reviewed transcript"
+
+        result = await db_session.execute(select(MediaFile).where(MediaFile.id == uuid.UUID(media["id"])))
+        persisted_media = result.scalar_one()
+        assert persisted_media.transcript == "Reviewed transcript"
+        transcribe_media_file.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_schemas.py
+++ b/backend/tests/unit/test_schemas.py
@@ -271,11 +271,23 @@ class TestMediaUploadRequestSchema:
             media_type=MediaType.AUDIO,
             alt_text="A sound clip",
             caption="Recording from 1920",
+            transcript="Reviewed transcript",
             sort_order=3,
         )
         assert req.alt_text == "A sound clip"
         assert req.caption == "Recording from 1920"
+        assert req.transcript == "Reviewed transcript"
         assert req.sort_order == 3
+
+    def test_trims_transcript(self):
+        req = MediaUploadRequest(media_type=MediaType.AUDIO, transcript="  Reviewed transcript  ")
+
+        assert req.transcript == "Reviewed transcript"
+
+    def test_normalizes_whitespace_only_transcript_to_none(self):
+        req = MediaUploadRequest(media_type=MediaType.AUDIO, transcript="   ")
+
+        assert req.transcript is None
 
     def test_rejects_negative_sort_order(self):
         with pytest.raises(ValidationError):

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -351,6 +351,65 @@ class TestUploadMediaForStoryService:
         assert task.kwargs["content"] == b"audio-bytes"
         assert task.kwargs["mime_type"] == "audio/webm"
 
+    async def test_upload_audio_with_transcript_persists_and_skips_background_transcription(self):
+        story_id = uuid.uuid4()
+        story = _make_story(id=story_id)
+        payload = MediaUploadRequest(media_type=MediaType.AUDIO, transcript="  Reviewed transcript  ")
+        file = _make_upload_file("recording.webm", b"audio-bytes", "audio/webm")
+        background_tasks = BackgroundTasks()
+
+        db = AsyncMock()
+        db.add = MagicMock()
+        db.execute.return_value.scalar_one_or_none = lambda: story
+
+        async def _refresh_side_effect(media_obj):
+            media_obj.id = uuid.uuid4()
+            media_obj.created_at = datetime.now(timezone.utc)
+
+        db.refresh.side_effect = _refresh_side_effect
+
+        with patch("app.services.story_service.upload_bytes"):
+            result = await upload_media_for_story(
+                db,
+                story_id,
+                file,
+                payload,
+                background_tasks=background_tasks,
+            )
+
+        assert result.media.media_type == MediaType.AUDIO
+        assert result.media.transcript == "Reviewed transcript"
+        assert background_tasks.tasks == []
+
+    async def test_upload_audio_with_blank_transcript_queues_background_transcription(self):
+        story_id = uuid.uuid4()
+        story = _make_story(id=story_id)
+        payload = MediaUploadRequest(media_type=MediaType.AUDIO, transcript="   ")
+        file = _make_upload_file("recording.webm", b"audio-bytes", "audio/webm")
+        background_tasks = BackgroundTasks()
+
+        db = AsyncMock()
+        db.add = MagicMock()
+        db.execute.return_value.scalar_one_or_none = lambda: story
+
+        async def _refresh_side_effect(media_obj):
+            media_obj.id = uuid.uuid4()
+            media_obj.created_at = datetime.now(timezone.utc)
+
+        db.refresh.side_effect = _refresh_side_effect
+
+        with patch("app.services.story_service.upload_bytes"):
+            result = await upload_media_for_story(
+                db,
+                story_id,
+                file,
+                payload,
+                background_tasks=background_tasks,
+            )
+
+        assert result.media.transcript is None
+        assert len(background_tasks.tasks) == 1
+
     async def test_upload_image_does_not_queue_background_transcription(self):
         story_id = uuid.uuid4()
         story = _make_story(id=story_id)

--- a/frontend/story-create.html
+++ b/frontend/story-create.html
@@ -241,7 +241,7 @@
                   id="recording-transcript-draft"
                   rows="4"
                   class="mt-2 w-full resize-y rounded-xl border border-border bg-white px-3 py-2 text-sm leading-6 text-textmain shadow-sm focus:border-primary focus:ring-primary disabled:cursor-not-allowed disabled:opacity-60"
-                  placeholder="Transcript appears here after the server responds, or type your own."
+                  placeholder="Transcript appears here after the server responds."
                 ></textarea>
               </div>
 
@@ -846,7 +846,6 @@
         setStartRecordingLabel("Record Again");
         setRecordingStatus("Recording ready. Preview it here, then publish the story to upload it.", false);
         void fetchTranscriptionPreviewForRecordedFile(recordedFile);
-        void fetchTranscriptionPreviewForRecordedFile(recordedFile);
       });
 
       recorder.start();
@@ -1056,6 +1055,12 @@
         formData.append("file", file);
         formData.append("media_type", mediaType);
         formData.append("sort_order", String(fileIndex));
+
+        if (mediaType === "audio" && recordedFiles && recordedFiles.indexOf(file) !== -1) {
+          var transcriptDraft = document.getElementById("recording-transcript-draft");
+          var transcriptValue = transcriptDraft ? transcriptDraft.value : "";
+          formData.append("transcript", transcriptValue);
+        }
 
         var uploadResponse = await authFetch(API_BASE + "/stories/" + createdStory.id + "/media", {
           method: "POST",


### PR DESCRIPTION
## Description
Add support for an optional `transcript` field on `POST /stories/{story_id}/media` for audio uploads. If a reviewed transcript is provided, the backend now saves it directly to the uploaded media record and skips the background Whisper transcription job. If the field is omitted or blank, the existing background transcription flow remains unchanged.

Suggested labels: `feature`, `backend`

## Related Issue(s)
- Closes #340

## Changes

| File | Change |
|------|--------|
| `backend/app/models/story.py` | Added optional `transcript` to `MediaUploadRequest` and normalized whitespace-only values to `None`. |
| `backend/app/routers/story.py` | Updated the story media upload endpoint to accept `transcript` as an optional multipart form field. |
| `backend/app/services/story_service.py` | Persisted provided transcripts for audio uploads and skipped background transcription when transcript text exists. |
| `backend/tests/unit/test_schemas.py` | Added tests for transcript trimming and blank transcript normalization. |
| `backend/tests/unit/test_story_service.py` | Added tests covering transcript persistence and conditional background transcription behavior. |
| `backend/tests/api/test_story_api.py` | Added API-level coverage to verify transcript persistence and that reviewed audio uploads do not trigger background transcription. |

## Checklist
- [x] All tests passed
- [x] I have self-reviewed my own code
- [x] I have requested at least 1 reviewer
