### PR TITLE
Feat/frontend multi location

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -31,6 +31,8 @@ COPY tags.js /usr/share/nginx/html/tags.js
 COPY search-filters.js /usr/share/nginx/html/search-filters.js
 COPY story-edit.html /usr/share/nginx/html/story-edit.html
 COPY story-transcript.js /usr/share/nginx/html/story-transcript.js
+COPY anonymous.js /usr/share/nginx/html/anonymous.js
+COPY multi-location.js /usr/share/nginx/html/multi-location.js
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 EXPOSE 80

--- a/frontend/map.html
+++ b/frontend/map.html
@@ -259,6 +259,85 @@
             transform: scale(1.1);
         }
 
+        /* Multi-location story marker — tertiary blue with a route badge */
+        .story-marker.multi {
+            background: #35618f;
+            border-color: #ffffff;
+            position: relative;
+        }
+        .story-marker.multi::after {
+            content: attr(data-count);
+            position: absolute;
+            top: -6px;
+            right: -6px;
+            min-width: 18px;
+            height: 18px;
+            padding: 0 4px;
+            border-radius: 9999px;
+            background: #c5a059;
+            color: #1d1c16;
+            font-size: 10px;
+            font-weight: 800;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            border: 2px solid #ffffff;
+            line-height: 1;
+        }
+
+        /* Focus mode banner */
+        #focus-banner {
+            position: absolute;
+            top: 16px;
+            left: 50%;
+            transform: translateX(-50%);
+            z-index: 1000;
+            display: none;
+            align-items: center;
+            gap: 12px;
+            padding: 10px 14px 10px 18px;
+            background: rgba(255, 255, 255, 0.96);
+            backdrop-filter: blur(8px);
+            border: 1px solid #e7e2d9;
+            border-radius: 9999px;
+            box-shadow: 0 12px 32px rgba(0, 0, 0, 0.12);
+            font-family: Inter, sans-serif;
+            font-size: 13px;
+            color: #1d1c16;
+            max-width: calc(100% - 32px);
+        }
+        #focus-banner.visible {
+            display: inline-flex;
+        }
+        #focus-banner .focus-banner-dot {
+            width: 10px;
+            height: 10px;
+            border-radius: 9999px;
+            background: #35618f;
+            flex: 0 0 auto;
+        }
+        #focus-banner .focus-banner-title {
+            font-weight: 700;
+            max-width: 16rem;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        #focus-banner button {
+            border: none;
+            background: #1d1c16;
+            color: #ffffff;
+            font-weight: 600;
+            font-size: 12px;
+            padding: 6px 12px;
+            border-radius: 9999px;
+            cursor: pointer;
+            transition: opacity 0.15s ease;
+        }
+        #focus-banner button:hover {
+            opacity: 0.9;
+        }
+
         /* Story popup card */
         .leaflet-popup-content-wrapper {
             border-radius: 16px !important;
@@ -410,6 +489,18 @@
         <div class="relative h-[58vh] min-h-[360px] md:h-[calc(100vh-68px)]">
             <div id="map" class="absolute inset-0 md:top-0"></div>
 
+            <!-- Focus mode banner (multi-location story view) -->
+            <div id="focus-banner" role="status" aria-live="polite">
+                <span class="focus-banner-dot" aria-hidden="true"></span>
+                <span>
+                    <span class="focus-banner-title" id="focus-banner-title">Story focus</span>
+                    <span style="display:block;font-size:11px;color:#5f584c;margin-top:2px;">
+                        <span id="focus-banner-count">0</span> locations · other stories hidden
+                    </span>
+                </span>
+                <button type="button" id="btn-exit-focus" aria-label="Exit story focus mode">Exit focus</button>
+            </div>
+
             <!-- Map Layer Toggle -->
             <div class="absolute left-4 top-20 z-[1000] flex flex-col gap-2 md:top-40">
                 <button id="btn-layers"
@@ -481,6 +572,7 @@
     <script src="config.js"></script>
     <script src="auth.js"></script>
     <script src="anonymous.js"></script>
+    <script src="multi-location.js"></script>
     <!-- Leaflet JS -->
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
     <script src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"></script>
@@ -788,7 +880,21 @@
         });
 
         // ─── Create Markers ───
