### PR TITLE
feat: ISSUE-251 set up log aggregation and a basic metrics dashboard to monitor backend health on Render

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ A collaborative platform for sharing and discovering local history stories tied 
 | Mobile | Capacitor + Android |
 | Infrastructure | Docker Compose, GitHub Actions, Render |
 
+## Operations
+
+Monitoring and log aggregation setup is documented in [docs/wiki/monitoring-and-logs.md](docs/wiki/monitoring-and-logs.md).
+
 ## Quick Start
 
 ```bash

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,6 +4,7 @@ DATABASE_URL=postgresql://postgres:postgres@db:5432/localhistory
 
 # Useful during development — leave false in production
 LOG_SQL=false
+LOG_LEVEL=INFO
 
 # ── Object Storage ────────────────────────────────────────────────────────────
 # Local: MinIO (docker-compose minio service uses "minio" as the hostname inside Docker)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -6,6 +6,7 @@ class Settings(BaseSettings):
 
     # Set to "true" in .env to write every SQL query to logs/sql.log
     LOG_SQL: bool = False
+    LOG_LEVEL: str = "INFO"
 
     # ── CORS ──────────────────────────────────────────────────────────────────
     # Comma-separated list of allowed origins

--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -1,0 +1,17 @@
+import logging
+import sys
+
+
+def configure_logging(log_level: str) -> None:
+    """Configure app logs for Render stdout/stderr collection."""
+    normalized_level = getattr(logging, log_level.upper(), logging.INFO)
+    logging.basicConfig(
+        level=normalized_level,
+        format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+        stream=sys.stdout,
+        force=True,
+    )
+
+    # Keep framework loggers aligned so Render and log streams can filter by level.
+    for logger_name in ("app", "uvicorn", "uvicorn.error"):
+        logging.getLogger(logger_name).setLevel(normalized_level)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -57,7 +57,7 @@ def root():
 
 
 @app.get("/health")
-async def health(response: Response | None = None):
+async def health(response: Response = None):
     # Check DB connectivity
     try:
         async with engine.connect() as conn:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,16 +1,19 @@
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Response, status
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy import text
 
 from app.core.config import settings
+from app.core.logging import configure_logging
 from app.db.session import engine
 from app.routers.auth import router as auth_router
 from app.routers.story import router as story_router
 from app.routers.transcription import router as transcription_router
 from app.routers.users import router as users_router
 from app.services.storage import check_connection
+
+configure_logging(settings.LOG_LEVEL)
 
 
 @asynccontextmanager
@@ -54,7 +57,7 @@ def root():
 
 
 @app.get("/health")
-async def health():
+async def health(response: Response | None = None):
     # Check DB connectivity
     try:
         async with engine.connect() as conn:
@@ -71,6 +74,9 @@ async def health():
         storage_status = f"unreachable: {e}"
 
     all_ok = db_status == "ok" and storage_status == "ok"
+    if not all_ok and response is not None:
+        response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+
     return {
         "status": "ok" if all_ok else "degraded",
         "db": db_status,

--- a/backend/tests/unit/test_health.py
+++ b/backend/tests/unit/test_health.py
@@ -1,6 +1,8 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from fastapi import status
+from starlette.responses import Response
 
 
 @pytest.mark.asyncio
@@ -10,55 +12,63 @@ class TestHealthEndpoint:
     async def test_returns_ok_when_all_healthy(self, mock_engine, mock_check):
         from app.main import health
 
+        response = Response()
         mock_conn = AsyncMock()
         mock_engine.connect.return_value.__aenter__ = AsyncMock(return_value=mock_conn)
         mock_engine.connect.return_value.__aexit__ = AsyncMock(return_value=False)
 
-        result = await health()
+        result = await health(response)
 
         assert result["status"] == "ok"
         assert result["db"] == "ok"
         assert result["storage"] == "ok"
+        assert response.status_code == status.HTTP_200_OK
 
     @patch("app.main.check_connection")
     @patch("app.main.engine")
     async def test_returns_degraded_when_db_unreachable(self, mock_engine, mock_check):
         from app.main import health
 
+        response = Response()
         mock_engine.connect.return_value.__aenter__ = AsyncMock(side_effect=Exception("DB connection refused"))
         mock_engine.connect.return_value.__aexit__ = AsyncMock(return_value=False)
 
-        result = await health()
+        result = await health(response)
 
         assert result["status"] == "degraded"
         assert "unreachable" in result["db"]
         assert result["storage"] == "ok"
+        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
 
     @patch("app.main.check_connection", side_effect=Exception("Storage down"))
     @patch("app.main.engine")
     async def test_returns_degraded_when_storage_unreachable(self, mock_engine, mock_check):
         from app.main import health
 
+        response = Response()
         mock_conn = AsyncMock()
         mock_engine.connect.return_value.__aenter__ = AsyncMock(return_value=mock_conn)
         mock_engine.connect.return_value.__aexit__ = AsyncMock(return_value=False)
 
-        result = await health()
+        result = await health(response)
 
         assert result["status"] == "degraded"
         assert result["db"] == "ok"
         assert "unreachable" in result["storage"]
+        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
 
     @patch("app.main.check_connection", side_effect=Exception("Storage down"))
     @patch("app.main.engine")
     async def test_returns_degraded_when_both_unreachable(self, mock_engine, mock_check):
         from app.main import health
 
+        response = Response()
         mock_engine.connect.return_value.__aenter__ = AsyncMock(side_effect=Exception("DB down"))
         mock_engine.connect.return_value.__aexit__ = AsyncMock(return_value=False)
 
-        result = await health()
+        result = await health(response)
 
         assert result["status"] == "degraded"
         assert "unreachable" in result["db"]
         assert "unreachable" in result["storage"]
+        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE

--- a/backend/tests/unit/test_logging_config.py
+++ b/backend/tests/unit/test_logging_config.py
@@ -1,0 +1,19 @@
+import logging
+
+from app.core.logging import configure_logging
+
+
+def test_configure_logging_applies_requested_log_level():
+    configure_logging("WARNING")
+
+    assert logging.getLogger().level == logging.WARNING
+    assert logging.getLogger("app").level == logging.WARNING
+    assert logging.getLogger("uvicorn").level == logging.WARNING
+    assert logging.getLogger("uvicorn.error").level == logging.WARNING
+
+
+def test_configure_logging_falls_back_to_info_for_unknown_level():
+    configure_logging("NOT_A_LEVEL")
+
+    assert logging.getLogger().level == logging.INFO
+    assert logging.getLogger("app").level == logging.INFO

--- a/docs/wiki/monitoring-and-logs.md
+++ b/docs/wiki/monitoring-and-logs.md
@@ -1,0 +1,67 @@
+# Monitoring & Logs
+
+Bu sayfa Render uzerindeki backend sagligini, background task hatalarini ve temel sistem performansini izlemek icin kullanilir.
+
+## Gunluk Kontrol Noktalari
+
+- Render backend service > Logs: canli log akisi ve son uygulama loglari.
+- Render backend service > Metrics: CPU, memory, restart/deploy durumu, response time ve 5xx oranlari.
+- Backend health endpoint: `/health`.
+- Better Stack / Logtail source:
+  - Production: `render-backend-prod`
+  - Development varsa: `render-backend-dev`
+
+## Render Log Stream Kurulumu
+
+1. Better Stack icinde yeni bir Render log source olustur.
+2. Source adini ortama gore `render-backend-prod` veya `render-backend-dev` yap.
+3. Better Stack'in verdigi syslog ingest host'unu ve source token'i kopyala.
+4. Render Dashboard'da workspace ana ekranindan `Integrations > Observability > Log Streams` bolumune git.
+5. Default destination olarak Better Stack endpoint'ini ekle.
+6. Endpoint formatini `HOST:6514` olarak gir.
+7. Token alanina Better Stack source token'ini gir.
+8. Kaydettikten sonra backend loglarinin Better Stack'e dusmesini birkac dakika icinde kontrol et.
+
+Papertrail kullanilirsa ayni adimlar uygulanir, sadece Log Endpoint Papertrail'in TLS syslog endpoint'i olur.
+
+## Alarm Kurallari
+
+Better Stack / Logtail uzerinde asagidaki query'ler icin alarm tanimla. Esik: 15 dakika icinde en az 1 error log.
+
+| Alarm | Query |
+| --- | --- |
+| Transcription hatasi | `Audio transcription failed for` |
+| Transcript kaydetme hatasi | `Failed to persist transcript for media file` |
+| AI tagging hatasi | `AI tagging failed for story` |
+
+Bildirim hedefi ekip e-postasi veya ekip Slack/Discord kanali olmalidir.
+
+Ilk fazda alarm olmayan ama takip edilecek uyari:
+
+```text
+Whisper transcription for
+```
+
+## Health Check
+
+Render veya Better Stack uptime monitor ile backend `/health` endpoint'ini izle.
+
+- Beklenen basarili yanit: HTTP `200`, body icinde `"status": "ok"`.
+- Hata durumu: HTTP `503`, body icinde `"status": "degraded"`.
+- Alarm kosulu: 2 ardisik kontrolde endpoint basarisiz veya degraded.
+
+## Incident Kontrol Listesi
+
+1. Render backend service > Metrics ekraninda CPU, memory, restart ve 5xx oranini kontrol et.
+2. Render backend service > Logs ekraninda son deploy sonrasi error olup olmadigina bak.
+3. Better Stack / Logtail'de alarm query'lerini calistir.
+4. `/health` yanitinda `db` ve `storage` alanlarindan hangisinin degraded oldugunu kontrol et.
+5. Son deploy zamanini ve GitHub Actions deploy summary'sini kontrol et.
+
+## Kabul Kriterleri
+
+- Render Logs ekraninda backend loglari gorunuyor.
+- Better Stack / Logtail icinde Render'dan gelen backend loglari gorunuyor.
+- Uc background task hata query'si loglari filtreleyebiliyor.
+- Test amacli error log uretildiginde alarm tetikleniyor.
+- `/health` uptime monitor tarafindan izleniyor.

--- a/docs/wiki/monitoring-and-logs.md
+++ b/docs/wiki/monitoring-and-logs.md
@@ -1,42 +1,42 @@
 # Monitoring & Logs
 
-Bu sayfa Render uzerindeki backend sagligini, background task hatalarini ve temel sistem performansini izlemek icin kullanilir.
+This page explains how to monitor backend health, background task failures, and basic system performance on Render.
 
-## Gunluk Kontrol Noktalari
+## Daily Checkpoints
 
-- Render backend service > Logs: canli log akisi ve son uygulama loglari.
-- Render backend service > Metrics: CPU, memory, restart/deploy durumu, response time ve 5xx oranlari.
+- Render backend service > Logs: live log stream and recent application logs.
+- Render backend service > Metrics: CPU, memory, restart/deploy status, response time, and 5xx rates.
 - Backend health endpoint: `/health`.
 - Better Stack / Logtail source:
   - Production: `render-backend-prod`
-  - Development varsa: `render-backend-dev`
+  - Development, if available: `render-backend-dev`
 
-## Render Log Stream Kurulumu
+## Render Log Stream Setup
 
-1. Better Stack icinde yeni bir Render log source olustur.
-2. Source adini ortama gore `render-backend-prod` veya `render-backend-dev` yap.
-3. Better Stack'in verdigi syslog ingest host'unu ve source token'i kopyala.
-4. Render Dashboard'da workspace ana ekranindan `Integrations > Observability > Log Streams` bolumune git.
-5. Default destination olarak Better Stack endpoint'ini ekle.
-6. Endpoint formatini `HOST:6514` olarak gir.
-7. Token alanina Better Stack source token'ini gir.
-8. Kaydettikten sonra backend loglarinin Better Stack'e dusmesini birkac dakika icinde kontrol et.
+1. Create a new Render log source in Better Stack.
+2. Name the source `render-backend-prod` or `render-backend-dev`, depending on the environment.
+3. Copy the syslog ingest host and source token provided by Better Stack.
+4. In the Render Dashboard, go to `Integrations > Observability > Log Streams` from the workspace home page.
+5. Add the Better Stack endpoint as the default destination.
+6. Enter the endpoint in `HOST:6514` format.
+7. Enter the Better Stack source token in the token field.
+8. After saving, verify within a few minutes that backend logs are arriving in Better Stack.
 
-Papertrail kullanilirsa ayni adimlar uygulanir, sadece Log Endpoint Papertrail'in TLS syslog endpoint'i olur.
+If Papertrail is used instead, follow the same steps and use Papertrail's TLS syslog endpoint as the log endpoint.
 
-## Alarm Kurallari
+## Alert Rules
 
-Better Stack / Logtail uzerinde asagidaki query'ler icin alarm tanimla. Esik: 15 dakika icinde en az 1 error log.
+Create alerts in Better Stack / Logtail for the following queries. Threshold: at least 1 error log within 15 minutes.
 
 | Alarm | Query |
 | --- | --- |
-| Transcription hatasi | `Audio transcription failed for` |
-| Transcript kaydetme hatasi | `Failed to persist transcript for media file` |
-| AI tagging hatasi | `AI tagging failed for story` |
+| Transcription failure | `Audio transcription failed for` |
+| Transcript persistence failure | `Failed to persist transcript for media file` |
+| AI tagging failure | `AI tagging failed for story` |
 
-Bildirim hedefi ekip e-postasi veya ekip Slack/Discord kanali olmalidir.
+The notification target should be the team email address or the team Slack/Discord channel.
 
-Ilk fazda alarm olmayan ama takip edilecek uyari:
+Warning to monitor during the first phase, without an alert:
 
 ```text
 Whisper transcription for
