### PR TITLE
chore: ISSUE-320 seperate admin service from story layer

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,6 +7,7 @@ from sqlalchemy import text
 from app.core.config import settings
 from app.core.logging import configure_logging
 from app.db.session import engine
+from app.routers.admin import router as admin_router
 from app.routers.auth import router as auth_router
 from app.routers.story import router as story_router
 from app.routers.transcription import router as transcription_router
@@ -46,6 +47,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 app.include_router(auth_router)
+app.include_router(admin_router)
 app.include_router(story_router)
 app.include_router(transcription_router)
 app.include_router(users_router)

--- a/backend/app/models/admin.py
+++ b/backend/app/models/admin.py
@@ -1,0 +1,36 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+from app.db.enums import ReportReason, ReportStatus
+
+
+class AdminReportListItem(BaseModel):
+    """Report with related story and user information for admin view."""
+
+    id: uuid.UUID
+    story_id: uuid.UUID
+    user_id: uuid.UUID
+    reason: ReportReason
+    description: str | None
+    status: ReportStatus
+    created_at: datetime
+    story_title: str | None = None
+    story_author_username: str | None = None
+    reporter_username: str | None = None
+
+    model_config = {"from_attributes": True}
+
+
+class AdminReportsListResponse(BaseModel):
+    """Response for admin reports listing."""
+
+    total: int
+    reports: list[AdminReportListItem]
+
+
+class UpdateReportStatusRequest(BaseModel):
+    """Request to update report status."""
+
+    status: ReportStatus = Field(..., description="New status for the report")

--- a/backend/app/models/story.py
+++ b/backend/app/models/story.py
@@ -333,5 +333,3 @@ class StoryReportResponse(BaseModel):
     created_at: datetime
 
     model_config = {"from_attributes": True}
-
-

--- a/backend/app/models/story.py
+++ b/backend/app/models/story.py
@@ -335,31 +335,3 @@ class StoryReportResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 
-class AdminReportListItem(BaseModel):
-    """Report with related story and user information for admin view."""
-
-    id: uuid.UUID
-    story_id: uuid.UUID
-    user_id: uuid.UUID
-    reason: ReportReason
-    description: str | None
-    status: ReportStatus
-    created_at: datetime
-    story_title: str | None = None
-    story_author_username: str | None = None
-    reporter_username: str | None = None
-
-    model_config = {"from_attributes": True}
-
-
-class AdminReportsListResponse(BaseModel):
-    """Response for admin reports listing."""
-
-    total: int
-    reports: list[AdminReportListItem]
-
-
-class UpdateReportStatusRequest(BaseModel):
-    """Request to update report status."""
-
-    status: ReportStatus = Field(..., description="New status for the report")

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -7,7 +7,8 @@ from app.core.deps import get_current_user
 from app.db.enums import ReportStatus
 from app.db.session import get_db
 from app.db.user import User
