### PR TITLE
feat: ISSUE-358 semantic search for stories

### DIFF
--- a/backend/app/routers/story.py
+++ b/backend/app/routers/story.py
@@ -211,8 +211,7 @@ async def search_stories(
             detail=exc.errors(include_context=False, include_url=False),
         )
 
-    search_term = q or place_name
-    if search_term is None:
+    if q is None and place_name is None:
         raise HTTPException(
             status_code=422,
             detail="Either q or place_name is required",
@@ -220,7 +219,8 @@ async def search_stories(
 
     return await search_available_stories_by_place(
         db,
-        search_term,
+        place_name=place_name,
+        search_query=q,
         query_start=normalized_query_start,
         query_end=normalized_query_end,
         tags=tags,

--- a/backend/app/routers/story.py
+++ b/backend/app/routers/story.py
@@ -163,18 +163,29 @@ async def list_stories(
 @router.get(
     "/search",
     response_model=StoryListResponse,
-    summary="Search stories by place name",
+    summary="Search stories",
     description=(
-        "Search published public stories by place name (case-insensitive substring match). "
+        "Search published public stories by general query (q) or legacy place_name. "
         "Optionally filter by date range using query_start/query_end/query_precision and by tags. "
         "Multiple tags use OR matching; stories matching more requested tags rank higher."
     ),
     responses={
-        422: {"description": "Validation error for place_name or date filter parameters"},
+        422: {"description": "Validation error for search, tags, or date filter parameters"},
     },
 )
 async def search_stories(
-    place_name: str = Query(min_length=1, max_length=255),
+    q: str | None = Query(
+        default=None,
+        min_length=1,
+        max_length=255,
+        description="General search query. In this API contract step, q is accepted and uses the existing search path.",
+    ),
+    place_name: str | None = Query(
+        default=None,
+        min_length=1,
+        max_length=255,
+        description="Legacy place-name search parameter. Kept for backward compatibility.",
+    ),
     query_start: int | str | None = Query(default=None),
     query_end: int | str | None = Query(default=None),
     query_precision: str | None = Query(default=None),
@@ -200,9 +211,16 @@ async def search_stories(
             detail=exc.errors(include_context=False, include_url=False),
         )
 
+    search_term = q or place_name
+    if search_term is None:
+        raise HTTPException(
+            status_code=422,
+            detail="Either q or place_name is required",
+        )
+
     return await search_available_stories_by_place(
         db,
-        place_name,
+        search_term,
         query_start=normalized_query_start,
         query_end=normalized_query_end,
         tags=tags,

--- a/backend/app/routers/story.py
+++ b/backend/app/routers/story.py
@@ -165,9 +165,11 @@ async def list_stories(
     response_model=StoryListResponse,
     summary="Search stories",
     description=(
-        "Search published public stories by general query (q) or legacy place_name. "
+        "Search published public stories by general query (q) across title, summary, content, place name, and tags, "
+        "or by legacy place_name. "
         "Optionally filter by date range using query_start/query_end/query_precision and by tags. "
-        "Multiple tags use OR matching; stories matching more requested tags rank higher."
+        "Multiple tags use OR matching; stories matching more requested tags rank higher. "
+        "Example: /stories/search?q=gecek"
     ),
     responses={
         422: {"description": "Validation error for search, tags, or date filter parameters"},
@@ -178,7 +180,10 @@ async def search_stories(
         default=None,
         min_length=1,
         max_length=255,
-        description="General search query. In this API contract step, q is accepted and uses the existing search path.",
+        description=(
+            "General search query matched against story title, summary, content, place name, and tags "
+            "(for example, q=gecek can match a story tagged gecekondu)."
+        ),
     ),
     place_name: str | None = Query(
         default=None,

--- a/backend/app/routers/story.py
+++ b/backend/app/routers/story.py
@@ -218,7 +218,7 @@ async def search_stories(
 
     if q is None and place_name is None:
         raise HTTPException(
-            status_code=422,
+            status_code=400,
             detail="Either q or place_name is required",
         )
 

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -69,13 +69,20 @@ def _apply_tag_relevance_filter(stmt, tag_names: list[str]):
 def _apply_hybrid_search_filter(stmt, search_query: str):
     normalized_query = search_query.strip().lower()
     query_pattern = f"%{normalized_query}%"
-    # Score priority: exact tag (30) > partial tag (15) > title (20) > place (10) > summary (12) > content (8).
+    fuzzy_threshold = 0.3
+    title_similarity = func.similarity(Story.title, search_query)
+    summary_similarity = func.similarity(Story.summary, search_query)
+    content_similarity = func.similarity(Story.content, search_query)
+    place_similarity = func.similarity(Story.place_name, search_query)
+    tag_similarity = func.similarity(Tag.name, search_query)
+    # Score priority: exact tag (30) > text/tag substring matches > fuzzy typo matches.
     # Tag scores are aggregated with MAX so a story isn't double-counted for multiple tag rows.
     tag_score = func.coalesce(
         func.max(
             case(
                 (func.lower(Tag.name) == normalized_query, 30),
                 (Tag.name.ilike(query_pattern), 15),
+                (tag_similarity >= fuzzy_threshold, 9),
                 else_=0,
             )
         ),
@@ -83,9 +90,13 @@ def _apply_hybrid_search_filter(stmt, search_query: str):
     )
     text_score = (
         case((Story.title.ilike(query_pattern), 20), else_=0)
+        + case((title_similarity >= fuzzy_threshold, 12), else_=0)
         + case((Story.summary.ilike(query_pattern), 12), else_=0)
+        + case((summary_similarity >= fuzzy_threshold, 7), else_=0)
         + case((Story.content.ilike(query_pattern), 8), else_=0)
+        + case((content_similarity >= fuzzy_threshold, 5), else_=0)
         + case((Story.place_name.ilike(query_pattern), 10), else_=0)
+        + case((place_similarity >= fuzzy_threshold, 6), else_=0)
     )
     search_score = tag_score + text_score
 
@@ -99,6 +110,11 @@ def _apply_hybrid_search_filter(stmt, search_query: str):
                 Story.content.ilike(query_pattern),
                 Story.place_name.ilike(query_pattern),
                 Tag.name.ilike(query_pattern),
+                title_similarity >= fuzzy_threshold,
+                summary_similarity >= fuzzy_threshold,
+                content_similarity >= fuzzy_threshold,
+                place_similarity >= fuzzy_threshold,
+                tag_similarity >= fuzzy_threshold,
             )
         )
         .group_by(Story.id, User.username)

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -69,6 +69,8 @@ def _apply_tag_relevance_filter(stmt, tag_names: list[str]):
 def _apply_hybrid_search_filter(stmt, search_query: str):
     normalized_query = search_query.strip().lower()
     query_pattern = f"%{normalized_query}%"
+    # Score priority: exact tag (30) > partial tag (15) > title (20) > place (10) > summary (12) > content (8).
+    # Tag scores are aggregated with MAX so a story isn't double-counted for multiple tag rows.
     tag_score = func.coalesce(
         func.max(
             case(

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -70,11 +70,17 @@ def _apply_hybrid_search_filter(stmt, search_query: str):
     normalized_query = search_query.strip().lower()
     query_pattern = f"%{normalized_query}%"
     fuzzy_threshold = 0.3
-    title_similarity = func.similarity(Story.title, search_query)
-    summary_similarity = func.similarity(Story.summary, search_query)
-    content_similarity = func.similarity(Story.content, search_query)
-    place_similarity = func.similarity(Story.place_name, search_query)
-    tag_similarity = func.similarity(Tag.name, search_query)
+    title_similarity = func.greatest(func.similarity(Story.title, search_query), func.word_similarity(search_query, Story.title))
+    summary_similarity = func.greatest(
+        func.similarity(Story.summary, search_query), func.word_similarity(search_query, Story.summary)
+    )
+    content_similarity = func.greatest(
+        func.similarity(Story.content, search_query), func.word_similarity(search_query, Story.content)
+    )
+    place_similarity = func.greatest(
+        func.similarity(Story.place_name, search_query), func.word_similarity(search_query, Story.place_name)
+    )
+    tag_similarity = func.greatest(func.similarity(Tag.name, search_query), func.word_similarity(search_query, Tag.name))
     # Score priority: exact tag (30) > text/tag substring matches > fuzzy typo matches.
     # Tag scores are aggregated with MAX so a story isn't double-counted for multiple tag rows.
     tag_score = func.coalesce(

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -3,7 +3,7 @@ from datetime import date, datetime, timezone
 from pathlib import Path
 
 from fastapi import BackgroundTasks, HTTPException, UploadFile, status
-from sqlalchemy import and_, exists, func, nulls_last, or_, select
+from sqlalchemy import and_, case, exists, func, nulls_last, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -63,6 +63,44 @@ def _apply_tag_relevance_filter(stmt, tag_names: list[str]):
         .where(Tag.name.in_(tag_names))
         .group_by(Story.id, User.username)
         .order_by(tag_match_count.desc(), Story.created_at.desc())
+    )
+
+
+def _apply_hybrid_search_filter(stmt, search_query: str):
+    normalized_query = search_query.strip().lower()
+    query_pattern = f"%{normalized_query}%"
+    tag_score = func.coalesce(
+        func.max(
+            case(
+                (func.lower(Tag.name) == normalized_query, 30),
+                (Tag.name.ilike(query_pattern), 15),
+                else_=0,
+            )
+        ),
+        0,
+    )
+    text_score = (
+        case((Story.title.ilike(query_pattern), 20), else_=0)
+        + case((Story.summary.ilike(query_pattern), 12), else_=0)
+        + case((Story.content.ilike(query_pattern), 8), else_=0)
+        + case((Story.place_name.ilike(query_pattern), 10), else_=0)
+    )
+    search_score = tag_score + text_score
+
+    return (
+        stmt.outerjoin(story_tags_table, story_tags_table.c.story_id == Story.id)
+        .outerjoin(Tag, Tag.id == story_tags_table.c.tag_id)
+        .where(
+            or_(
+                Story.title.ilike(query_pattern),
+                Story.summary.ilike(query_pattern),
+                Story.content.ilike(query_pattern),
+                Story.place_name.ilike(query_pattern),
+                Tag.name.ilike(query_pattern),
+            )
+        )
+        .group_by(Story.id, User.username)
+        .order_by(search_score.desc(), Story.created_at.desc())
     )
 
 
@@ -254,7 +292,8 @@ async def list_available_stories(
 
 async def search_available_stories_by_place(
     db: AsyncSession,
-    place_name: str,
+    place_name: str | None = None,
+    search_query: str | None = None,
     query_start: date | None = None,
     query_end: date | None = None,
     tags: list[str] | None = None,
@@ -268,9 +307,13 @@ async def search_available_stories_by_place(
             Story.status == StoryStatus.PUBLISHED,
             Story.visibility == StoryVisibility.PUBLIC,
             Story.deleted_at.is_(None),
-            Story.place_name.ilike(f"%{place_name}%"),
         )
     )
+
+    if search_query is not None:
+        stmt = _apply_hybrid_search_filter(stmt, search_query)
+    elif place_name is not None:
+        stmt = stmt.where(Story.place_name.ilike(f"%{place_name}%"))
 
     if query_start is not None and query_end is not None:
         stmt = stmt.where(
@@ -280,9 +323,11 @@ async def search_available_stories_by_place(
             Story.date_end >= query_start,
         )
 
-    if normalized_tags:
+    if search_query is not None and normalized_tags:
+        stmt = stmt.where(Tag.name.in_(normalized_tags))
+    elif normalized_tags:
         stmt = _apply_tag_relevance_filter(stmt, normalized_tags)
-    else:
+    elif search_query is None:
         stmt = stmt.order_by(Story.created_at.desc())
 
     result = await db.execute(stmt)

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -70,7 +70,9 @@ def _apply_hybrid_search_filter(stmt, search_query: str):
     normalized_query = search_query.strip().lower()
     query_pattern = f"%{normalized_query}%"
     fuzzy_threshold = 0.3
-    title_similarity = func.greatest(func.similarity(Story.title, search_query), func.word_similarity(search_query, Story.title))
+    title_similarity = func.greatest(
+        func.similarity(Story.title, search_query), func.word_similarity(search_query, Story.title)
+    )
     summary_similarity = func.greatest(
         func.similarity(Story.summary, search_query), func.word_similarity(search_query, Story.summary)
     )
@@ -80,7 +82,9 @@ def _apply_hybrid_search_filter(stmt, search_query: str):
     place_similarity = func.greatest(
         func.similarity(Story.place_name, search_query), func.word_similarity(search_query, Story.place_name)
     )
-    tag_similarity = func.greatest(func.similarity(Tag.name, search_query), func.word_similarity(search_query, Tag.name))
+    tag_similarity = func.greatest(
+        func.similarity(Tag.name, search_query), func.word_similarity(search_query, Tag.name)
+    )
     # Score priority: exact tag (30) > text/tag substring matches > fuzzy typo matches.
     # Tag scores are aggregated with MAX so a story isn't double-counted for multiple tag rows.
     tag_score = func.coalesce(

--- a/backend/tests/api/test_story_api.py
+++ b/backend/tests/api/test_story_api.py
@@ -1432,6 +1432,17 @@ class TestStorySearchAPI:
         assert data["stories"][0]["title"] == "Istanbul Story"
         assert data["stories"][0]["place_name"] == "Istanbul"
 
+    async def test_search_by_q_uses_search_contract(self, client, db_session):
+        await self._seed_stories(db_session)
+
+        resp = await client.get("/stories/search?q=Istanbul")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["stories"][0]["title"] == "Istanbul Story"
+        assert data["stories"][0]["place_name"] == "Istanbul"
+
     async def test_search_by_place_name_returns_only_public_published(self, client, db_session):
         await self._seed_stories(db_session)
 
@@ -1511,9 +1522,15 @@ class TestStorySearchAPI:
         resp = await client.get("/stories/search")
 
         assert resp.status_code == 422
+        assert resp.json()["detail"] == "Either q or place_name is required"
 
     async def test_search_empty_place_name_returns_422(self, client):
         resp = await client.get("/stories/search?place_name=")
+
+        assert resp.status_code == 422
+
+    async def test_search_empty_q_returns_422(self, client):
+        resp = await client.get("/stories/search?q=")
 
         assert resp.status_code == 422
 

--- a/backend/tests/api/test_story_api.py
+++ b/backend/tests/api/test_story_api.py
@@ -1674,8 +1674,21 @@ class TestStorySearchAPI:
     async def test_search_missing_place_name_returns_422(self, client):
         resp = await client.get("/stories/search")
 
-        assert resp.status_code == 422
+        assert resp.status_code == 400
         assert resp.json()["detail"] == "Either q or place_name is required"
+
+    async def test_search_q_takes_precedence_over_place_name(self, client, db_session):
+        await self._seed_stories(db_session)
+
+        # q=istanbul matches the Istanbul story; place_name=Ankara would have returned
+        # the Ankara story if it took precedence. Only Istanbul results should appear.
+        resp = await client.get("/stories/search?q=istanbul&place_name=Ankara")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        titles = [s["title"] for s in data["stories"]]
+        assert "Istanbul Story" in titles
+        assert "Ankara Story" not in titles
 
     async def test_search_empty_place_name_returns_422(self, client):
         resp = await client.get("/stories/search?place_name=")

--- a/backend/tests/api/test_story_api.py
+++ b/backend/tests/api/test_story_api.py
@@ -1478,6 +1478,56 @@ class TestStorySearchAPI:
         assert data["stories"][0]["title"] == "Neighborhood Memory"
         assert data["stories"][0]["tags"] == ["gecekondu"]
 
+    async def test_search_by_q_matches_story_content(self, client, db_session):
+        from app.db.enums import StoryStatus, StoryVisibility
+        from app.db.story import Story
+        from app.db.user import User
+        from app.services.auth_service import hash_password
+
+        user = User(
+            username="contentsearchauthor",
+            email="contentsearchauthor@example.com",
+            password_hash=hash_password("SearchPass1!"),
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        matching_story = Story(
+            user_id=user.id,
+            title="Urban Memory",
+            summary="A local memory",
+            content="A story about old gecekondu streets and neighbors.",
+            status=StoryStatus.PUBLISHED,
+            visibility=StoryVisibility.PUBLIC,
+            place_name="Istanbul",
+        )
+        non_matching_story = Story(
+            user_id=user.id,
+            title="Coastal Memory",
+            summary="A seaside memory",
+            content="A story about boats and sea wind.",
+            status=StoryStatus.PUBLISHED,
+            visibility=StoryVisibility.PUBLIC,
+            place_name="Izmir",
+        )
+        db_session.add_all([matching_story, non_matching_story])
+        await db_session.commit()
+
+        resp = await client.get("/stories/search?q=gecek")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["stories"][0]["title"] == "Urban Memory"
+
+    async def test_search_by_q_no_match_returns_empty(self, client, db_session):
+        await self._seed_stories(db_session)
+
+        resp = await client.get("/stories/search?q=doesnotexist")
+
+        assert resp.status_code == 200
+        assert resp.json() == {"stories": [], "total": 0}
+
     async def test_search_by_place_name_returns_only_public_published(self, client, db_session):
         await self._seed_stories(db_session)
 
@@ -1552,6 +1602,74 @@ class TestStorySearchAPI:
         data = resp.json()
         assert data["total"] == 1
         assert data["stories"][0]["title"] == "Recent Izmir Story"
+
+    async def test_search_by_q_with_tags_and_date_filter_narrows_results(self, client, db_session):
+        from datetime import date
+
+        from app.db.enums import DatePrecision, StoryStatus, StoryVisibility
+        from app.db.story import Story
+        from app.db.user import User
+        from app.services.auth_service import hash_password
+
+        user = User(
+            username="combinedsearchauthor",
+            email="combinedsearchauthor@example.com",
+            password_hash=hash_password("SearchPass1!"),
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        matching_story = Story(
+            user_id=user.id,
+            title="Gecekondu Sports Story",
+            summary="A matching urban sports memory",
+            content="A gecekondu neighborhood sports story.",
+            status=StoryStatus.PUBLISHED,
+            visibility=StoryVisibility.PUBLIC,
+            place_name="Istanbul",
+            date_start=date(2020, 1, 1),
+            date_end=date(2020, 12, 31),
+            date_precision=DatePrecision.YEAR,
+        )
+        wrong_tag_story = Story(
+            user_id=user.id,
+            title="Gecekondu Music Story",
+            summary="Wrong tag",
+            content="A gecekondu neighborhood music story.",
+            status=StoryStatus.PUBLISHED,
+            visibility=StoryVisibility.PUBLIC,
+            place_name="Istanbul",
+            date_start=date(2020, 1, 1),
+            date_end=date(2020, 12, 31),
+            date_precision=DatePrecision.YEAR,
+        )
+        wrong_date_story = Story(
+            user_id=user.id,
+            title="Old Gecekondu Sports Story",
+            summary="Wrong date",
+            content="A gecekondu neighborhood sports story.",
+            status=StoryStatus.PUBLISHED,
+            visibility=StoryVisibility.PUBLIC,
+            place_name="Istanbul",
+            date_start=date(1980, 1, 1),
+            date_end=date(1980, 12, 31),
+            date_precision=DatePrecision.YEAR,
+        )
+        db_session.add_all([matching_story, wrong_tag_story, wrong_date_story])
+        await db_session.commit()
+
+        await apply_ai_tags_to_story(db_session, matching_story.id, ["spor"])
+        await apply_ai_tags_to_story(db_session, wrong_tag_story.id, ["muzik"])
+        await apply_ai_tags_to_story(db_session, wrong_date_story.id, ["spor"])
+
+        resp = await client.get(
+            "/stories/search?q=gecek&tags=spor&query_start=2020-01-01&query_end=2020-12-31&query_precision=date"
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["stories"][0]["title"] == "Gecekondu Sports Story"
 
     async def test_search_missing_place_name_returns_422(self, client):
         resp = await client.get("/stories/search")

--- a/backend/tests/api/test_story_api.py
+++ b/backend/tests/api/test_story_api.py
@@ -1478,6 +1478,41 @@ class TestStorySearchAPI:
         assert data["stories"][0]["title"] == "Neighborhood Memory"
         assert data["stories"][0]["tags"] == ["gecekondu"]
 
+    async def test_search_by_q_matches_story_tags_with_typo(self, client, db_session):
+        from app.db.enums import StoryStatus, StoryVisibility
+        from app.db.story import Story
+        from app.db.user import User
+        from app.services.auth_service import hash_password
+
+        user = User(
+            username="typosearchauthor",
+            email="typosearchauthor@example.com",
+            password_hash=hash_password("SearchPass1!"),
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        story = Story(
+            user_id=user.id,
+            title="Neighborhood Memory",
+            summary="A local city story",
+            content="Families remembered the old streets together.",
+            status=StoryStatus.PUBLISHED,
+            visibility=StoryVisibility.PUBLIC,
+            place_name="Istanbul",
+        )
+        db_session.add(story)
+        await db_session.commit()
+        await apply_ai_tags_to_story(db_session, story.id, ["gecekondu"])
+
+        resp = await client.get("/stories/search?q=gecokondi")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["stories"][0]["title"] == "Neighborhood Memory"
+        assert data["stories"][0]["tags"] == ["gecekondu"]
+
     async def test_search_by_q_matches_story_content(self, client, db_session):
         from app.db.enums import StoryStatus, StoryVisibility
         from app.db.story import Story

--- a/backend/tests/api/test_story_api.py
+++ b/backend/tests/api/test_story_api.py
@@ -1555,6 +1555,39 @@ class TestStorySearchAPI:
         assert data["total"] == 1
         assert data["stories"][0]["title"] == "Urban Memory"
 
+    async def test_search_by_q_matches_story_content_with_typo(self, client, db_session):
+        from app.db.enums import StoryStatus, StoryVisibility
+        from app.db.story import Story
+        from app.db.user import User
+        from app.services.auth_service import hash_password
+
+        user = User(
+            username="contenttypoauthor",
+            email="contenttypoauthor@example.com",
+            password_hash=hash_password("SearchPass1!"),
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        story = Story(
+            user_id=user.id,
+            title="Urban Memory",
+            summary="A local memory",
+            content="A story about old gecekondu streets and neighbors.",
+            status=StoryStatus.PUBLISHED,
+            visibility=StoryVisibility.PUBLIC,
+            place_name="Istanbul",
+        )
+        db_session.add(story)
+        await db_session.commit()
+
+        resp = await client.get("/stories/search?q=gecokondi")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["stories"][0]["title"] == "Urban Memory"
+
     async def test_search_by_q_no_match_returns_empty(self, client, db_session):
         await self._seed_stories(db_session)
 

--- a/backend/tests/api/test_story_api.py
+++ b/backend/tests/api/test_story_api.py
@@ -1443,6 +1443,41 @@ class TestStorySearchAPI:
         assert data["stories"][0]["title"] == "Istanbul Story"
         assert data["stories"][0]["place_name"] == "Istanbul"
 
+    async def test_search_by_q_matches_story_tags(self, client, db_session):
+        from app.db.enums import StoryStatus, StoryVisibility
+        from app.db.story import Story
+        from app.db.user import User
+        from app.services.auth_service import hash_password
+
+        user = User(
+            username="semanticsearchauthor",
+            email="semanticsearchauthor@example.com",
+            password_hash=hash_password("SearchPass1!"),
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        story = Story(
+            user_id=user.id,
+            title="Neighborhood Memory",
+            summary="A local city story",
+            content="Families remembered the old streets together.",
+            status=StoryStatus.PUBLISHED,
+            visibility=StoryVisibility.PUBLIC,
+            place_name="Istanbul",
+        )
+        db_session.add(story)
+        await db_session.commit()
+        await apply_ai_tags_to_story(db_session, story.id, ["gecekondu"])
+
+        resp = await client.get("/stories/search?q=gecek")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["stories"][0]["title"] == "Neighborhood Memory"
+        assert data["stories"][0]["tags"] == ["gecekondu"]
+
     async def test_search_by_place_name_returns_only_public_published(self, client, db_session):
         await self._seed_stories(db_session)
 

--- a/backend/tests/integration/test_story_flow.py
+++ b/backend/tests/integration/test_story_flow.py
@@ -235,8 +235,8 @@ class TestStorySearchByPlaceNameFlow:
 
         assert resp.status_code == 200
         data = resp.json()
-        assert data["total"] == 1
-        assert data["stories"][0]["title"] == "Istanbul Story"
+        titles = [story["title"] for story in data["stories"]]
+        assert "Istanbul Story" in titles
 
     async def test_search_q_returns_matching_story_content_with_typo(self, client):
         await self._seed_stories(client)
@@ -245,8 +245,8 @@ class TestStorySearchByPlaceNameFlow:
 
         assert resp.status_code == 200
         data = resp.json()
-        assert data["total"] == 1
-        assert data["stories"][0]["title"] == "Istanbul Story"
+        titles = [story["title"] for story in data["stories"]]
+        assert "Istanbul Story" in titles
 
     async def test_search_excludes_non_matching_place(self, client):
         await self._seed_stories(client)

--- a/backend/tests/integration/test_story_flow.py
+++ b/backend/tests/integration/test_story_flow.py
@@ -228,6 +228,16 @@ class TestStorySearchByPlaceNameFlow:
         assert data["stories"][0]["title"] == "Istanbul Story"
         assert data["stories"][0]["place_name"] == "Istanbul"
 
+    async def test_search_q_returns_matching_story_content(self, client):
+        await self._seed_stories(client)
+
+        resp = await client.get("/stories/search?q=Content%20about%20Istanbul")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["stories"][0]["title"] == "Istanbul Story"
+
     async def test_search_excludes_non_matching_place(self, client):
         await self._seed_stories(client)
 
@@ -241,6 +251,15 @@ class TestStorySearchByPlaceNameFlow:
         await self._seed_stories(client)
 
         resp = await client.get("/stories/search?place_name=Trabzon")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data == {"stories": [], "total": 0}
+
+    async def test_search_q_no_match_returns_empty(self, client):
+        await self._seed_stories(client)
+
+        resp = await client.get("/stories/search?q=Trabzon")
 
         assert resp.status_code == 200
         data = resp.json()

--- a/backend/tests/integration/test_story_flow.py
+++ b/backend/tests/integration/test_story_flow.py
@@ -224,8 +224,8 @@ class TestStorySearchByPlaceNameFlow:
 
         assert resp.status_code == 200
         data = resp.json()
-        assert data["total"] == 1
-        assert data["stories"][0]["title"] == "Istanbul Story"
+        titles = [story["title"] for story in data["stories"]]
+        assert "Istanbul Story" in titles
         assert data["stories"][0]["place_name"] == "Istanbul"
 
     async def test_search_q_returns_matching_story_content(self, client):

--- a/backend/tests/integration/test_story_flow.py
+++ b/backend/tests/integration/test_story_flow.py
@@ -238,6 +238,16 @@ class TestStorySearchByPlaceNameFlow:
         assert data["total"] == 1
         assert data["stories"][0]["title"] == "Istanbul Story"
 
+    async def test_search_q_returns_matching_story_content_with_typo(self, client):
+        await self._seed_stories(client)
+
+        resp = await client.get("/stories/search?q=Istanubl")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["stories"][0]["title"] == "Istanbul Story"
+
     async def test_search_excludes_non_matching_place(self, client):
         await self._seed_stories(client)
 

--- a/backend/tests/integration/test_story_flow.py
+++ b/backend/tests/integration/test_story_flow.py
@@ -268,4 +268,4 @@ class TestStorySearchByPlaceNameFlow:
     async def test_search_missing_place_name_returns_422(self, client):
         resp = await client.get("/stories/search")
 
-        assert resp.status_code == 422
+        assert resp.status_code == 400

--- a/backend/tests/integration/test_story_tag_flow.py
+++ b/backend/tests/integration/test_story_tag_flow.py
@@ -170,6 +170,24 @@ class TestStoryTagFlow:
         assert data["stories"][0]["id"] == story_id
         assert data["stories"][0]["tags"] == ["gecekondu"]
 
+    async def test_story_search_q_matches_tag_typo(self, client, db_session):
+        token = await self._register_and_login(client, "tagtypo", "tagtypo@example.com")
+        story_id = await self._create_story(client, token, title="Typo Tolerant Memory")
+
+        await apply_ai_tags_to_story(
+            db_session,
+            uuid.UUID(story_id),
+            ["Gecekondu"],
+        )
+
+        resp = await client.get("/stories/search?q=gecokondi")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["stories"][0]["id"] == story_id
+        assert data["stories"][0]["tags"] == ["gecekondu"]
+
     async def test_saved_stories_returns_tags(self, client, db_session):
         author_token = await self._register_and_login(client, "tagsaveauthor", "tagsaveauthor@example.com")
         saver_token = await self._register_and_login(client, "tagsaver", "tagsaver@example.com")

--- a/backend/tests/integration/test_story_tag_flow.py
+++ b/backend/tests/integration/test_story_tag_flow.py
@@ -152,6 +152,24 @@ class TestStoryTagFlow:
         titles = [story["title"] for story in resp.json()["stories"]]
         assert titles == ["Istanbul Sport History Story", "Istanbul Sport Story"]
 
+    async def test_story_search_q_matches_partial_tag(self, client, db_session):
+        token = await self._register_and_login(client, "tagsemantic", "tagsemantic@example.com")
+        story_id = await self._create_story(client, token, title="Gecekondu Memory")
+
+        await apply_ai_tags_to_story(
+            db_session,
+            uuid.UUID(story_id),
+            ["Gecekondu"],
+        )
+
+        resp = await client.get("/stories/search?q=gecek")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["stories"][0]["id"] == story_id
+        assert data["stories"][0]["tags"] == ["gecekondu"]
+
     async def test_saved_stories_returns_tags(self, client, db_session):
         author_token = await self._register_and_login(client, "tagsaveauthor", "tagsaveauthor@example.com")
         saver_token = await self._register_and_login(client, "tagsaver", "tagsaver@example.com")

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -266,6 +266,31 @@ class TestSearchAvailableStoriesByPlaceService:
         assert result.stories == []
         db.execute.assert_awaited_once()
 
+    async def test_general_search_returns_mapped_stories_and_total(self):
+        story = _make_story(title="Gecekondu Memory", place_name="Istanbul")
+
+        db = AsyncMock()
+        db.execute.return_value.all = lambda: [(story, "storyauthor")]
+
+        result = await search_available_stories_by_place(db, search_query="gecek")
+
+        assert result.total == 1
+        assert len(result.stories) == 1
+        assert result.stories[0].id == story.id
+        assert result.stories[0].title == "Gecekondu Memory"
+        assert result.stories[0].author == "storyauthor"
+        db.execute.assert_awaited_once()
+
+    async def test_general_search_returns_empty_response_when_no_match(self):
+        db = AsyncMock()
+        db.execute.return_value.all = lambda: []
+
+        result = await search_available_stories_by_place(db, search_query="unknown")
+
+        assert result.total == 0
+        assert result.stories == []
+        db.execute.assert_awaited_once()
+
     async def test_search_query_includes_date_overlap_filters(self):
         db = AsyncMock()
         db.execute.return_value.all = lambda: []
@@ -299,6 +324,26 @@ class TestSearchAvailableStoriesByPlaceService:
         assert "stories.content" in sql
         assert "stories.place_name" in sql
         assert "tags.name" in sql
+        assert "GROUP BY stories.id, users.username" in sql
+        assert "ORDER BY" in sql
+        assert "stories.created_at DESC" in sql
+
+    async def test_general_search_query_with_tags_keeps_hybrid_search_and_applies_tag_filter(self):
+        db = AsyncMock()
+        db.execute.return_value.all = lambda: []
+
+        await search_available_stories_by_place(db, search_query="gecek", tags=["history"])
+
+        stmt = db.execute.await_args.args[0]
+        sql = str(stmt)
+
+        assert "LEFT OUTER JOIN story_tags" in sql
+        assert "LEFT OUTER JOIN tags" in sql
+        assert "stories.title" in sql
+        assert "stories.summary" in sql
+        assert "stories.content" in sql
+        assert "stories.place_name" in sql
+        assert "tags.name IN" in sql
         assert "GROUP BY stories.id, users.username" in sql
         assert "ORDER BY" in sql
         assert "stories.created_at DESC" in sql

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -283,6 +283,26 @@ class TestSearchAvailableStoriesByPlaceService:
         assert "stories.date_start <=" in sql
         assert "stories.date_end >=" in sql
 
+    async def test_general_search_query_includes_story_text_place_and_tag_matching(self):
+        db = AsyncMock()
+        db.execute.return_value.all = lambda: []
+
+        await search_available_stories_by_place(db, search_query="gecek")
+
+        stmt = db.execute.await_args.args[0]
+        sql = str(stmt)
+
+        assert "LEFT OUTER JOIN story_tags" in sql
+        assert "LEFT OUTER JOIN tags" in sql
+        assert "stories.title" in sql
+        assert "stories.summary" in sql
+        assert "stories.content" in sql
+        assert "stories.place_name" in sql
+        assert "tags.name" in sql
+        assert "GROUP BY stories.id, users.username" in sql
+        assert "ORDER BY" in sql
+        assert "stories.created_at DESC" in sql
+
     async def test_search_query_includes_tag_or_filter_and_relevance_sorting_when_tags_provided(self):
         db = AsyncMock()
         db.execute.return_value.all = lambda: []

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -312,7 +312,7 @@ class TestSearchAvailableStoriesByPlaceService:
         db = AsyncMock()
         db.execute.return_value.all = lambda: []
 
-        await search_available_stories_by_place(db, search_query="gecek")
+        await search_available_stories_by_place(db, search_query="gecokondi")
 
         stmt = db.execute.await_args.args[0]
         sql = str(stmt)
@@ -324,6 +324,7 @@ class TestSearchAvailableStoriesByPlaceService:
         assert "stories.content" in sql
         assert "stories.place_name" in sql
         assert "tags.name" in sql
+        assert "similarity" in sql.lower()
         assert "GROUP BY stories.id, users.username" in sql
         assert "ORDER BY" in sql
         assert "stories.created_at DESC" in sql

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -325,6 +325,7 @@ class TestSearchAvailableStoriesByPlaceService:
         assert "stories.place_name" in sql
         assert "tags.name" in sql
         assert "similarity" in sql.lower()
+        assert "word_similarity" in sql.lower()
         assert "GROUP BY stories.id, users.username" in sql
         assert "ORDER BY" in sql
         assert "stories.created_at DESC" in sql


### PR DESCRIPTION

We added a DB-native hybrid search path to GET /stories/search without introducing Elastic/OpenSearch. The endpoint now accepts q for general search across story title, summary, content, place name, and tags, while keeping the old place_name parameter backward compatible. Results are ranked with a simple internal score based on tag/text/place matches, and existing tag/date filters still work with the new query flow. We also updated OpenAPI text and expanded unit, API, and integration test coverage for the new q behavior.