@@ -44,24 +44,24 @@ Whisper transcription for
 
 ## Health Check
 
-Render veya Better Stack uptime monitor ile backend `/health` endpoint'ini izle.
+Monitor the backend `/health` endpoint with Render or Better Stack uptime monitoring.
 
-- Beklenen basarili yanit: HTTP `200`, body icinde `"status": "ok"`.
-- Hata durumu: HTTP `503`, body icinde `"status": "degraded"`.
-- Alarm kosulu: 2 ardisik kontrolde endpoint basarisiz veya degraded.
+- Expected successful response: HTTP `200`, with `"status": "ok"` in the response body.
+- Failure response: HTTP `503`, with `"status": "degraded"` in the response body.
+- Alert condition: the endpoint fails or returns degraded status in 2 consecutive checks.
 
-## Incident Kontrol Listesi
+## Incident Checklist
 
-1. Render backend service > Metrics ekraninda CPU, memory, restart ve 5xx oranini kontrol et.
-2. Render backend service > Logs ekraninda son deploy sonrasi error olup olmadigina bak.
-3. Better Stack / Logtail'de alarm query'lerini calistir.
-4. `/health` yanitinda `db` ve `storage` alanlarindan hangisinin degraded oldugunu kontrol et.
-5. Son deploy zamanini ve GitHub Actions deploy summary'sini kontrol et.
+1. Check CPU, memory, restarts, and 5xx rate in Render backend service > Metrics.
+2. Check Render backend service > Logs for errors after the latest deploy.
+3. Run the alert queries in Better Stack / Logtail.
+4. Check the `/health` response to see whether `db` or `storage` is degraded.
+5. Check the latest deploy time and the GitHub Actions deploy summary.
 