-from app.models.story import AdminReportsListResponse, StoryReportResponse, UpdateReportStatusRequest
+from app.models.admin import AdminReportsListResponse, UpdateReportStatusRequest
+from app.models.story import StoryReportResponse
 from app.services.admin_service import (
     ensure_admin_user,
     list_admin_reports,

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -1,0 +1,17 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.deps import get_current_user
+from app.db.session import get_db
+from app.db.user import User
+from app.services.admin_service import ensure_admin_user
+
+router = APIRouter(prefix="/stories/admin", tags=["admin"])
+
+
+async def get_admin_context(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> tuple[User, AsyncSession]:
+    ensure_admin_user(current_user)
+    return current_user, db

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -1,10 +1,19 @@
-from fastapi import APIRouter, Depends
+import uuid
+
+from fastapi import APIRouter, Depends, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.deps import get_current_user
+from app.db.enums import ReportStatus
 from app.db.session import get_db
 from app.db.user import User
-from app.services.admin_service import ensure_admin_user
+from app.models.story import AdminReportsListResponse, StoryReportResponse, UpdateReportStatusRequest
+from app.services.admin_service import (
+    ensure_admin_user,
+    list_admin_reports,
+    remove_story_as_admin,
+    update_report_status_as_admin,
+)
 
 router = APIRouter(prefix="/stories/admin", tags=["admin"])
 
@@ -15,3 +24,62 @@ async def get_admin_context(
 ) -> tuple[User, AsyncSession]:
     ensure_admin_user(current_user)
     return current_user, db
+
+
+@router.get(
+    "/reports",
+    response_model=AdminReportsListResponse,
+    summary="Get reported stories (admin only)",
+    description="Retrieve all reported stories with filtering options. Admin access required.",
+    responses={
+        401: {"description": "Missing or invalid authentication token"},
+        403: {"description": "User is not an admin"},
+    },
+)
+async def get_admin_reports(
+    report_status: ReportStatus | None = Query(None, alias="status", description="Filter by report status"),
+    context: tuple[User, AsyncSession] = Depends(get_admin_context),
+):
+    _, db = context
+    return await list_admin_reports(db, report_status=report_status)
+
+
+@router.put(
+    "/reports/{report_id}",
+    response_model=StoryReportResponse,
+    summary="Update report status (admin only)",
+    description="Mark a reported story as reviewed. Story removal is handled by the admin remove-story endpoint.",
+    responses={
+        401: {"description": "Missing or invalid authentication token"},
+        400: {"description": "Invalid report status transition"},
+        403: {"description": "User is not an admin"},
+        404: {"description": "Report not found"},
+        409: {"description": "Report can no longer be updated"},
+    },
+)
+async def update_report_status(
+    report_id: uuid.UUID,
+    payload: UpdateReportStatusRequest,
+    context: tuple[User, AsyncSession] = Depends(get_admin_context),
+):
+    _, db = context
+    return await update_report_status_as_admin(db, report_id, payload)
+
+
+@router.delete(
+    "/stories/{story_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Remove story (admin only)",
+    description="Soft-delete a story and mark its pending reports as removed. Admin access required.",
+    responses={
+        401: {"description": "Missing or invalid authentication token"},
+        403: {"description": "User is not an admin"},
+        404: {"description": "Story not found"},
+    },
+)
+async def admin_remove_story(
+    story_id: uuid.UUID,
+    context: tuple[User, AsyncSession] = Depends(get_admin_context),
+):
+    current_user, db = context
+    await remove_story_as_admin(db, story_id, current_user)

--- a/backend/app/routers/story.py
+++ b/backend/app/routers/story.py
@@ -5,15 +5,11 @@ from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.deps import get_current_user, get_optional_user
-from app.db.enums import MediaType, ReportStatus, UserRole
+from app.db.enums import MediaType
 from app.db.session import get_db
-from app.db.story import Story
-from app.db.story_report import StoryReport
 from app.db.user import User
 from app.models.comment import CommentCreateRequest, CommentListResponse, CommentResponse
 from app.models.story import (
-    AdminReportListItem,
-    AdminReportsListResponse,
     MediaUploadRequest,
     MediaUploadResponse,
     StoryBoundsFilter,
@@ -26,7 +22,6 @@ from app.models.story import (
     StoryReportResponse,
     StorySaveResponse,
     StoryUpdateRequest,
-    UpdateReportStatusRequest,
 )
 from app.services.ai_tagging_system import is_ai_tagging_configured, run_ai_tagging_for_story
 from app.services.story_service import (
@@ -42,7 +37,6 @@ from app.services.story_service import (
     list_available_stories,
     list_comments_for_story,
     list_saved_stories_for_user,
-    remove_story_as_admin,
     save_story_for_user,
     search_available_stories_by_place,
     unlike_story,
@@ -541,153 +535,3 @@ async def report_story(
     db: AsyncSession = Depends(get_db),
 ):
     return await create_report_for_story(db, story_id, current_user, payload)
-
-
-@router.get(
-    "/admin/reports",
-    response_model=AdminReportsListResponse,
-    tags=["admin"],
-    summary="Get reported stories (admin only)",
-    description="Retrieve all reported stories with filtering options. Admin access required.",
-    responses={
-        401: {"description": "Missing or invalid authentication token"},
-        403: {"description": "User is not an admin"},
-    },
-)
-async def get_admin_reports(
-    status: ReportStatus | None = Query(None, description="Filter by report status"),
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
-):
-    # Admin check
-    if current_user.role != UserRole.ADMIN:
-        raise HTTPException(status_code=403, detail="Admin access required")
-
-    # Build query with joins to get related data for both the reporter and story author.
-    from sqlalchemy import select
-    from sqlalchemy.orm import aliased
-
-    story_author = aliased(User)
-    reporter = aliased(User)
-
-    query = (
-        select(
-            StoryReport.id,
-            StoryReport.story_id,
-            StoryReport.user_id,
-            StoryReport.reason,
-            StoryReport.description,
-            StoryReport.status,
-            StoryReport.created_at,
-            Story.title.label("story_title"),
-            story_author.username.label("story_author_username"),
-            reporter.username.label("reporter_username"),
-        )
-        .join(Story, StoryReport.story_id == Story.id)
-        .join(story_author, Story.user_id == story_author.id)
-        .join(reporter, StoryReport.user_id == reporter.id)
-    )
-
-    if status:
-        query = query.where(StoryReport.status == status)
-
-    query = query.order_by(StoryReport.created_at.desc())
-
-    result = await db.execute(query)
-    rows = result.fetchall()
-
-    reports = [
-        AdminReportListItem(
-            id=row.id,
-            story_id=row.story_id,
-            user_id=row.user_id,
-            reason=row.reason,
-            description=row.description,
-            status=row.status,
-            created_at=row.created_at,
-            story_title=row.story_title,
-            reporter_username=row.reporter_username,
-            story_author_username=row.story_author_username,
-        )
-        for row in rows
-    ]
-
-    return AdminReportsListResponse(total=len(reports), reports=reports)
-
-
-@router.put(
-    "/admin/reports/{report_id}",
-    response_model=StoryReportResponse,
-    tags=["admin"],
-    summary="Update report status (admin only)",
-    description="Mark a reported story as reviewed. Story removal is handled by the admin remove-story endpoint.",
-    responses={
-        401: {"description": "Missing or invalid authentication token"},
-        400: {"description": "Invalid report status transition"},
-        403: {"description": "User is not an admin"},
-        404: {"description": "Report not found"},
-        409: {"description": "Report can no longer be updated"},
-    },
-)
-async def update_report_status(
-    report_id: uuid.UUID,
-    payload: UpdateReportStatusRequest,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
-):
-    # Admin check
-    if current_user.role != UserRole.ADMIN:
-        raise HTTPException(status_code=403, detail="Admin access required")
-
-    # Fetch the report
-    from sqlalchemy import select
-
-    query = select(StoryReport).where(StoryReport.id == report_id)
-    result = await db.execute(query)
-    report = result.scalars().first()
-
-    if not report:
-        raise HTTPException(status_code=404, detail="Report not found")
-
-    if payload.status == ReportStatus.REMOVED:
-        raise HTTPException(
-            status_code=400,
-            detail="Use the admin remove story endpoint to mark reports as removed",
-        )
-
-    if report.status == ReportStatus.REMOVED:
-        raise HTTPException(
-            status_code=409,
-            detail="Removed reports cannot be updated",
-        )
-
-    # MVP moderation flow: this endpoint is only for acknowledging a report as reviewed.
-    report.status = payload.status
-    db.add(report)
-    await db.commit()
-    await db.refresh(report)
-
-    return report
-
-
-@router.delete(
-    "/admin/stories/{story_id}",
-    status_code=status.HTTP_204_NO_CONTENT,
-    tags=["admin"],
-    summary="Remove story (admin only)",
-    description="Soft-delete a story and mark its pending reports as removed. Admin access required.",
-    responses={
-        401: {"description": "Missing or invalid authentication token"},
-        403: {"description": "User is not an admin"},
-        404: {"description": "Story not found"},
-    },
-)
-async def admin_remove_story(
-    story_id: uuid.UUID,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
-):
-    if current_user.role != UserRole.ADMIN:
-        raise HTTPException(status_code=403, detail="Admin access required")
-
-    await remove_story_as_admin(db, story_id, current_user)

--- a/backend/app/services/admin_service.py
+++ b/backend/app/services/admin_service.py
@@ -10,7 +10,8 @@ from app.db.enums import ReportStatus, UserRole
 from app.db.story import Story
 from app.db.story_report import StoryReport
 from app.db.user import User
-from app.models.story import AdminReportListItem, AdminReportsListResponse, StoryReportResponse, UpdateReportStatusRequest
+from app.models.admin import AdminReportListItem, AdminReportsListResponse, UpdateReportStatusRequest
+from app.models.story import StoryReportResponse
 
 
 def ensure_admin_user(current_user: User) -> None:
@@ -26,6 +27,62 @@ async def list_admin_reports(
     db: AsyncSession,
     report_status: ReportStatus | None = None,
 ) -> AdminReportsListResponse:
+    rows = await _fetch_admin_report_rows(db, report_status)
+    reports = [_map_admin_report_row(row) for row in rows]
+
+    return AdminReportsListResponse(total=len(reports), reports=reports)
+
+
+async def update_report_status_as_admin(
+    db: AsyncSession,
+    report_id: uuid.UUID,
+    payload: UpdateReportStatusRequest,
+) -> StoryReportResponse:
+    report = await _get_report_or_404(db, report_id)
+
+    if payload.status == ReportStatus.REMOVED:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Use the admin remove story endpoint to mark reports as removed",
+        )
+
+    if report.status == ReportStatus.REMOVED:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Removed reports cannot be updated",
+        )
+
+    report.status = payload.status
+    db.add(report)
+    await db.commit()
+    await db.refresh(report)
+
+    return StoryReportResponse.model_validate(report)
+
+
+async def remove_story_as_admin(
+    db: AsyncSession,
+    story_id: uuid.UUID,
+    current_user: User,
+) -> None:
+    story = await _get_story_or_404(db, story_id)
+
+    story.deleted_at = datetime.now(timezone.utc)
+    story.deleted_by = current_user.id
+    db.add(story)
+
+    pending_reports = await _list_pending_reports_for_story(db, story_id)
+    for report in pending_reports:
+        report.status = ReportStatus.REMOVED
+        db.add(report)
+
+    await db.commit()
+
+
+async def _fetch_admin_report_rows(
+    db: AsyncSession,
+    report_status: ReportStatus | None,
+):
     story_author = aliased(User)
     reporter = aliased(User)
 
@@ -53,63 +110,38 @@ async def list_admin_reports(
     query = query.order_by(StoryReport.created_at.desc())
 
     result = await db.execute(query)
-    rows = result.fetchall()
-
-    reports = [
-        AdminReportListItem(
-            id=row.id,
-            story_id=row.story_id,
-            user_id=row.user_id,
-            reason=row.reason,
-            description=row.description,
-            status=row.status,
-            created_at=row.created_at,
-            story_title=row.story_title,
-            reporter_username=row.reporter_username,
-            story_author_username=row.story_author_username,
-        )
-        for row in rows
-    ]
-
-    return AdminReportsListResponse(total=len(reports), reports=reports)
+    return result.fetchall()
 
 
-async def update_report_status_as_admin(
-    db: AsyncSession,
-    report_id: uuid.UUID,
-    payload: UpdateReportStatusRequest,
-) -> StoryReportResponse:
+def _map_admin_report_row(row) -> AdminReportListItem:
+    return AdminReportListItem(
+        id=row.id,
+        story_id=row.story_id,
+        user_id=row.user_id,
+        reason=row.reason,
+        description=row.description,
+        status=row.status,
+        created_at=row.created_at,
+        story_title=row.story_title,
+        reporter_username=row.reporter_username,
+        story_author_username=row.story_author_username,
+    )
+
+
+async def _get_report_or_404(db: AsyncSession, report_id: uuid.UUID) -> StoryReport:
     result = await db.execute(select(StoryReport).where(StoryReport.id == report_id))
     report = result.scalars().first()
 
     if not report:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Report not found")
 
-    if payload.status == ReportStatus.REMOVED:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Use the admin remove story endpoint to mark reports as removed",
-        )
-
-    if report.status == ReportStatus.REMOVED:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="Removed reports cannot be updated",
-        )
-
-    report.status = payload.status
-    db.add(report)
-    await db.commit()
-    await db.refresh(report)
-
-    return StoryReportResponse.model_validate(report)
+    return report
 
 
-async def remove_story_as_admin(
+async def _get_story_or_404(
     db: AsyncSession,
     story_id: uuid.UUID,
-    current_user: User,
-) -> None:
+) -> Story:
     story_result = await db.execute(select(Story).where(Story.id == story_id, Story.deleted_at.is_(None)))
     story = story_result.scalar_one_or_none()
     if story is None:
@@ -118,19 +150,17 @@ async def remove_story_as_admin(
             detail="Story not found",
         )
 
-    story.deleted_at = datetime.now(timezone.utc)
-    story.deleted_by = current_user.id
-    db.add(story)
+    return story
 
+
+async def _list_pending_reports_for_story(
+    db: AsyncSession,
+    story_id: uuid.UUID,
+) -> list[StoryReport]:
     reports_result = await db.execute(
         select(StoryReport).where(
             StoryReport.story_id == story_id,
             StoryReport.status == ReportStatus.PENDING,
         )
     )
-    pending_reports = reports_result.scalars().all()
-    for report in pending_reports:
-        report.status = ReportStatus.REMOVED
-        db.add(report)
-
-    await db.commit()
+    return list(reports_result.scalars().all())

--- a/backend/app/services/admin_service.py
+++ b/backend/app/services/admin_service.py
@@ -1,7 +1,16 @@
-from fastapi import HTTPException, status
+import uuid
+from datetime import datetime, timezone
 
-from app.db.enums import UserRole
+from fastapi import HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
+
+from app.db.enums import ReportStatus, UserRole
+from app.db.story import Story
+from app.db.story_report import StoryReport
 from app.db.user import User
+from app.models.story import AdminReportListItem, AdminReportsListResponse, StoryReportResponse, UpdateReportStatusRequest
 
 
 def ensure_admin_user(current_user: User) -> None:
@@ -11,3 +20,117 @@ def ensure_admin_user(current_user: User) -> None:
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Admin access required",
         )
+
+
+async def list_admin_reports(
+    db: AsyncSession,
+    report_status: ReportStatus | None = None,
+) -> AdminReportsListResponse:
+    story_author = aliased(User)
+    reporter = aliased(User)
+
+    query = (
+        select(
+            StoryReport.id,
+            StoryReport.story_id,
+            StoryReport.user_id,
+            StoryReport.reason,
+            StoryReport.description,
+            StoryReport.status,
+            StoryReport.created_at,
+            Story.title.label("story_title"),
+            story_author.username.label("story_author_username"),
+            reporter.username.label("reporter_username"),
+        )
+        .join(Story, StoryReport.story_id == Story.id)
+        .join(story_author, Story.user_id == story_author.id)
+        .join(reporter, StoryReport.user_id == reporter.id)
+    )
+
+    if report_status:
+        query = query.where(StoryReport.status == report_status)
+
+    query = query.order_by(StoryReport.created_at.desc())
+
+    result = await db.execute(query)
+    rows = result.fetchall()
+
+    reports = [
+        AdminReportListItem(
+            id=row.id,
+            story_id=row.story_id,
+            user_id=row.user_id,
+            reason=row.reason,
+            description=row.description,
+            status=row.status,
+            created_at=row.created_at,
+            story_title=row.story_title,
+            reporter_username=row.reporter_username,
+            story_author_username=row.story_author_username,
+        )
+        for row in rows
+    ]
+
+    return AdminReportsListResponse(total=len(reports), reports=reports)
+
+
+async def update_report_status_as_admin(
+    db: AsyncSession,
+    report_id: uuid.UUID,
+    payload: UpdateReportStatusRequest,
+) -> StoryReportResponse:
+    result = await db.execute(select(StoryReport).where(StoryReport.id == report_id))
+    report = result.scalars().first()
+
+    if not report:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Report not found")
+
+    if payload.status == ReportStatus.REMOVED:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Use the admin remove story endpoint to mark reports as removed",
+        )
+
+    if report.status == ReportStatus.REMOVED:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Removed reports cannot be updated",
+        )
+
+    report.status = payload.status
+    db.add(report)
+    await db.commit()
+    await db.refresh(report)
+
+    return StoryReportResponse.model_validate(report)
+
+
+async def remove_story_as_admin(
+    db: AsyncSession,
+    story_id: uuid.UUID,
+    current_user: User,
+) -> None:
+    story_result = await db.execute(select(Story).where(Story.id == story_id, Story.deleted_at.is_(None)))
+    story = story_result.scalar_one_or_none()
+    if story is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Story not found",
+        )
+
+    story.deleted_at = datetime.now(timezone.utc)
+    story.deleted_by = current_user.id
+    db.add(story)
+
+    reports_result = await db.execute(
+        select(StoryReport).where(
+            StoryReport.story_id == story_id,
+            StoryReport.status == ReportStatus.PENDING,
+        )
+    )
+    pending_reports = reports_result.scalars().all()
+    for report in pending_reports:
+        report.status = ReportStatus.REMOVED
+        db.add(report)
+
+    await db.commit()

