### PR TITLE
feat: ISSUE-249 integrate external gemini sst service

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -31,11 +31,8 @@ GOOGLE_CLIENT_SECRET=
 GOOGLE_REDIRECT_URI=http://localhost:8000/auth/google/callback
 FRONTEND_GOOGLE_CALLBACK_URL=http://localhost:3000/oauth-callback.html
 
-# ── Speech-to-Text ────────────────────────────────────────────────────────────
-# Render staging/production should use "gemini" and reuse GEMINI_API_KEY.
-# Local development can keep "local" to use faster-whisper.
-STT_PROVIDER=local
-STT_MODEL=gemini-2.5-flash
+# ── Speech-to-Text fallback (faster-whisper) ─────────────────────────────────
+# Gemini transcription uses GEMINI_API_KEY when configured.
 TRANSCRIPTION_MODEL=base
 TRANSCRIPTION_DEVICE=cpu
 TRANSCRIPTION_COMPUTE_TYPE=int8

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -31,7 +31,11 @@ GOOGLE_CLIENT_SECRET=
 GOOGLE_REDIRECT_URI=http://localhost:8000/auth/google/callback
 FRONTEND_GOOGLE_CALLBACK_URL=http://localhost:3000/oauth-callback.html
 
-# ── Speech-to-Text (faster-whisper) ───────────────────────────────────────────
+# ── Speech-to-Text ────────────────────────────────────────────────────────────
+# Render staging/production should use "gemini" and reuse GEMINI_API_KEY.
+# Local development can keep "local" to use faster-whisper.
+STT_PROVIDER=local
+STT_MODEL=gemini-2.5-flash
 TRANSCRIPTION_MODEL=base
 TRANSCRIPTION_DEVICE=cpu
 TRANSCRIPTION_COMPUTE_TYPE=int8

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -39,6 +39,8 @@ class Settings(BaseSettings):
     FRONTEND_GOOGLE_CALLBACK_URL: str = "http://localhost:3000/oauth-callback.html"
 
     # ── Speech-to-Text ───────────────────────────────────────────────────────
+    STT_PROVIDER: str = "local"
+    STT_MODEL: str = "gemini-2.5-flash"
     TRANSCRIPTION_MODEL: str = "base"
     TRANSCRIPTION_DEVICE: str = "cpu"
     TRANSCRIPTION_COMPUTE_TYPE: str = "int8"

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -39,8 +39,6 @@ class Settings(BaseSettings):
     FRONTEND_GOOGLE_CALLBACK_URL: str = "http://localhost:3000/oauth-callback.html"
 
     # ── Speech-to-Text ───────────────────────────────────────────────────────
-    STT_PROVIDER: str = "local"
-    STT_MODEL: str = "gemini-2.5-flash"
     TRANSCRIPTION_MODEL: str = "base"
     TRANSCRIPTION_DEVICE: str = "cpu"
     TRANSCRIPTION_COMPUTE_TYPE: str = "int8"

--- a/backend/app/services/transcription_service.py
+++ b/backend/app/services/transcription_service.py
@@ -8,6 +8,8 @@ from functools import lru_cache
 from tempfile import NamedTemporaryFile
 
 from fastapi import UploadFile, status
+from google import genai
+from google.genai import types
 from sqlalchemy import select
 
 from app.core.config import settings
@@ -23,6 +25,14 @@ logger = logging.getLogger(__name__)
 # allocated, so no threadpool slots are wasted waiting and only one WhisperModel
 # is ever active. Both preview and background calls share this queue.
 _TRANSCRIPTION_EXECUTOR = ThreadPoolExecutor(max_workers=1)