-## Kabul Kriterleri
+## Acceptance Criteria
 
-- Render Logs ekraninda backend loglari gorunuyor.
-- Better Stack / Logtail icinde Render'dan gelen backend loglari gorunuyor.
-- Uc background task hata query'si loglari filtreleyebiliyor.
-- Test amacli error log uretildiginde alarm tetikleniyor.
-- `/health` uptime monitor tarafindan izleniyor.
+- Backend logs are visible in the Render Logs screen.
+- Logs coming from Render are visible in Better Stack / Logtail.
+- The three background task error queries can filter the relevant logs.
+- An alert is triggered when a test error log is generated.
+- `/health` is monitored by the uptime monitor.


### PR DESCRIPTION
## Description
Adds basic backend monitoring support for Render by standardizing application logging, improving the health check signal, and documenting the Render + Better Stack / Logtail monitoring setup.

## Related Issue(s)
- Closes #

## Changes

| File | Change |
|------|--------|
| `backend/app/core/logging.py` | Added logging configuration for stdout-based Render log collection. |
| `backend/app/core/config.py` | Added `LOG_LEVEL` setting. |
| `backend/.env.example` | Documented default `LOG_LEVEL=INFO`. |
| `backend/app/main.py` | Configured logging on startup and made degraded `/health` responses return HTTP 503. |
| `backend/tests/unit/test_health.py` | Added assertions for `/health` HTTP status codes. |
| `backend/tests/unit/test_logging_config.py` | Added tests for logging level configuration and fallback behavior. |
| `docs/wiki/monitoring-and-logs.md` | Added monitoring, log stream, alert, and incident checklist documentation. |
| `README.md` | Linked the monitoring documentation. |

## Checklist
- [x] All tests passed
- [x] I have self-reviewed my own code