--- a/backend/app/services/admin_service.py
+++ b/backend/app/services/admin_service.py
@@ -1,0 +1,13 @@
+from fastapi import HTTPException, status
+
+from app.db.enums import UserRole
+from app.db.user import User
+
+
+def ensure_admin_user(current_user: User) -> None:
+    """Require the current user to have admin privileges."""
+    if current_user.role != UserRole.ADMIN:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin access required",
+        )

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -939,32 +939,3 @@ async def create_report_for_story(
     return StoryReportResponse.model_validate(report)
 
 
-async def remove_story_as_admin(
-    db: AsyncSession,
-    story_id: uuid.UUID,
-    current_user: User,
-) -> None:
-    story_result = await db.execute(select(Story).where(Story.id == story_id, Story.deleted_at.is_(None)))
-    story = story_result.scalar_one_or_none()
-    if story is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Story not found",
-        )
-
-    story.deleted_at = datetime.now(timezone.utc)
-    story.deleted_by = current_user.id
-    db.add(story)
-
-    reports_result = await db.execute(
-        select(StoryReport).where(
-            StoryReport.story_id == story_id,
-            StoryReport.status == ReportStatus.PENDING,
-        )
-    )
-    pending_reports = reports_result.scalars().all()
-    for report in pending_reports:
-        report.status = ReportStatus.REMOVED
-        db.add(report)
-
-    await db.commit()

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -937,5 +937,3 @@ async def create_report_for_story(
         )
 
     return StoryReportResponse.model_validate(report)