-        function createMarkerIcon() {
+        function createMarkerIcon(story) {
+            var multi = hasMultipleLocations(story);
+            if (multi) {
+                var count = story.locations.length;
+                return L.divIcon({
+                    className: "",
+                    html:
+                        '<div class="story-marker multi" data-count="' + count + '" title="Multi-location story (' + count + ' pins)">' +
+                        '<span class="material-symbols-outlined" style="font-size:18px;">route</span>' +
+                        '</div>',
+                    iconSize: [40, 40],
+                    iconAnchor: [20, 20],
+                    popupAnchor: [0, -24]
+                });
+            }
             return L.divIcon({
                 className: "",
                 html: '<div class="story-marker"><span class="material-symbols-outlined" style="font-size:18px;">auto_stories</span></div>',
@@ -866,7 +972,84 @@
             return Number.isFinite(Number(story.latitude)) && Number.isFinite(Number(story.longitude));
         }
 
+        // ─── Focus mode (multi-location story view) ───
+        var focusLayer = L.layerGroup();
+        var focusPolyline = null;
+        var focusStoryId = null;
+        var lastStoriesSnapshot = [];
+
+        function enterFocusMode(story) {
+            focusStoryId = story.id;
+            var locs = getEffectiveLocations(story);
+            if (locs.length === 0) return;
+
+            // Hide all other stories
+            map.removeLayer(markerClusterLayer);
+            focusLayer.clearLayers();
+            if (focusPolyline) {
+                map.removeLayer(focusPolyline);
+                focusPolyline = null;
+            }
+
+            locs.forEach(function (loc, idx) {
+                var marker = L.marker([loc.latitude, loc.longitude], {
+                    icon: buildNumberedIcon(L, idx, { color: "#35618f", size: 36 })
+                });
+                var coordsText = loc.latitude.toFixed(4) + ", " + loc.longitude.toFixed(4);
+                var stopTitle = (idx + 1) + ". " + (loc.label || coordsText);
+                marker.bindPopup(
+                    '<div style="font-family:Inter,sans-serif;min-width:200px;">' +
+                    '<div style="font-size:11px;font-weight:700;color:#35618f;text-transform:uppercase;letter-spacing:0.06em;margin-bottom:4px;">Stop ' + (idx + 1) + ' / ' + locs.length + '</div>' +
+                    '<div style="font-size:13px;font-weight:700;color:#1d1c16;margin-bottom:6px;">' + (loc.label || coordsText) + '</div>' +
+                    '<a href="story-detail.html?id=' + story.id + '" style="font-size:12px;color:#775a19;font-weight:700;text-decoration:none;">Read full story →</a>' +
+                    '</div>',
+                    { closeButton: true }
+                );
+                marker.bindTooltip(stopTitle, { direction: "top", offset: [0, -18] });
+                focusLayer.addLayer(marker);
+            });
+
+            focusPolyline = L.polyline(
+                locs.map(function (l) { return [l.latitude, l.longitude]; }),
+                { color: "#35618f", weight: 4, opacity: 0.75, dashArray: "8 10" }
+            );
+            focusLayer.addLayer(focusPolyline);
+            focusLayer.addTo(map);
+
+            var bounds = L.latLngBounds(locs.map(function (l) { return [l.latitude, l.longitude]; }));
+            map.fitBounds(bounds, { padding: [80, 80], maxZoom: 16 });
+
+            var banner = document.getElementById("focus-banner");
+            document.getElementById("focus-banner-title").textContent = story.title || "Story focus";
+            document.getElementById("focus-banner-count").textContent = String(locs.length);
+            banner.classList.add("visible");
+        }
+
+        function exitFocusMode() {
+            focusStoryId = null;
+            focusLayer.clearLayers();
+            if (map.hasLayer(focusLayer)) map.removeLayer(focusLayer);
+            if (focusPolyline) {
+                map.removeLayer(focusPolyline);
+                focusPolyline = null;
+            }
+            if (!map.hasLayer(markerClusterLayer)) map.addLayer(markerClusterLayer);
+            document.getElementById("focus-banner").classList.remove("visible");
+        }
+
+        document.getElementById("btn-exit-focus").addEventListener("click", exitFocusMode);
+
         function loadStories(stories) {
+            lastStoriesSnapshot = stories || [];
+
+            // If we're in focus mode, don't disturb it — the user is reading
+            // one story, the underlying data refresh will be re-applied when
+            // they exit focus mode.
+            if (focusStoryId) {
+                document.getElementById("story-count").textContent = (stories || []).length + " stories on the map";
+                return;
+            }
+
             // Clear existing markers
             markerClusterLayer.clearLayers();
             markers.length = 0;
@@ -875,16 +1058,25 @@
                 if (!hasStoryCoordinates(story)) return;
 
                 const marker = L.marker([story.latitude, story.longitude], {
-                    icon: createMarkerIcon()
+                    icon: createMarkerIcon(story)
                 });
 
-                marker.bindPopup(buildPopupHtml(story, null), {
-                    maxWidth: 300,
-                    minWidth: 300,
-                    closeButton: true
-                });
+                var isMulti = hasMultipleLocations(story);
+
+                if (!isMulti) {
+                    marker.bindPopup(buildPopupHtml(story, null), {
+                        maxWidth: 300,
+                        minWidth: 300,
+                        closeButton: true
+                    });
+                }
 
                 marker.on("click", function () {
+                    if (isMulti) {
+                        enterFocusMode(story);
+                        return;
+                    }
+
                     // Highlight active marker
                     document.querySelectorAll(".story-marker").forEach(function (el) {
                         el.classList.remove("active");

--- a/frontend/multi-location.js
+++ b/frontend/multi-location.js
@@ -1,0 +1,271 @@
+// Shared helpers + picker for multi-location story support.
+//
+// Data shape used throughout the frontend:
+//   { latitude: number, longitude: number, label: string|null }
+//
+// The picker manages an ordered list of these and renders numbered, draggable
+// markers on a Leaflet map plus a chip strip in a DOM container. Single-pin
+// usage is unchanged: callers can read locations[0] for backwards
+// compatibility with the existing latitude/longitude/place_name flow.
+
+function normalizeLocation(loc) {
+    if (!loc) return null;
+    var lat = typeof loc.latitude === "number" ? loc.latitude : parseFloat(loc.latitude);
+    var lng = typeof loc.longitude === "number" ? loc.longitude : parseFloat(loc.longitude);
+    if (!isFinite(lat) || !isFinite(lng)) return null;
+    if (lat < -90 || lat > 90 || lng < -180 || lng > 180) return null;
+    var label = (loc.label == null || loc.label === "") ? null : String(loc.label).trim();
+    return { latitude: lat, longitude: lng, label: label || null };
+}
+
+function serializeLocations(arr) {
+    if (!Array.isArray(arr)) return [];
+    var out = [];
+    for (var i = 0; i < arr.length; i++) {
+        var loc = normalizeLocation(arr[i]);
+        if (loc) out.push(loc);
+    }
+    return out;
+}
+
+function findDuplicateIndex(arr) {
+    // Backend rejects duplicate (lat, lng) — match that on the client to
+    // give immediate feedback instead of a 422.
+    var seen = {};
+    for (var i = 0; i < arr.length; i++) {
+        var key = arr[i].latitude.toFixed(6) + "," + arr[i].longitude.toFixed(6);
+        if (seen[key] !== undefined) return i;
+        seen[key] = i;
+    }
+    return -1;
+}
+
+function hasMultipleLocations(story) {
+    if (!story) return false;
+    var locs = Array.isArray(story.locations) ? story.locations : [];
+    return locs.length > 1;
+}
+
+function getEffectiveLocations(story) {
+    // Returns the list of {latitude, longitude, label} to render for a
+    // story. Multi-location stories return their full list; legacy
+    // single-location stories return a one-item list from
+    // story.latitude/longitude/place_name so callers can use one code path.
+    if (!story) return [];
+    var locs = Array.isArray(story.locations) ? story.locations.slice() : [];
+    if (locs.length > 0) return serializeLocations(locs);
+    if (typeof story.latitude === "number" && typeof story.longitude === "number") {
+        return [{
+            latitude: story.latitude,
+            longitude: story.longitude,
+            label: story.place_name || null
+        }];
+    }
+    return [];
+}
+
+// ─── Map markers ───────────────────────────────────────────────────────────
+
+function buildNumberedIcon(L, index, options) {
+    var color = (options && options.color) || "#775a19"; // primary brown
+    var size = (options && options.size) || 32;
+    var html =
+        '<div style="' +
+        'width:' + size + 'px;height:' + size + 'px;' +
+        'background:' + color + ';color:#fff;' +
+        'border:2px solid #fff;border-radius:9999px;' +
+        'display:flex;align-items:center;justify-content:center;' +
+        'font-family:Inter,sans-serif;font-weight:700;font-size:13px;' +
+        'box-shadow:0 4px 12px rgba(0,0,0,0.25);' +
+        '">' + (index + 1) + '</div>';
+    return L.divIcon({
+        className: "multi-location-pin",
+        html: html,
+        iconSize: [size, size],
+        iconAnchor: [size / 2, size / 2],
+        popupAnchor: [0, -size / 2]
+    });
+}
+
+// ─── Picker (used on story-create / story-edit) ────────────────────────────
+
+function createMultiLocationPicker(L, map, options) {
+    options = options || {};
+    var onChange = options.onChange || function () { };
+    var maxLocations = options.maxLocations || 10;
+    var locations = [];
+    var markers = [];
+    var polyline = null;
+
+    function redrawPolyline() {
+        if (polyline) {
+            map.removeLayer(polyline);
+            polyline = null;
+        }
+        if (locations.length < 2) return;
+        var coords = locations.map(function (l) { return [l.latitude, l.longitude]; });
+        polyline = L.polyline(coords, {
+            color: "#775a19",
+            weight: 3,
+            opacity: 0.6,
+            dashArray: "6 8"
+        }).addTo(map);
+    }
+
+    function rebuildMarkers() {
+        markers.forEach(function (m) { map.removeLayer(m); });
+        markers = [];
+        locations.forEach(function (loc, idx) {
+            var marker = L.marker([loc.latitude, loc.longitude], {
+                draggable: true,
+                icon: buildNumberedIcon(L, idx)
+            }).addTo(map);
+
+            marker.on("dragend", function () {
+                var pos = marker.getLatLng();
+                locations[idx] = {
+                    latitude: pos.lat,
+                    longitude: pos.lng,
+                    label: locations[idx].label
+                };
+                redrawPolyline();
+                onChange(getLocations());
+            });
+
+            markers.push(marker);
+        });
+        redrawPolyline();
+    }
+
+    function getLocations() {
+        return locations.map(function (l) { return { latitude: l.latitude, longitude: l.longitude, label: l.label }; });
+    }
+
+    function add(loc) {
+        var n = normalizeLocation(loc);
+        if (!n) return false;
+        if (locations.length >= maxLocations) return false;
+        var dupIndex = findDuplicateIndex(locations.concat([n]));
+        if (dupIndex !== -1) return false;
+        locations.push(n);
+        rebuildMarkers();
+        onChange(getLocations());
+        return true;
+    }
+
+    function remove(index) {
+        if (index < 0 || index >= locations.length) return;
+        locations.splice(index, 1);
+        rebuildMarkers();
+        onChange(getLocations());
+    }
+
+    function setLabel(index, label) {
+        if (index < 0 || index >= locations.length) return;
+        var trimmed = (label || "").trim();
+        locations[index].label = trimmed || null;
+        onChange(getLocations());
+    }
+
+    function clear() {
+        locations = [];
+        rebuildMarkers();
+        onChange(getLocations());
+    }
+
+    function setAll(arr) {
+        locations = serializeLocations(arr);
+        rebuildMarkers();
+        onChange(getLocations());
+    }
+
+    function focus(index) {
+        if (index < 0 || index >= locations.length) return;
+        var loc = locations[index];
+        map.setView([loc.latitude, loc.longitude], Math.max(map.getZoom(), 15));
+        if (markers[index]) markers[index].openPopup();
+    }
+
+    return {
+        add: add,
+        remove: remove,
+        setLabel: setLabel,
+        clear: clear,
+        setAll: setAll,
+        focus: focus,
+        getLocations: getLocations,
+        count: function () { return locations.length; }
+    };
+}
+
+// ─── Chip strip renderer (vanilla DOM) ─────────────────────────────────────
+
+function renderLocationChips(container, locations, callbacks) {
+    callbacks = callbacks || {};
+    container.innerHTML = "";
+
+    if (!locations.length) {
+        var empty = document.createElement("p");
+        empty.className = "text-xs text-textmuted italic";
+        empty.textContent = "No locations yet — click the map to drop a pin.";
+        container.appendChild(empty);
+        return;
+    }
+
+    locations.forEach(function (loc, idx) {
+        var chip = document.createElement("div");
+        chip.className =
+            "group flex items-center gap-2 rounded-full border border-border bg-white pl-1 pr-2 py-1 " +
+            "text-xs shadow-sm transition hover:border-primary-light";
+        chip.setAttribute("data-index", String(idx));
+
+        var num = document.createElement("span");
+        num.className =
+            "flex h-6 w-6 flex-none items-center justify-center rounded-full bg-primary text-white " +
+            "text-[11px] font-bold";
+        num.textContent = String(idx + 1);
+        chip.appendChild(num);
+
+        var labelBtn = document.createElement("button");
+        labelBtn.type = "button";
+        labelBtn.className = "max-w-[12rem] truncate text-left text-textmain hover:text-primary";
+        var coordsText = loc.latitude.toFixed(4) + ", " + loc.longitude.toFixed(4);
+        labelBtn.textContent = loc.label || coordsText;
+        labelBtn.title = loc.label ? loc.label + " — " + coordsText : coordsText;
+        labelBtn.addEventListener("click", function () {
+            if (callbacks.onFocus) callbacks.onFocus(idx);
+        });
+        chip.appendChild(labelBtn);
+
+        var removeBtn = document.createElement("button");
+        removeBtn.type = "button";
+        removeBtn.setAttribute("aria-label", "Remove location " + (idx + 1));
+        removeBtn.className =
+            "flex h-5 w-5 flex-none items-center justify-center rounded-full text-textmuted " +
+            "transition hover:bg-red-50 hover:text-red-600";
+        removeBtn.innerHTML =
+            '<svg aria-hidden="true" viewBox="0 0 24 24" class="h-3.5 w-3.5" fill="none" ' +
+            'stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">' +
+            '<line x1="18" y1="6" x2="6" y2="18"></line>' +
+            '<line x1="6" y1="6" x2="18" y2="18"></line></svg>';
+        removeBtn.addEventListener("click", function () {
+            if (callbacks.onRemove) callbacks.onRemove(idx);
+        });
+        chip.appendChild(removeBtn);
+
+        container.appendChild(chip);
+    });
+}
+
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = {
+        normalizeLocation: normalizeLocation,
+        serializeLocations: serializeLocations,
+        findDuplicateIndex: findDuplicateIndex,
+        hasMultipleLocations: hasMultipleLocations,
+        getEffectiveLocations: getEffectiveLocations,
+        renderLocationChips: renderLocationChips,
+        createMultiLocationPicker: createMultiLocationPicker,
+        buildNumberedIcon: buildNumberedIcon
+    };
+}

--- a/frontend/multi-location.test.js
+++ b/frontend/multi-location.test.js
@@ -1,0 +1,159 @@
+const {
+    normalizeLocation,
+    serializeLocations,
+    findDuplicateIndex,
+    hasMultipleLocations,
+    getEffectiveLocations,
+    renderLocationChips
+} = require("./multi-location");
+
+describe("multi-location helpers", () => {
+    describe("normalizeLocation", () => {
+        test("returns null for missing/invalid input", () => {
+            expect(normalizeLocation(null)).toBeNull();
+            expect(normalizeLocation(undefined)).toBeNull();
+            expect(normalizeLocation({})).toBeNull();
+            expect(normalizeLocation({ latitude: "abc", longitude: 1 })).toBeNull();
+            expect(normalizeLocation({ latitude: 91, longitude: 1 })).toBeNull();
+            expect(normalizeLocation({ latitude: 1, longitude: 181 })).toBeNull();
+        });
+
+        test("parses numeric strings and trims the label", () => {
+            expect(normalizeLocation({ latitude: "41.0", longitude: "29.0", label: "  Eminönü  " }))
+                .toEqual({ latitude: 41, longitude: 29, label: "Eminönü" });
+        });
+
+        test("nulls out empty labels", () => {
+            expect(normalizeLocation({ latitude: 1, longitude: 1, label: "" }).label).toBeNull();
+            expect(normalizeLocation({ latitude: 1, longitude: 1, label: "   " }).label).toBeNull();
+            expect(normalizeLocation({ latitude: 1, longitude: 1 }).label).toBeNull();
+        });
+    });
+
+    describe("serializeLocations", () => {
+        test("drops invalid items but keeps valid ones in order", () => {
+            const out = serializeLocations([
+                { latitude: 1, longitude: 1 },
+                { latitude: "bad" },
+                { latitude: 2, longitude: 2, label: "B" }
+            ]);
+            expect(out).toEqual([
+                { latitude: 1, longitude: 1, label: null },
+                { latitude: 2, longitude: 2, label: "B" }
+            ]);
+        });
+
+        test("returns empty array for non-array input", () => {
+            expect(serializeLocations(null)).toEqual([]);
+            expect(serializeLocations(undefined)).toEqual([]);
+            expect(serializeLocations("nope")).toEqual([]);
+        });
+    });
+
+    describe("findDuplicateIndex", () => {
+        test("detects exact-coordinate duplicates", () => {
+            expect(findDuplicateIndex([
+                { latitude: 1, longitude: 2 },
+                { latitude: 3, longitude: 4 },
+                { latitude: 1, longitude: 2 }
+            ])).toBe(2);
+        });
+
+        test("returns -1 when all locations are distinct", () => {
+            expect(findDuplicateIndex([
+                { latitude: 1, longitude: 2 },
+                { latitude: 3, longitude: 4 }
+            ])).toBe(-1);
+        });
+    });
+
+    describe("hasMultipleLocations", () => {
+        test("true only when story.locations has length > 1", () => {
+            expect(hasMultipleLocations({ locations: [{}, {}] })).toBe(true);
+            expect(hasMultipleLocations({ locations: [{}] })).toBe(false);
+            expect(hasMultipleLocations({ locations: [] })).toBe(false);
+            expect(hasMultipleLocations({})).toBe(false);
+            expect(hasMultipleLocations(null)).toBe(false);
+        });
+    });
+
+    describe("getEffectiveLocations", () => {
+        test("returns the locations array for multi-location stories", () => {
+            const story = {
+                latitude: 0, longitude: 0,
+                locations: [
+                    { latitude: 1, longitude: 1, label: "A" },
+                    { latitude: 2, longitude: 2, label: null }
+                ]
+            };
+            const out = getEffectiveLocations(story);
+            expect(out).toHaveLength(2);
+            expect(out[0]).toEqual({ latitude: 1, longitude: 1, label: "A" });
+        });
+
+        test("falls back to top-level lat/lng for legacy single-location stories", () => {
+            const story = { latitude: 41, longitude: 29, place_name: "Galata" };
+            expect(getEffectiveLocations(story)).toEqual([
+                { latitude: 41, longitude: 29, label: "Galata" }
+            ]);
+        });
+
+        test("returns empty array when no coordinates are available", () => {
+            expect(getEffectiveLocations({})).toEqual([]);
+            expect(getEffectiveLocations(null)).toEqual([]);
+        });
+    });
+
+    describe("renderLocationChips", () => {
+        let container;
+        beforeEach(() => {
+            container = document.createElement("div");
+            document.body.appendChild(container);
+        });
+        afterEach(() => {
+            container.remove();
+        });
+
+        test("renders empty-state message when there are no locations", () => {
+            renderLocationChips(container, [], {});
+            expect(container.textContent).toMatch(/No locations yet/i);
+        });
+
+        test("renders one numbered chip per location with label fallback to coords", () => {
+            renderLocationChips(container, [
+                { latitude: 41.012345, longitude: 28.998765, label: "Galata" },
+                { latitude: 41.5, longitude: 29.5, label: null }
+            ], {});
+
+            const chips = container.querySelectorAll('[data-index]');
+            expect(chips).toHaveLength(2);
+            expect(chips[0].textContent).toContain("Galata");
+            expect(chips[1].textContent).toContain("41.5000, 29.5000");
+            expect(chips[0].querySelectorAll("span")[0].textContent).toBe("1");
+            expect(chips[1].querySelectorAll("span")[0].textContent).toBe("2");
+        });
+
+        test("remove button calls onRemove with the chip index", () => {
+            const onRemove = jest.fn();
+            renderLocationChips(container, [
+                { latitude: 1, longitude: 1, label: "A" },
+                { latitude: 2, longitude: 2, label: "B" }
+            ], { onRemove });
+
+            const removeButtons = container.querySelectorAll('button[aria-label^="Remove"]');
+            removeButtons[1].click();
+            expect(onRemove).toHaveBeenCalledWith(1);
+        });
+
+        test("label button calls onFocus with the chip index", () => {
+            const onFocus = jest.fn();
+            renderLocationChips(container, [
+                { latitude: 1, longitude: 1, label: "A" }
+            ], { onFocus });
+
+            const labelBtn = container.querySelector('[data-index="0"] button.text-left');
+            labelBtn.click();
+            expect(onFocus).toHaveBeenCalledWith(0);
+        });
+    });
+});

--- a/frontend/story-create.html
+++ b/frontend/story-create.html
@@ -141,16 +141,21 @@
             <div id="create-map" style="height: 100%; width: 100%;"></div>
           </div>
 
-          <!-- Selected Location Display -->
-          <div id="selected-location" class="mt-3 hidden">
-            <div class="flex items-center gap-2 rounded-xl bg-[rgba(53,97,143,0.08)] px-4 py-3 text-sm">
-              <span class="text-tertiary font-semibold">📍 Pinned:</span>
-              <span id="selected-location-text" class="text-textmain"></span>
-              <button type="button" id="clear-location" class="ml-auto text-xs text-red-500 hover:underline">Clear</button>
+          <!-- Pinned locations chip strip -->
+          <div class="mt-4 rounded-2xl border border-border bg-[rgba(53,97,143,0.05)] p-4">
+            <div class="flex items-center justify-between gap-3">
+              <div>
+                <p class="text-sm font-semibold text-textmain">Pinned locations</p>
+                <p class="mt-0.5 text-xs text-textmuted">Click the map to add a pin. Drag any pin to refine its position. Add multiple pins to tell a story across places — a route will connect them in order.</p>
+              </div>
+              <button type="button" id="clear-locations" class="hidden shrink-0 text-xs font-semibold text-red-500 hover:underline">
+                Clear all
+              </button>
             </div>
+            <div id="location-chips" class="mt-3 flex flex-wrap gap-2"></div>
           </div>
 
-          <!-- Hidden fields for coordinates -->
+          <!-- Hidden fields for coordinates (kept for the existing backend payload shape) -->
           <input type="hidden" id="latitude" name="latitude" />
           <input type="hidden" id="longitude" name="longitude" />
         </section>
@@ -349,6 +354,7 @@
 <script src="auth.js"></script>
 <script src="recording.js"></script>
 <script src="tags.js"></script>
+<script src="multi-location.js"></script>
 <!-- Leaflet JS -->
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 
@@ -365,59 +371,50 @@
     maxZoom: 19
   }).addTo(createMap);
 
-  var pinMarker = null;
+  // ─── Multi-location picker ───
+  var chipContainer = document.getElementById("location-chips");
+  var clearAllBtn = document.getElementById("clear-locations");
+  var latitudeInput = document.getElementById("latitude");
+  var longitudeInput = document.getElementById("longitude");
+  var locationNameInput = document.getElementById("location");
 
-  function setPin(lat, lng, label) {
-    if (pinMarker) createMap.removeLayer(pinMarker);
-
-    pinMarker = L.marker([lat, lng], {
-      draggable: true
-    }).addTo(createMap);
-
-    pinMarker.on("dragend", function () {
-      var pos = pinMarker.getLatLng();
-      updateLocationFields(pos.lat, pos.lng, null);
-      reverseGeocode(pos.lat, pos.lng);
-    });
-
-    document.getElementById("latitude").value = lat.toFixed(6);
-    document.getElementById("longitude").value = lng.toFixed(6);
-
-    var display = label || (lat.toFixed(4) + ", " + lng.toFixed(4));
-    document.getElementById("selected-location-text").textContent = display;
-    document.getElementById("selected-location").classList.remove("hidden");
-
-    updateChecklist();
-  }
-
-  function updateLocationFields(lat, lng, name) {
-    document.getElementById("latitude").value = lat.toFixed(6);
-    document.getElementById("longitude").value = lng.toFixed(6);
-    if (name) {
-      document.getElementById("location").value = name;
-      document.getElementById("selected-location-text").textContent = name + " (" + lat.toFixed(4) + ", " + lng.toFixed(4) + ")";
+  function onPickerChange(locs) {
+    if (locs.length > 0) {
+      latitudeInput.value = locs[0].latitude.toFixed(6);
+      longitudeInput.value = locs[0].longitude.toFixed(6);
     } else {
-      document.getElementById("selected-location-text").textContent = lat.toFixed(4) + ", " + lng.toFixed(4);
+      latitudeInput.value = "";
+      longitudeInput.value = "";
     }
-    document.getElementById("selected-location").classList.remove("hidden");
+    clearAllBtn.classList.toggle("hidden", locs.length === 0);
+    renderLocationChips(chipContainer, locs, {
+      onRemove: function (i) { picker.remove(i); },
+      onFocus: function (i) { picker.focus(i); }
+    });
     updateChecklist();
   }
 
-  // Click on map to pin
+  var picker = createMultiLocationPicker(L, createMap, { onChange: onPickerChange });
+  onPickerChange([]); // initial render
+
+  function addPinFromMapClick(lat, lng) {
+    var added = picker.add({ latitude: lat, longitude: lng, label: null });
+    if (!added) return;
+    // Reverse geocode this pin so the chip shows a readable label and
+    // (if the user hasn't typed one yet) the "Location Name" input is
+    // populated from the first pin.
+    reverseGeocode(lat, lng, picker.count() - 1);
+  }
+
+  // Click on map to add a pin
   createMap.on("click", function (e) {
-    setPin(e.latlng.lat, e.latlng.lng, null);
-    reverseGeocode(e.latlng.lat, e.latlng.lng);
+    addPinFromMapClick(e.latlng.lat, e.latlng.lng);
   });
 
-  // Clear location
-  document.getElementById("clear-location").addEventListener("click", function () {
-    if (pinMarker) createMap.removeLayer(pinMarker);
-    pinMarker = null;
-    document.getElementById("latitude").value = "";
-    document.getElementById("longitude").value = "";
-    document.getElementById("location").value = "";
-    document.getElementById("selected-location").classList.add("hidden");
-    updateChecklist();
+  // Clear all locations
+  clearAllBtn.addEventListener("click", function () {
+    picker.clear();
+    locationNameInput.value = "";
   });
 
   // ─── Geocoding (Nominatim / OpenStreetMap) ───
@@ -451,9 +448,12 @@
                   div.addEventListener("click", function () {
                     var lat = parseFloat(item.lat);
                     var lon = parseFloat(item.lon);
+                    var shortLabel = item.display_name.split(",").slice(0, 2).join(",").trim();
                     createMap.setView([lat, lon], 16);
-                    setPin(lat, lon, item.display_name.split(",").slice(0, 2).join(","));
-                    document.getElementById("location").value = item.display_name.split(",").slice(0, 2).join(",").trim();
+                    var added = picker.add({ latitude: lat, longitude: lon, label: shortLabel });
+                    if (added && picker.count() === 1 && !locationNameInput.value.trim()) {
+                      locationNameInput.value = shortLabel;
+                    }
                     searchInput.value = item.display_name.split(",").slice(0, 3).join(",");
                     searchResults.classList.add("hidden");
                   });
@@ -475,16 +475,24 @@
     }
   });
 
-  // Reverse geocode when clicking on map
-  function reverseGeocode(lat, lng) {
+  // Reverse geocode a pin so its chip shows a readable label. For the very
+  // first pin, also populate the "Location Name" input (the user can still
+  // overwrite it) so single-location stories behave the same as before.
+  function reverseGeocode(lat, lng, pinIndex) {
     fetch("https://nominatim.openstreetmap.org/reverse?format=json&lat=" + lat + "&lon=" + lng + "&zoom=16")
             .then(function (r) { return r.json(); })
             .then(function (data) {
-              if (data && data.display_name) {
-                var shortName = data.display_name.split(",").slice(0, 3).join(",").trim();
-                var locationName = data.display_name.split(",").slice(0, 2).join(",").trim();
-                document.getElementById("location").value = locationName;
-                document.getElementById("selected-location-text").textContent = shortName + " (" + lat.toFixed(4) + ", " + lng.toFixed(4) + ")";
+              if (!data || !data.display_name) return;
+              var locationName = data.display_name.split(",").slice(0, 2).join(",").trim();
+              if (typeof pinIndex === "number") {
+                picker.setLabel(pinIndex, locationName);
+                renderLocationChips(chipContainer, picker.getLocations(), {
+                  onRemove: function (i) { picker.remove(i); },
+                  onFocus: function (i) { picker.focus(i); }
+                });
+              }
+              if (pinIndex === 0 && !locationNameInput.value.trim()) {
+                locationNameInput.value = locationName;
               }
             })
             .catch(function () { /* silent fail */ });
@@ -1169,6 +1177,7 @@
     }
 
     var isAnonymous = document.getElementById("is-anonymous").value === "true";
+    var pickerLocations = picker.getLocations();
 
     var payload = {
       title: title,
@@ -1181,6 +1190,13 @@
       date_end: usingDateRange ? getISODateFromDateInput(dateEnd) : null,
       is_anonymous: isAnonymous
     };
+
+    // Only send the locations array for multi-location stories. Single-pin
+    // stories continue to use the legacy latitude/longitude/place_name shape
+    // for backwards compatibility with existing list/detail rendering.
+    if (pickerLocations.length > 1) {
+      payload.locations = pickerLocations;
+    }
 
     setSubmittingState(true, "Creating Story...");
 

--- a/frontend/story-detail.html
+++ b/frontend/story-detail.html
@@ -218,6 +218,7 @@
 <script src="comments.js"></script>
 <script src="saves.js"></script>
 <script src="anonymous.js"></script>
+<script src="multi-location.js"></script>
 <script src="tags.js"></script>
 <script src="story-transcript.js"></script>
 <script>
@@ -420,12 +421,43 @@
       timelineLink.classList.add("hidden");
     }
 
-    if (hasCoordinates) {
-      detailMap.setView([storyLat, storyLng], 15);
-      L.marker([storyLat, storyLng])
-        .addTo(detailMap)
-        .bindPopup('<div style="font-family:Inter,sans-serif;"><strong style="font-size:13px;">' + story.title + '</strong><br><span style="font-size:11px;color:#5f584c;">' + (story.place_name || "") + '</span></div>')
-        .openPopup();
+    var allLocations = getEffectiveLocations(story);
+    if (allLocations.length > 0) {
+      var isMulti = allLocations.length > 1;
+      allLocations.forEach(function (loc, idx) {
+        var icon = isMulti
+          ? buildNumberedIcon(L, idx, { color: "#35618f", size: 32 })
+          : undefined;
+        var marker = icon
+          ? L.marker([loc.latitude, loc.longitude], { icon: icon }).addTo(detailMap)
+          : L.marker([loc.latitude, loc.longitude]).addTo(detailMap);
+        var coords = loc.latitude.toFixed(4) + ", " + loc.longitude.toFixed(4);
+        var popupTitle = isMulti
+          ? ((idx + 1) + ". " + (loc.label || coords))
+          : (story.title || coords);
+        var popupSub = isMulti
+          ? coords
+          : (story.place_name || coords);
+        marker.bindPopup(
+          '<div style="font-family:Inter,sans-serif;">' +
+          '<strong style="font-size:13px;">' + popupTitle + '</strong><br>' +
+          '<span style="font-size:11px;color:#5f584c;">' + popupSub + '</span>' +
+          '</div>'
+        );
+      });
+
+      if (isMulti) {
+        L.polyline(
+          allLocations.map(function (l) { return [l.latitude, l.longitude]; }),
+          { color: "#35618f", weight: 3, opacity: 0.75, dashArray: "6 8" }
+        ).addTo(detailMap);
+        detailMap.fitBounds(
+          allLocations.map(function (l) { return [l.latitude, l.longitude]; }),
+          { padding: [30, 30], maxZoom: 16 }
+        );
+      } else {
+        detailMap.setView([allLocations[0].latitude, allLocations[0].longitude], 15);
+      }
     } else {
       document.getElementById('detail-map').parentElement.style.display = 'none';
     }

--- a/frontend/story-detail.html
+++ b/frontend/story-detail.html
@@ -351,54 +351,6 @@
   function applyStoryDetail(story) {
     document.getElementById('story-title').textContent = story.title || "Untitled";
     document.getElementById('story-summary').textContent = story.summary || "";
-    document.getElementById('story-author').innerHTML = 'by ' + (story.author || "Unknown");
-    document.getElementById('story-date').textContent = story.date_label || "No Date";
-    document.getElementById('story-location').textContent = story.place_name || "Istanbul";
-    document.getElementById('story-content').textContent = story.content || "No content available.";
-    document.getElementById('detail-location-label').textContent = story.place_name || "Istanbul";
-
-    var storyLat = Number(story.latitude);
-    var storyLng = Number(story.longitude);
-    var hasCoordinates = Number.isFinite(storyLat) && Number.isFinite(storyLng);
-    var timelineLink = document.getElementById('detail-timeline-link');
-
-    if (hasCoordinates) {
-      timelineLink.href = "timeline.html?lat=" + encodeURIComponent(storyLat) + "&lng=" + encodeURIComponent(storyLng) + "&radius_km=1";
-      timelineLink.classList.remove("hidden");
-    } else {
-      timelineLink.classList.add("hidden");
-    }
-
-    if (hasCoordinates) {
-      detailMap.setView([storyLat, storyLng], 15);
-      L.marker([storyLat, storyLng])
-        .addTo(detailMap)
-        .bindPopup('<div style="font-family:Inter,sans-serif;"><strong style="font-size:13px;">' + story.title + '</strong><br><span style="font-size:11px;color:#5f584c;">' + (story.place_name || "") + '</span></div>')
-        .openPopup();
-    } else {
-      document.getElementById('detail-map').parentElement.style.display = 'none';
-    }
-
-    renderStoryMedia(story);
-    startTranscriptPolling(String(story.id || storyId), story.media_files);
-
-    setupComments(API_BASE, String(story.id || storyId));
-    var likeSeed = { like_count: typeof story.like_count === "number" ? story.like_count : 0 };
-    setupLikes(API_BASE, String(story.id || storyId), likeSeed);
-  }
-
-  if (!storyId) {
-    document.getElementById('story-title').textContent = "Story not found";
-    document.getElementById('story-summary').textContent = "No ID provided in the URL.";
-  } else {
-    if (typeof setupSaveButton === "function") {
-      setupSaveButton(API_BASE, storyId);
-    }
-
-    fetch(API_BASE + "/stories/" + storyId)
-     function applyStoryDetail(story) {
-    document.getElementById('story-title').textContent = story.title || "Untitled";
-    document.getElementById('story-summary').textContent = story.summary || "";
 
     var authorEl = document.getElementById('story-author');
     authorEl.textContent = getAuthorByLine(story);

--- a/frontend/story-detail.html
+++ b/frontend/story-detail.html
@@ -507,14 +507,6 @@
       });
   }
 
-      })
-      .catch(function (err) {
-         console.error("Error loading story details:", err);
-         document.getElementById('story-title').textContent = "Failed to load story";
-         document.getElementById('story-summary').textContent = "There was a problem communicating with the server.";
-      });
-  }
-
   // ─── Report functionality ───────────────────────────────────────────────────
   var selectedReportReason = null;
   var reportReasonsList = [

--- a/frontend/story-edit.html
+++ b/frontend/story-edit.html
@@ -103,12 +103,17 @@
           <div id="edit-map" style="height: 100%; width: 100%;"></div>
         </div>
 
-        <div id="selected-location" class="mt-3 hidden">
-          <div class="flex items-center gap-2 rounded-xl bg-[rgba(53,97,143,0.08)] px-4 py-3 text-sm">
-            <span class="text-tertiary font-semibold">📍 Pinned:</span>
-            <span id="selected-location-text" class="text-textmain"></span>
-            <button type="button" id="clear-location" class="ml-auto text-xs text-red-500 hover:underline">Clear</button>
+        <div class="mt-4 rounded-2xl border border-border bg-[rgba(53,97,143,0.05)] p-4">
+          <div class="flex items-center justify-between gap-3">
+            <div>
+              <p class="text-sm font-semibold text-textmain">Pinned locations</p>
+              <p class="mt-0.5 text-xs text-textmuted">Click the map to add a pin. Drag any pin to refine its position. Multi-stop stories show a route connecting their pins in order.</p>
+            </div>
+            <button type="button" id="clear-locations" class="hidden shrink-0 text-xs font-semibold text-red-500 hover:underline">
+              Clear all
+            </button>
           </div>
+          <div id="location-chips" class="mt-3 flex flex-wrap gap-2"></div>
         </div>
 
         <input type="hidden" id="latitude" name="latitude" />
@@ -170,6 +175,7 @@
 <script src="config.js"></script>
 <script src="auth.js"></script>
 <script src="tags.js"></script>
+<script src="multi-location.js"></script>
 <script>
   if (!requireAuth()) throw new Error("redirect");
 
@@ -188,50 +194,60 @@
     maxZoom: 19
   }).addTo(editMap);
 
-  var pinMarker = null;
+  // ─── Multi-location picker ───
+  var chipContainer = document.getElementById("location-chips");
+  var clearAllBtn = document.getElementById("clear-locations");
+  var latitudeInput = document.getElementById("latitude");
+  var longitudeInput = document.getElementById("longitude");
+  var locationNameInput = document.getElementById("location");
 
-  function setPin(lat, lng, label) {
-    if (pinMarker) editMap.removeLayer(pinMarker);
-    pinMarker = L.marker([lat, lng], { draggable: true }).addTo(editMap);
-    pinMarker.on("dragend", function() {
-      var pos = pinMarker.getLatLng();
-      document.getElementById("latitude").value = pos.lat.toFixed(6);
-      document.getElementById("longitude").value = pos.lng.toFixed(6);
-      document.getElementById("selected-location-text").textContent = pos.lat.toFixed(4) + ", " + pos.lng.toFixed(4);
-      reverseGeocode(pos.lat, pos.lng);
+  function renderEditChips(locs) {
+    renderLocationChips(chipContainer, locs, {
+      onRemove: function (i) { picker.remove(i); },
+      onFocus: function (i) { picker.focus(i); }
     });
-    document.getElementById("latitude").value = lat.toFixed(6);
-    document.getElementById("longitude").value = lng.toFixed(6);
-    document.getElementById("selected-location-text").textContent = label || (lat.toFixed(4) + ", " + lng.toFixed(4));
-    document.getElementById("selected-location").classList.remove("hidden");
   }
 
-  editMap.on("click", function(e) {
-    setPin(e.latlng.lat, e.latlng.lng, null);
-    reverseGeocode(e.latlng.lat, e.latlng.lng);
+  function onPickerChange(locs) {
+    if (locs.length > 0) {
+      latitudeInput.value = locs[0].latitude.toFixed(6);
+      longitudeInput.value = locs[0].longitude.toFixed(6);
+    } else {
+      latitudeInput.value = "";
+      longitudeInput.value = "";
+    }
+    clearAllBtn.classList.toggle("hidden", locs.length === 0);
+    renderEditChips(locs);
+  }
+
+  var picker = createMultiLocationPicker(L, editMap, { onChange: onPickerChange });
+  onPickerChange([]);
+
+  editMap.on("click", function (e) {
+    var added = picker.add({ latitude: e.latlng.lat, longitude: e.latlng.lng, label: null });
+    if (added) reverseGeocode(e.latlng.lat, e.latlng.lng, picker.count() - 1);
   });
 
-  document.getElementById("clear-location").addEventListener("click", function() {
-    if (pinMarker) editMap.removeLayer(pinMarker);
-    pinMarker = null;
-    document.getElementById("latitude").value = "";
-    document.getElementById("longitude").value = "";
-    document.getElementById("location").value = "";
-    document.getElementById("selected-location").classList.add("hidden");
+  clearAllBtn.addEventListener("click", function () {
+    picker.clear();
+    locationNameInput.value = "";
   });
 
-  function reverseGeocode(lat, lng) {
+  function reverseGeocode(lat, lng, pinIndex) {
     fetch("https://nominatim.openstreetmap.org/reverse?format=json&lat=" + lat + "&lon=" + lng + "&zoom=16")
-      .then(function(r) { return r.json(); })
-      .then(function(data) {
-        if (data && data.display_name) {
-          var shortName = data.display_name.split(",").slice(0, 3).join(",").trim();
-          var locationName = data.display_name.split(",").slice(0, 2).join(",").trim();
-          document.getElementById("location").value = locationName;
-          document.getElementById("selected-location-text").textContent = shortName + " (" + lat.toFixed(4) + ", " + lng.toFixed(4) + ")";
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        if (!data || !data.display_name) return;
+        var locationName = data.display_name.split(",").slice(0, 2).join(",").trim();
+        if (typeof pinIndex === "number") {
+          picker.setLabel(pinIndex, locationName);
+          renderEditChips(picker.getLocations());
+        }
+        if (pinIndex === 0 && !locationNameInput.value.trim()) {
+          locationNameInput.value = locationName;
         }
       })
-      .catch(function() {});
+      .catch(function () {});
   }
 
   // ─── Location Search ───
@@ -260,9 +276,12 @@
             div.addEventListener("click", function() {
               var lat = parseFloat(item.lat);
               var lon = parseFloat(item.lon);
+              var shortLabel = item.display_name.split(",").slice(0, 2).join(",").trim();
               editMap.setView([lat, lon], 16);
-              setPin(lat, lon, item.display_name.split(",").slice(0, 2).join(","));
-              document.getElementById("location").value = item.display_name.split(",").slice(0, 2).join(",").trim();
+              var added = picker.add({ latitude: lat, longitude: lon, label: shortLabel });
+              if (added && picker.count() === 1 && !locationNameInput.value.trim()) {
+                locationNameInput.value = shortLabel;
+              }
               searchInput.value = item.display_name.split(",").slice(0, 3).join(",");
               searchResults.classList.add("hidden");
             });
@@ -324,22 +343,17 @@
           document.getElementById("location").value = story.place_name;
         }
 
-        if (story.latitude && story.longitude) {
-          document.getElementById("latitude").value = String(story.latitude);
-          document.getElementById("longitude").value = String(story.longitude);
-          if (pinMarker) editMap.removeLayer(pinMarker);
-          pinMarker = L.marker([story.latitude, story.longitude], { draggable: true }).addTo(editMap);
-          pinMarker.on("dragend", function() {
-            var pos = pinMarker.getLatLng();
-            document.getElementById("latitude").value = pos.lat.toFixed(6);
-            document.getElementById("longitude").value = pos.lng.toFixed(6);
-            document.getElementById("selected-location-text").textContent = pos.lat.toFixed(4) + ", " + pos.lng.toFixed(4);
-            reverseGeocode(pos.lat, pos.lng);
-          });
-          editMap.setView([story.latitude, story.longitude], 14);
-          document.getElementById("selected-location-text").textContent =
-            story.place_name || (story.latitude.toFixed(4) + ", " + story.longitude.toFixed(4));
-          document.getElementById("selected-location").classList.remove("hidden");
+        var initialLocations = getEffectiveLocations(story);
+        if (initialLocations.length > 0) {
+          picker.setAll(initialLocations);
+          if (initialLocations.length > 1) {
+            editMap.fitBounds(
+              initialLocations.map(function (l) { return [l.latitude, l.longitude]; }),
+              { padding: [40, 40], maxZoom: 16 }
+            );
+          } else {
+            editMap.setView([initialLocations[0].latitude, initialLocations[0].longitude], 14);
+          }
         }
 
         var dateStart = story.date_start;
@@ -434,6 +448,8 @@
       return;
     }
 
+    var pickerLocations = picker.getLocations();
+
     var payload = {
       title: title,
       content: content,
@@ -442,7 +458,8 @@
       longitude: parseFloat(lng),
       place_name: placeName,
       date_start: usingDateRange ? getISODateFromDateInput(dateStart) : getISODateFromDateInput(dateSingle),
-      date_end: usingDateRange ? getISODateFromDateInput(dateEnd) : null
+      date_end: usingDateRange ? getISODateFromDateInput(dateEnd) : null,
+      locations: pickerLocations.length > 0 ? pickerLocations : null
     };
 
     setSaving(true);


### PR DESCRIPTION
## Description
  Implements the frontend portion of multi-location story support on top of
  the already-merged backend (PR #337). Stories can now have multiple
  ordered pins, and the picker UI, map view, and story detail page all
  understand them.

  **Create / edit pages** — replace the single-pin control with a
  multi-pin picker. Clicking the map adds a pin; the chip strip below
  shows the pins in order with their reverse-geocoded label and a remove
  button. The first pin doubles as the legacy `latitude/longitude/place_name`
  anchor, so single-pin stories stay byte-identical to before.

  **Map view** — multi-location stories get a tertiary-blue marker with a
  count badge so users can spot them at a glance. Clicking enters "story
  focus mode": cluster layer hides, all the story's stops appear as
  numbered blue markers, a dashed polyline connects them in order, the
  map fits the bounds, and a banner at the top of the map shows the title,
  stop count, and an "Exit focus" button. Single-pin stories continue to
  behave exactly as before (popup with cover image, etc.).

  **Story detail mini-map** — renders every stop with numbered markers and
  a polyline, then `fitBounds` so all pins are visible. Legacy single-pin
  stories render the same single marker they always did.

  **Routing** — straight `L.polyline` connections between pins. Road
  routing would require an external service (OSRM/Mapbox) and isn't
  needed for v1; the issue note about Leaflet marker groups is satisfied
  by the focus-mode layer group.

  Also fixed a pre-existing JS error in `story-detail.html` from a merge
  artifact: the file had a duplicate `applyStoryDetail` function inside
  a dangling `else { fetch( ... }` block plus two orphan `})` chains
  after the working `if/else` block. These were causing "Statement
  expected" / "Missing }" errors at lines 510 and 601. Removed the
  duplicate and orphans; only the multi-location-aware version remains.

  Also added `anonymous.js` and `multi-location.js` to the frontend
  Dockerfile's `COPY` list so Nginx actually serves them — without this
  the new scripts 404'd in the container even though they exist on disk.

  ## Related Issue(s)
  - Closes #241
  
  ## Changes

  | File | Change |
  |------|--------|
  | `frontend/multi-location.js` | Added — pure helpers (`normalizeLocation`, `serializeLocations`, `findDuplicateIndex`, `hasMultipleLocations`, `getEffectiveLocations`), the
  `createMultiLocationPicker` factory, `renderLocationChips`, and `buildNumberedIcon` reused across pages. |
  | `frontend/multi-location.test.js` | Added — 15 Jest unit tests covering the helpers and the chip renderer. |
  | `frontend/story-create.html` | Replaced single-pin display with the chip-strip picker; map clicks and Nominatim search results add pins; submit now sends `locations` when
  there are 2+ pins. |
  | `frontend/story-edit.html` | Same picker UI; loads existing locations via `getEffectiveLocations(story)` so legacy and multi-location stories both round-trip; submit sends
  the picker's locations array. |
  | `frontend/map.html` | Tertiary-blue marker for multi-location stories with a stop-count badge; click enters focus mode (numbered blue pins, dashed polyline, `fitBounds`,
  banner with "Exit focus" button); single-pin behavior unchanged. |
  | `frontend/story-detail.html` | Mini-map now renders every stop with numbered markers + polyline + `fitBounds`. Removed pre-existing duplicate `applyStoryDetail` and orphan
  `})` chains that caused "Missing }" syntax errors. |
  | `frontend/Dockerfile` | Added `COPY` entries for `anonymous.js` and `multi-location.js` so Nginx serves them. |

  ## Checklist
  - [x] All tests passed (`npx jest` → 144 passed across 15 suites; 15 new in `multi-location.test.js`)
  - [x] I have self-reviewed my own code
  - [x] I have requested at least 1 reviewer