### PR TITLE
imp: replace faster-whisper with OpenAI Whisper API

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -33,6 +33,7 @@ FRONTEND_GOOGLE_CALLBACK_URL=http://localhost:3000/oauth-callback.html
 
 # ── Speech-to-Text (OpenAI Whisper API) ───────────────────────────────────────
 OPENAI_API_KEY=
+AI_WHISPER_MODEL=whisper-1
 
 # ── AI Auto-Tagging ────────────────────────────────────────────────────────────
 GEMINI_API_KEY=

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -31,10 +31,8 @@ GOOGLE_CLIENT_SECRET=
 GOOGLE_REDIRECT_URI=http://localhost:8000/auth/google/callback
 FRONTEND_GOOGLE_CALLBACK_URL=http://localhost:3000/oauth-callback.html
 
-# ── Speech-to-Text (faster-whisper) ───────────────────────────────────────────
-TRANSCRIPTION_MODEL=base
-TRANSCRIPTION_DEVICE=cpu
-TRANSCRIPTION_COMPUTE_TYPE=int8
+# ── Speech-to-Text (OpenAI Whisper API) ───────────────────────────────────────
+OPENAI_API_KEY=
 
 # ── AI Auto-Tagging ────────────────────────────────────────────────────────────
 GEMINI_API_KEY=

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -39,9 +39,7 @@ class Settings(BaseSettings):
     FRONTEND_GOOGLE_CALLBACK_URL: str = "http://localhost:3000/oauth-callback.html"
 
     # ── Speech-to-Text ───────────────────────────────────────────────────────
-    TRANSCRIPTION_MODEL: str = "base"
-    TRANSCRIPTION_DEVICE: str = "cpu"
-    TRANSCRIPTION_COMPUTE_TYPE: str = "int8"
+    OPENAI_API_KEY: str = ""
     GEMINI_API_KEY: str = ""
     AI_TAGGING_MODEL: str = "gemini-2.5-flash"
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -40,6 +40,7 @@ class Settings(BaseSettings):
 
     # ── Speech-to-Text ───────────────────────────────────────────────────────
     OPENAI_API_KEY: str = ""
+    AI_WHISPER_MODEL: str = "whisper-1"
     GEMINI_API_KEY: str = ""
     AI_TAGGING_MODEL: str = "gemini-2.5-flash"
 