-
-

--- a/backend/tests/api/test_admin_routing_api.py
+++ b/backend/tests/api/test_admin_routing_api.py
@@ -1,0 +1,41 @@
+from app.main import app
+
+
+def _route_by_path(path: str):
+    return next(route for route in app.routes if getattr(route, "path", None) == path)
+
+
+class TestAdminRoutingAPI:
+    def test_admin_routes_are_exposed_from_admin_router(self):
+        admin_paths = {
+            "/stories/admin/reports",
+            "/stories/admin/reports/{report_id}",
+            "/stories/admin/stories/{story_id}",
+        }
+
+        routes = {
+            route.path: route
+            for route in app.routes
+            if getattr(route, "path", None) in admin_paths
+        }
+
+        assert set(routes) == admin_paths
+        assert all(route.endpoint.__module__ == "app.routers.admin" for route in routes.values())
+
+    def test_admin_routes_are_registered_before_story_id_route(self):
+        route_paths = [getattr(route, "path", None) for route in app.routes]
+
+        story_detail_index = route_paths.index("/stories/{story_id}")
+
+        assert route_paths.index("/stories/admin/reports") < story_detail_index
+        assert route_paths.index("/stories/admin/reports/{report_id}") < story_detail_index
+        assert route_paths.index("/stories/admin/stories/{story_id}") < story_detail_index
+
+    def test_story_router_does_not_own_admin_paths(self):
+        admin_routes = [
+            _route_by_path("/stories/admin/reports"),
+            _route_by_path("/stories/admin/reports/{report_id}"),
+            _route_by_path("/stories/admin/stories/{story_id}"),
+        ]
+
+        assert all(route.endpoint.__module__ != "app.routers.story" for route in admin_routes)