+_GEMINI_TRANSCRIPTION_PROMPT = (
+    "Generate an accurate transcript of the speech in this audio file. "
+    "Return only the transcript text. Do not summarize, translate, add timestamps, "
+    "or include explanations. If no speech is present, return an empty response."
+)
+_GEMINI_MIME_TYPE_ALIASES = {
+    "audio/mpeg": "audio/mp3",
+}
 
 
 async def transcribe_media_file(
@@ -68,7 +78,7 @@ async def transcribe_audio_content(
     mime_type: str | None,
 ) -> str | None:
     try:
-        return await _transcribe_with_whisper(
+        return await _transcribe_with_configured_provider(
             filename=filename,
             content=content,
             mime_type=mime_type,
@@ -76,6 +86,38 @@ async def transcribe_audio_content(
     except Exception:
         logger.exception("Audio transcription failed for %s", filename)
         return None
+
+
+async def _transcribe_with_configured_provider(
+    *,
+    filename: str,
+    content: bytes,
+    mime_type: str | None,
+) -> str | None:
+    if settings.STT_PROVIDER.lower() != "gemini":
+        return await _transcribe_with_whisper(
+            filename=filename,
+            content=content,
+            mime_type=mime_type,
+        )
+
+    try:
+        transcript = await _transcribe_with_gemini(
+            filename=filename,
+            content=content,
+            mime_type=mime_type,
+        )
+        if transcript:
+            return transcript
+        logger.warning("Gemini transcription for %s returned no text; falling back to local Whisper", filename)
+    except Exception:
+        logger.exception("Gemini transcription failed for %s; falling back to local Whisper", filename)
+
+    return await _transcribe_with_whisper(
+        filename=filename,
+        content=content,
+        mime_type=mime_type,
+    )
 
 
 async def preview_audio_transcription(file: UploadFile) -> str | None:
@@ -101,6 +143,62 @@ async def _transcribe_with_whisper(
     loop = asyncio.get_running_loop()
     fn = functools.partial(_transcribe_with_whisper_sync, filename=filename, content=content, mime_type=mime_type)
     return await loop.run_in_executor(_TRANSCRIPTION_EXECUTOR, fn)
+
+
+async def _transcribe_with_gemini(
+    *,
+    filename: str,
+    content: bytes,
+    mime_type: str | None,
+) -> str | None:
+    return await asyncio.to_thread(
+        _transcribe_with_gemini_sync,
+        filename=filename,
+        content=content,
+        mime_type=mime_type,
+    )
+
+
+def _transcribe_with_gemini_sync(
+    *,
+    filename: str,
+    content: bytes,
+    mime_type: str | None,
+) -> str | None:
+    if not settings.GEMINI_API_KEY:
+        raise ValueError("GEMINI_API_KEY is not configured")
+
+    client = genai.Client(api_key=settings.GEMINI_API_KEY)
+    try:
+        response = client.models.generate_content(
+            model=settings.STT_MODEL,
+            contents=[
+                _GEMINI_TRANSCRIPTION_PROMPT,
+                types.Part.from_bytes(
+                    data=content,
+                    mime_type=_normalize_gemini_mime_type(mime_type),
+                ),
+            ],
+        )
+    finally:
+        client.close()
+
+    transcript = getattr(response, "text", None)
+    if not isinstance(transcript, str):
+        raise ValueError("Could not extract Gemini transcription text")
+
+    transcript = transcript.strip()
+    if not transcript:
+        logger.warning("Gemini transcription for %s returned no text", filename)
+        return None
+
+    return transcript
+
+
+def _normalize_gemini_mime_type(mime_type: str | None) -> str:
+    if not mime_type:
+        return "audio/mp3"
+    return _GEMINI_MIME_TYPE_ALIASES.get(mime_type, mime_type)
 
 
 @lru_cache(maxsize=1)

--- a/backend/app/services/transcription_service.py
+++ b/backend/app/services/transcription_service.py
@@ -30,6 +30,7 @@ _GEMINI_TRANSCRIPTION_PROMPT = (
     "Return only the transcript text. Do not summarize, translate, add timestamps, "
     "or include explanations. If no speech is present, return an empty response."
 )
+_GEMINI_TRANSCRIPTION_MODEL = "gemini-2.5-flash"
 _GEMINI_MIME_TYPE_ALIASES = {
     "audio/mpeg": "audio/mp3",
 }
@@ -94,7 +95,7 @@ async def _transcribe_with_configured_provider(
     content: bytes,
     mime_type: str | None,
 ) -> str | None:
-    if settings.STT_PROVIDER.lower() != "gemini":
+    if not settings.GEMINI_API_KEY:
         return await _transcribe_with_whisper(
             filename=filename,
             content=content,
@@ -171,7 +172,7 @@ def _transcribe_with_gemini_sync(
     client = genai.Client(api_key=settings.GEMINI_API_KEY)
     try:
         response = client.models.generate_content(
-            model=settings.STT_MODEL,
+            model=_GEMINI_TRANSCRIPTION_MODEL,
             contents=[
                 _GEMINI_TRANSCRIPTION_PROMPT,
                 types.Part.from_bytes(

--- a/backend/tests/integration/test_story_recorded_media_flow.py
+++ b/backend/tests/integration/test_story_recorded_media_flow.py
@@ -7,8 +7,14 @@ Covers issue #211 acceptance criteria:
 - Codec parameter strings (e.g. audio/webm;codecs=opus) are accepted.
 - Mixed-case MIME types (e.g. Audio/WebM;Codecs=Opus) are accepted.
 """
+from unittest.mock import AsyncMock
 
 import pytest
+
+
+@pytest.fixture(autouse=True)
+def disable_background_transcription(monkeypatch):
+    monkeypatch.setattr("app.services.story_service.transcribe_media_file", AsyncMock())
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_story_recorded_media_flow.py
+++ b/backend/tests/integration/test_story_recorded_media_flow.py
@@ -7,6 +7,7 @@ Covers issue #211 acceptance criteria:
 - Codec parameter strings (e.g. audio/webm;codecs=opus) are accepted.
 - Mixed-case MIME types (e.g. Audio/WebM;Codecs=Opus) are accepted.
 """
+
 from unittest.mock import AsyncMock
 
 import pytest

--- a/backend/tests/unit/test_transcription_service.py
+++ b/backend/tests/unit/test_transcription_service.py
@@ -44,8 +44,8 @@ class TestTranscribeAudioContent:
         assert result == "Transcribed text"
         mock_stt.assert_awaited_once()
 
-    async def test_uses_gemini_provider_when_configured(self, monkeypatch):
-        monkeypatch.setattr(settings, "STT_PROVIDER", "gemini")
+    async def test_uses_gemini_provider_when_api_key_is_configured(self, monkeypatch):
+        monkeypatch.setattr(settings, "GEMINI_API_KEY", "secret")
 
         with patch(
             "app.services.transcription_service._transcribe_with_gemini",
@@ -65,8 +65,29 @@ class TestTranscribeAudioContent:
         mock_gemini.assert_awaited_once()
         mock_whisper.assert_not_awaited()
 
+    async def test_uses_local_whisper_when_gemini_api_key_is_missing(self, monkeypatch):
+        monkeypatch.setattr(settings, "GEMINI_API_KEY", "")
+
+        with patch(
+            "app.services.transcription_service._transcribe_with_gemini",
+            new=AsyncMock(),
+        ) as mock_gemini:
+            with patch(
+                "app.services.transcription_service._transcribe_with_whisper",
+                new=AsyncMock(return_value="Local transcript"),
+            ) as mock_whisper:
+                result = await transcribe_audio_content(
+                    filename="audio.webm",
+                    content=b"audio-bytes",
+                    mime_type="audio/webm",
+                )
+
+        assert result == "Local transcript"
+        mock_gemini.assert_not_awaited()
+        mock_whisper.assert_awaited_once()
+
     async def test_falls_back_to_local_whisper_when_gemini_fails(self, monkeypatch):
-        monkeypatch.setattr(settings, "STT_PROVIDER", "gemini")
+        monkeypatch.setattr(settings, "GEMINI_API_KEY", "secret")
 
         with patch(
             "app.services.transcription_service._transcribe_with_gemini",
@@ -87,7 +108,7 @@ class TestTranscribeAudioContent:
         mock_whisper.assert_awaited_once()
 
     async def test_falls_back_to_local_whisper_when_gemini_returns_no_text(self, monkeypatch):
-        monkeypatch.setattr(settings, "STT_PROVIDER", "gemini")
+        monkeypatch.setattr(settings, "GEMINI_API_KEY", "secret")
 
         with patch(
             "app.services.transcription_service._transcribe_with_gemini",

--- a/backend/tests/unit/test_transcription_service.py
+++ b/backend/tests/unit/test_transcription_service.py
@@ -10,6 +10,7 @@ from starlette.datastructures import Headers, UploadFile
 from app.core.config import settings
 from app.db.enums import MediaType
 from app.services.transcription_service import (
+    _normalize_gemini_mime_type,
     preview_audio_transcription,
     transcribe_audio_content,
     transcribe_media_file,
@@ -85,6 +86,27 @@ class TestTranscribeAudioContent:
         mock_gemini.assert_awaited_once()
         mock_whisper.assert_awaited_once()
 
+    async def test_falls_back_to_local_whisper_when_gemini_returns_no_text(self, monkeypatch):
+        monkeypatch.setattr(settings, "STT_PROVIDER", "gemini")
+
+        with patch(
+            "app.services.transcription_service._transcribe_with_gemini",
+            new=AsyncMock(return_value=None),
+        ) as mock_gemini:
+            with patch(
+                "app.services.transcription_service._transcribe_with_whisper",
+                new=AsyncMock(return_value="Local transcript"),
+            ) as mock_whisper:
+                result = await transcribe_audio_content(
+                    filename="silent.mp3",
+                    content=b"audio-bytes",
+                    mime_type="audio/mp3",
+                )
+
+        assert result == "Local transcript"
+        mock_gemini.assert_awaited_once()
+        mock_whisper.assert_awaited_once()
+
     async def test_returns_none_when_provider_raises(self):
         with patch(
             "app.services.transcription_service._transcribe_with_whisper",
@@ -98,6 +120,17 @@ class TestTranscribeAudioContent:
 
         assert result is None
         mock_stt.assert_awaited_once()
+
+
+class TestGeminiTranscriptionHelpers:
+    def test_normalizes_mpeg_mime_type_for_gemini(self):
+        assert _normalize_gemini_mime_type("audio/mpeg") == "audio/mp3"
+
+    def test_uses_mp3_mime_type_when_missing(self):
+        assert _normalize_gemini_mime_type(None) == "audio/mp3"
+
+    def test_preserves_supported_mime_type(self):
+        assert _normalize_gemini_mime_type("audio/wav") == "audio/wav"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_transcription_service.py
+++ b/backend/tests/unit/test_transcription_service.py
@@ -7,6 +7,7 @@ import pytest
 from fastapi import HTTPException
 from starlette.datastructures import Headers, UploadFile
 
+from app.core.config import settings
 from app.db.enums import MediaType
 from app.services.transcription_service import (
     preview_audio_transcription,
@@ -41,6 +42,48 @@ class TestTranscribeAudioContent:
 
         assert result == "Transcribed text"
         mock_stt.assert_awaited_once()
+
+    async def test_uses_gemini_provider_when_configured(self, monkeypatch):
+        monkeypatch.setattr(settings, "STT_PROVIDER", "gemini")
+
+        with patch(
+            "app.services.transcription_service._transcribe_with_gemini",
+            new=AsyncMock(return_value="Gemini transcript"),
+        ) as mock_gemini:
+            with patch(
+                "app.services.transcription_service._transcribe_with_whisper",
+                new=AsyncMock(),
+            ) as mock_whisper:
+                result = await transcribe_audio_content(
+                    filename="audio.mp3",
+                    content=b"audio-bytes",
+                    mime_type="audio/mp3",
+                )
+
+        assert result == "Gemini transcript"
+        mock_gemini.assert_awaited_once()
+        mock_whisper.assert_not_awaited()
+
+    async def test_falls_back_to_local_whisper_when_gemini_fails(self, monkeypatch):
+        monkeypatch.setattr(settings, "STT_PROVIDER", "gemini")
+
+        with patch(
+            "app.services.transcription_service._transcribe_with_gemini",
+            new=AsyncMock(side_effect=RuntimeError("gemini down")),
+        ) as mock_gemini:
+            with patch(
+                "app.services.transcription_service._transcribe_with_whisper",
+                new=AsyncMock(return_value="Local transcript"),
+            ) as mock_whisper:
+                result = await transcribe_audio_content(
+                    filename="audio.webm",
+                    content=b"audio-bytes",
+                    mime_type="audio/webm",
+                )
+
+        assert result == "Local transcript"
+        mock_gemini.assert_awaited_once()
+        mock_whisper.assert_awaited_once()
 
     async def test_returns_none_when_provider_raises(self):
         with patch(


### PR DESCRIPTION
## Description
Adds Gemini-based speech-to-text support for audio transcription. The backend now uses `GEMINI_API_KEY` when available and falls back to local `faster-whisper` if Gemini is unavailable or returns no transcript.

## Related Issue(s)
- Closes #

## Changes

| File | Change |
|------|--------|
| `backend/app/services/transcription_service.py` | Added Gemini transcription flow with local Whisper fallback. |
| `backend/app/core/config.py` | Removed unnecessary STT provider/model env config. |
| `backend/.env.example` | Documented that Gemini transcription uses `GEMINI_API_KEY`. |
| `backend/tests/unit/test_transcription_service.py` | Added tests for Gemini usage and fallback behavior. |
| `backend/tests/integration/test_story_recorded_media_flow.py` | Mocked background transcription to avoid external calls in media flow tests. |

## Checklist
- [x] All tests passed
- [x] I have self-reviewed my own code