--- a/backend/app/services/transcription_service.py
+++ b/backend/app/services/transcription_service.py
@@ -98,7 +98,7 @@ async def _transcribe_with_openai(
         response = await client.post(
             _OPENAI_TRANSCRIPTION_URL,
             headers={"Authorization": f"Bearer {settings.OPENAI_API_KEY}"},
-            data={"model": "whisper-1"},
+            data={"model": settings.AI_WHISPER_MODEL},
             files={"file": (filename, content, mime_type or "application/octet-stream")},
         )
         response.raise_for_status()

--- a/backend/app/services/transcription_service.py
+++ b/backend/app/services/transcription_service.py
@@ -1,12 +1,7 @@
-import asyncio
-import functools
 import logging
-import os
 import uuid
-from concurrent.futures import ThreadPoolExecutor
-from functools import lru_cache
-from tempfile import NamedTemporaryFile
 
+import httpx
 from fastapi import UploadFile, status
 from sqlalchemy import select
 
@@ -19,10 +14,7 @@ from app.services.media_validation import read_uploaded_file_content, validate_m
 
 logger = logging.getLogger(__name__)
 
-# Single-worker executor: all transcription work is serialised before a thread is
-# allocated, so no threadpool slots are wasted waiting and only one WhisperModel
-# is ever active. Both preview and background calls share this queue.
-_TRANSCRIPTION_EXECUTOR = ThreadPoolExecutor(max_workers=1)
+_OPENAI_TRANSCRIPTION_URL = "https://api.openai.com/v1/audio/transcriptions"
 
 
 async def transcribe_media_file(
@@ -68,7 +60,7 @@ async def transcribe_audio_content(
     mime_type: str | None,
 ) -> str | None:
     try:
-        return await _transcribe_with_whisper(
+        return await _transcribe_with_openai(
             filename=filename,
             content=content,
             mime_type=mime_type,
@@ -92,48 +84,28 @@ async def preview_audio_transcription(file: UploadFile) -> str | None:
     )
 
 
-async def _transcribe_with_whisper(
+async def _transcribe_with_openai(
     *,
     filename: str,
     content: bytes,
     mime_type: str | None,
 ) -> str | None:
-    loop = asyncio.get_running_loop()
-    fn = functools.partial(_transcribe_with_whisper_sync, filename=filename, content=content, mime_type=mime_type)
-    return await loop.run_in_executor(_TRANSCRIPTION_EXECUTOR, fn)
+    if not settings.OPENAI_API_KEY:
+        logger.warning("OPENAI_API_KEY is not set; skipping transcription")
+        return None
 
+    async with httpx.AsyncClient(timeout=120) as client:
+        response = await client.post(
+            _OPENAI_TRANSCRIPTION_URL,
+            headers={"Authorization": f"Bearer {settings.OPENAI_API_KEY}"},
+            data={"model": "whisper-1"},
+            files={"file": (filename, content, mime_type or "application/octet-stream")},
+        )
+        response.raise_for_status()
 
-@lru_cache(maxsize=1)
-def _load_whisper_model():
-    try:
-        from faster_whisper import WhisperModel
-    except ImportError as exc:
-        raise RuntimeError("faster-whisper is not installed") from exc
-
-    return WhisperModel(
-        settings.TRANSCRIPTION_MODEL,
-        device=settings.TRANSCRIPTION_DEVICE,
-        compute_type=settings.TRANSCRIPTION_COMPUTE_TYPE,
-    )
-
-
-def _transcribe_with_whisper_sync(
-    *,
-    filename: str,
-    content: bytes,
-    mime_type: str | None,
-) -> str | None:
-    suffix = os.path.splitext(filename)[1] or ".audio"
-    with NamedTemporaryFile(suffix=suffix, delete=True) as temp_audio:
-        temp_audio.write(content)
-        temp_audio.flush()
-
-        model = _load_whisper_model()
-        segments, _info = model.transcribe(temp_audio.name, beam_size=5)
-        transcript = " ".join(segment.text.strip() for segment in segments if getattr(segment, "text", "").strip())
-
+    transcript = response.json().get("text", "").strip()
     if not transcript:
-        logger.warning("Whisper transcription for %s returned no text", filename)
+        logger.warning("OpenAI Whisper returned no text for %s", filename)
         return None
 
     return transcript

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -25,8 +25,5 @@ python-multipart
 # Object storage (S3-compatible — works with MinIO locally and Supabase Storage in prod)
 boto3
 
-# Speech-to-text
-faster-whisper
-
 # Linting & formatting
 ruff

--- a/backend/tests/unit/test_transcription_service.py
+++ b/backend/tests/unit/test_transcription_service.py
@@ -30,7 +30,7 @@ class _SessionContextManager:
 class TestTranscribeAudioContent:
     async def test_returns_transcript_when_provider_succeeds(self):
         with patch(
-            "app.services.transcription_service._transcribe_with_whisper",
+            "app.services.transcription_service._transcribe_with_openai",
             new=AsyncMock(return_value="Transcribed text"),
         ) as mock_stt:
             result = await transcribe_audio_content(
@@ -44,7 +44,7 @@ class TestTranscribeAudioContent:
 
     async def test_returns_none_when_provider_raises(self):
         with patch(
-            "app.services.transcription_service._transcribe_with_whisper",
+            "app.services.transcription_service._transcribe_with_openai",
             new=AsyncMock(side_effect=RuntimeError("boom")),
         ) as mock_stt:
             result = await transcribe_audio_content(


### PR DESCRIPTION
## Description
Replaces the local `faster-whisper` model with the OpenAI Whisper API (`whisper-1`). This frees up server memory (no model loaded at startup), removes the model download from the Docker build, and simplifies the transcription code path significantly — the thread pool executor, `lru_cache`, temp file handling, and sync wrapper are all gone. The service now makes a single async `httpx` POST to OpenAI. Transcription is skipped gracefully when `OPENAI_API_KEY` is not set.

## Related Issue(s)
- Closes #249

## Changes

| File | Change |
|------|--------|
| `backend/app/services/transcription_service.py` | Replaced local Whisper model stack with async `httpx` call to OpenAI API; removed executor, `lru_cache`, temp file, and sync wrapper |
| `backend/app/core/config.py` | Removed `TRANSCRIPTION_MODEL`, `TRANSCRIPTION_DEVICE`, `TRANSCRIPTION_COMPUTE_TYPE`; added `OPENAI_API_KEY` |
| `backend/requirements.txt` | Removed `faster-whisper` dependency |
| `backend/tests/unit/test_transcription_service.py` | Updated mock patch paths from `_transcribe_with_whisper` to `_transcribe_with_openai` |

## Checklist
- [x] All tests passed 
- [x] I have self-reviewed my own code
- [x] I have requested at least 1 reviewer