--- a/backend/tests/api/test_admin_routing_api.py
+++ b/backend/tests/api/test_admin_routing_api.py
@@ -13,11 +13,7 @@ class TestAdminRoutingAPI:
             "/stories/admin/stories/{story_id}",
         }
 
-        routes = {
-            route.path: route
-            for route in app.routes
-            if getattr(route, "path", None) in admin_paths
-        }
+        routes = {route.path: route for route in app.routes if getattr(route, "path", None) in admin_paths}
 
         assert set(routes) == admin_paths
         assert all(route.endpoint.__module__ == "app.routers.admin" for route in routes.values())

--- a/backend/tests/unit/test_admin_service.py
+++ b/backend/tests/unit/test_admin_service.py
@@ -6,8 +6,14 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from fastapi import HTTPException
 
-from app.db.enums import DatePrecision, ReportStatus, StoryStatus, StoryVisibility
-from app.services.admin_service import remove_story_as_admin
+from app.db.enums import DatePrecision, ReportReason, ReportStatus, StoryStatus, StoryVisibility, UserRole
+from app.models.admin import UpdateReportStatusRequest
+from app.services.admin_service import (
+    ensure_admin_user,
+    list_admin_reports,
+    remove_story_as_admin,
+    update_report_status_as_admin,
+)
 
 
 def _make_story(**overrides):
@@ -31,6 +37,131 @@ def _make_story(**overrides):
     }
     base.update(overrides)
     return SimpleNamespace(**base)
+
+
+class TestAdminAuthorization:
+    def test_ensure_admin_user_allows_admin(self):
+        ensure_admin_user(SimpleNamespace(role=UserRole.ADMIN))
+
+    def test_ensure_admin_user_rejects_non_admin(self):
+        with pytest.raises(HTTPException) as exc_info:
+            ensure_admin_user(SimpleNamespace(role=UserRole.USER))
+
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.detail == "Admin access required"
+
+
+@pytest.mark.asyncio
+class TestAdminReportsService:
+    async def test_list_admin_reports_maps_report_rows(self):
+        report_id = uuid.uuid4()
+        story_id = uuid.uuid4()
+        reporter_id = uuid.uuid4()
+        created_at = datetime.now(timezone.utc)
+        row = SimpleNamespace(
+            id=report_id,
+            story_id=story_id,
+            user_id=reporter_id,
+            reason=ReportReason.INAPPROPRIATE_CONTENT,
+            description="bad content",
+            status=ReportStatus.PENDING,
+            created_at=created_at,
+            story_title="Reported Story",
+            reporter_username="reporter",
+            story_author_username="author",
+        )
+
+        db = AsyncMock()
+        db.execute.return_value.fetchall = lambda: [row]
+
+        result = await list_admin_reports(db)
+
+        assert result.total == 1
+        assert result.reports[0].id == report_id
+        assert result.reports[0].story_id == story_id
+        assert result.reports[0].user_id == reporter_id
+        assert result.reports[0].reason == ReportReason.INAPPROPRIATE_CONTENT
+        assert result.reports[0].description == "bad content"
+        assert result.reports[0].status == ReportStatus.PENDING
+        assert result.reports[0].created_at == created_at
+        assert result.reports[0].story_title == "Reported Story"
+        assert result.reports[0].reporter_username == "reporter"
+        assert result.reports[0].story_author_username == "author"
+        db.execute.assert_awaited_once()
+
+    async def test_list_admin_reports_applies_status_filter(self):
+        db = AsyncMock()
+        db.execute.return_value.fetchall = lambda: []
+
+        await list_admin_reports(db, report_status=ReportStatus.REVIEWED)
+
+        stmt = db.execute.await_args.args[0]
+        sql = str(stmt)
+
+        assert "story_reports.status" in sql
+        assert "ORDER BY story_reports.created_at DESC" in sql
+
+    async def test_update_report_status_success(self):
+        report = SimpleNamespace(
+            id=uuid.uuid4(),
+            story_id=uuid.uuid4(),
+            user_id=uuid.uuid4(),
+            reason=ReportReason.MISINFORMATION,
+            description=None,
+            status=ReportStatus.PENDING,
+            created_at=datetime.now(timezone.utc),
+        )
+        payload = UpdateReportStatusRequest(status=ReportStatus.REVIEWED)
+
+        db = AsyncMock()
+        db.add = MagicMock()
+        db.execute.return_value = SimpleNamespace(scalars=lambda: SimpleNamespace(first=lambda: report))
+
+        result = await update_report_status_as_admin(db, report.id, payload)
+
+        assert report.status == ReportStatus.REVIEWED
+        assert result.status == ReportStatus.REVIEWED
+        db.add.assert_called_once_with(report)
+        db.commit.assert_awaited_once()
+        db.refresh.assert_awaited_once_with(report)
+
+    async def test_update_report_status_raises_404_when_report_missing(self):
+        db = AsyncMock()
+        db.execute.return_value = SimpleNamespace(scalars=lambda: SimpleNamespace(first=lambda: None))
+        payload = UpdateReportStatusRequest(status=ReportStatus.REVIEWED)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await update_report_status_as_admin(db, uuid.uuid4(), payload)
+
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "Report not found"
+        db.commit.assert_not_awaited()
+
+    async def test_update_report_status_rejects_removed_target_status(self):
+        report = SimpleNamespace(status=ReportStatus.PENDING)
+        db = AsyncMock()
+        db.execute.return_value = SimpleNamespace(scalars=lambda: SimpleNamespace(first=lambda: report))
+        payload = UpdateReportStatusRequest(status=ReportStatus.REMOVED)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await update_report_status_as_admin(db, uuid.uuid4(), payload)
+
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail == "Use the admin remove story endpoint to mark reports as removed"
+        db.commit.assert_not_awaited()
+
+    async def test_update_report_status_rejects_removed_report(self):
+        report = SimpleNamespace(status=ReportStatus.REMOVED)
+        db = AsyncMock()
+        db.execute.return_value = SimpleNamespace(scalars=lambda: SimpleNamespace(first=lambda: report))
+        payload = UpdateReportStatusRequest(status=ReportStatus.REVIEWED)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await update_report_status_as_admin(db, uuid.uuid4(), payload)
+
+        assert exc_info.value.status_code == 409
+        assert exc_info.value.detail == "Removed reports cannot be updated"
+        db.commit.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_admin_service.py
+++ b/backend/tests/unit/test_admin_service.py
@@ -1,0 +1,72 @@
+import uuid
+from datetime import date, datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.db.enums import DatePrecision, ReportStatus, StoryStatus, StoryVisibility
+from app.services.admin_service import remove_story_as_admin
+
+
+def _make_story(**overrides):
+    base = {
+        "id": uuid.uuid4(),
+        "title": "Story Title",
+        "summary": "Story summary",
+        "content": "Story content",
+        "place_name": "Istanbul",
+        "latitude": 41.0082,
+        "longitude": 28.9784,
+        "date_start": date(1453, 1, 1),
+        "date_end": date(1453, 12, 31),
+        "date_precision": DatePrecision.YEAR,
+        "status": StoryStatus.PUBLISHED,
+        "visibility": StoryVisibility.PUBLIC,
+        "is_anonymous": False,
+        "view_count": 0,
+        "created_at": datetime.now(timezone.utc),
+        "story_likes": [],
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+@pytest.mark.asyncio
+class TestAdminRemoveStoryService:
+    async def test_soft_deletes_story_and_marks_pending_reports_removed(self):
+        story_id = uuid.uuid4()
+        admin_id = uuid.uuid4()
+        story = _make_story(id=story_id, deleted_at=None, deleted_by=None)
+        current_user = SimpleNamespace(id=admin_id)
+
+        pending_report_1 = SimpleNamespace(status=ReportStatus.PENDING)
+        pending_report_2 = SimpleNamespace(status=ReportStatus.PENDING)
+
+        db = AsyncMock()
+        db.add = MagicMock()
+        db.execute.side_effect = [
+            SimpleNamespace(scalar_one_or_none=lambda: story),
+            SimpleNamespace(scalars=lambda: SimpleNamespace(all=lambda: [pending_report_1, pending_report_2])),
+        ]
+
+        await remove_story_as_admin(db, story_id, current_user)
+
+        assert story.deleted_at is not None
+        assert story.deleted_by == admin_id
+        assert pending_report_1.status == ReportStatus.REMOVED
+        assert pending_report_2.status == ReportStatus.REMOVED
+        db.commit.assert_awaited_once()
+        assert db.add.call_count == 3
+
+    async def test_remove_story_raises_404_when_story_missing(self):
+        db = AsyncMock()
+        db.execute.return_value.scalar_one_or_none = lambda: None
+
+        with pytest.raises(HTTPException) as exc_info:
+            await remove_story_as_admin(db, uuid.uuid4(), SimpleNamespace(id=uuid.uuid4()))
+
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "Story not found"
+        db.commit.assert_not_awaited()

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -20,7 +20,6 @@ from app.db.notification import Notification
 from app.db.tag import Tag
 from app.models.comment import CommentCreateRequest
 from app.models.story import MediaUploadRequest, StoryCreateRequest, StoryResponse, StoryUpdateRequest
-from app.services.admin_service import remove_story_as_admin
 from app.services.story_service import (
     create_comment_for_story,
     create_story_with_location,
@@ -1783,45 +1782,6 @@ class TestAiTagPersistenceHelpers:
 
         with pytest.raises(HTTPException) as exc_info:
             await apply_ai_tags_to_story(db, uuid.uuid4(), ["bogazici"])
-
-        assert exc_info.value.status_code == 404
-        assert exc_info.value.detail == "Story not found"
-        db.commit.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-class TestAdminRemoveStoryService:
-    async def test_soft_deletes_story_and_marks_pending_reports_removed(self):
-        story_id = uuid.uuid4()
-        admin_id = uuid.uuid4()
-        story = _make_story(id=story_id, deleted_at=None, deleted_by=None)
-        current_user = SimpleNamespace(id=admin_id)
-
-        pending_report_1 = SimpleNamespace(status=ReportStatus.PENDING)
-        pending_report_2 = SimpleNamespace(status=ReportStatus.PENDING)
-
-        db = AsyncMock()
-        db.add = MagicMock()
-        db.execute.side_effect = [
-            SimpleNamespace(scalar_one_or_none=lambda: story),
-            SimpleNamespace(scalars=lambda: SimpleNamespace(all=lambda: [pending_report_1, pending_report_2])),
-        ]
-
-        await remove_story_as_admin(db, story_id, current_user)
-
-        assert story.deleted_at is not None
-        assert story.deleted_by == admin_id
-        assert pending_report_1.status == ReportStatus.REMOVED
-        assert pending_report_2.status == ReportStatus.REMOVED
-        db.commit.assert_awaited_once()
-        assert db.add.call_count == 3
-
-    async def test_remove_story_raises_404_when_story_missing(self):
-        db = AsyncMock()
-        db.execute.return_value.scalar_one_or_none = lambda: None
-
-        with pytest.raises(HTTPException) as exc_info:
-            await remove_story_as_admin(db, uuid.uuid4(), SimpleNamespace(id=uuid.uuid4()))
 
         assert exc_info.value.status_code == 404
         assert exc_info.value.detail == "Story not found"

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -20,6 +20,7 @@ from app.db.notification import Notification
 from app.db.tag import Tag
 from app.models.comment import CommentCreateRequest
 from app.models.story import MediaUploadRequest, StoryCreateRequest, StoryResponse, StoryUpdateRequest
+from app.services.admin_service import remove_story_as_admin
 from app.services.story_service import (
     create_comment_for_story,
     create_story_with_location,
@@ -32,7 +33,6 @@ from app.services.story_service import (
     list_available_stories,
     list_comments_for_story,
     list_saved_stories_for_user,
-    remove_story_as_admin,
     save_story_for_user,
     search_available_stories_by_place,
     unlike_story,

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -12,7 +12,6 @@ from app.db.enums import (
     DatePrecision,
     MediaType,
     NotificationEventType,
-    ReportStatus,
     StoryStatus,
     StoryVisibility,
 )


### PR DESCRIPTION
## Description
Extracted admin-related story moderation logic into a dedicated admin service/router to improve separation of concerns and keep story service focused on user story workflows.

## Related Issue(s)
- Closes #

## Changes

| File | Change |
|------|--------|
| `backend/app/routers/admin.py` | Added admin routes for report listing, report status updates, and story removal. |
| `backend/app/services/admin_service.py` | Added admin business logic and centralized RBAC enforcement. |
| `backend/app/routers/story.py` | Removed admin endpoints and admin-specific imports. |
| `backend/app/services/story_service.py` | Removed admin story removal logic. |
| `backend/app/models/admin.py` | Added admin-specific request/response schemas. |
| `backend/app/models/story.py` | Removed admin-specific schemas from story models. |
| `backend/app/main.py` | Registered the dedicated admin router. |
| `backend/tests/unit/test_admin_service.py` | Added/updated admin service unit tests. |
| `backend/tests/api/test_admin_routing_api.py` | Added routing tests to verify admin paths are served by the admin router. |

## Checklist
- [x] All tests passed
- [x] I have self-reviewed my own code
