### PR TITLE
test: extend seeded_db with media file, DATE story, and admin story

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import MagicMock
 
 import pytest_asyncio
@@ -42,13 +43,18 @@ BADGE_SEEDS = [
     },
 ]
 
-# Build the async DB URL
-# For tests, replace 'db' hostname with 'localhost' for local development
-_url = settings.DATABASE_URL.replace("@db:", "@localhost:")
-if _url.startswith("postgresql://"):
-    _url = _url.replace("postgresql://", "postgresql+asyncpg://", 1)
-elif _url.startswith("postgres://"):
-    _url = _url.replace("postgres://", "postgresql+asyncpg://", 1)
+# Build the async DB URL.
+# TEST_DATABASE_URL env var overrides everything (useful when running tests
+# inside Docker where 'db' is the correct hostname, not 'localhost').
+# Otherwise, replace 'db' with 'localhost' for running tests on the host
+# against the port-forwarded postgres container.
+_raw = os.environ.get("TEST_DATABASE_URL") or settings.DATABASE_URL.replace("@db:", "@localhost:")
+if _raw.startswith("postgresql://"):
+    _url = _raw.replace("postgresql://", "postgresql+asyncpg://", 1)
+elif _raw.startswith("postgres://"):
+    _url = _raw.replace("postgres://", "postgresql+asyncpg://", 1)
+else:
+    _url = _raw
 
 
 @pytest_asyncio.fixture
@@ -117,7 +123,8 @@ async def seeded_db(db_session):
     """
     from datetime import date
 
-    from app.db.enums import DatePrecision, StoryStatus, StoryVisibility, UserRole
+    from app.db.enums import DatePrecision, MediaType, StoryStatus, StoryVisibility, UserRole
+    from tests.factories.media_file_factory import make_media_file_entity
     from tests.factories.story_factory import make_story_entity
     from tests.factories.user_factory import make_user_entity
 
@@ -198,9 +205,51 @@ async def seeded_db(db_session):
             status=StoryStatus.PUBLISHED,
             visibility=StoryVisibility.PRIVATE,
         ),
+        # DATE-precision story — exercises exact-date filter queries
+        make_story_entity(
+            user_id=bob.id,
+            title="Battle of Gallipoli",
+            content="The Allied campaign against the Ottoman Empire at Gallipoli in 1915.",
+            summary="WWI campaign at Gallipoli.",
+            place_name="Çanakkale",
+            latitude=40.1553,
+            longitude=26.4142,
+            date_start=date(1915, 4, 25),
+            date_end=date(1915, 4, 25),
+            date_precision=DatePrecision.DATE,
+            status=StoryStatus.PUBLISHED,
+            visibility=StoryVisibility.PUBLIC,
+        ),
+        # Admin-owned story — supports admin moderation test scenarios
+        make_story_entity(
+            user_id=admin.id,
+            title="Admin's Historical Note",
+            content="A public story created by the admin user.",
+            summary="Admin-authored story.",
+            place_name="Ankara",
+            latitude=39.9334,
+            longitude=32.8597,
+            date_start=date(2020, 1, 1),
+            date_end=date(2020, 12, 31),
+            date_precision=DatePrecision.YEAR,
+            status=StoryStatus.PUBLISHED,
+            visibility=StoryVisibility.PUBLIC,
+        ),
     ]
 
     db_session.add_all(stories_data)
+    await db_session.flush()
+
+    # Attach a media file to "Fall of Constantinople" for story-detail media assertions
+    constantinople = next(s for s in stories_data if s.title == "Fall of Constantinople")
+    media = make_media_file_entity(
+        story_id=constantinople.id,
+        original_filename="constantinople.png",
+        alt_text="Map of the siege",
+        caption="Ottoman forces surrounding Constantinople, 1453",
+        media_type=MediaType.IMAGE,
+    )
+    db_session.add(media)
     await db_session.commit()
 
     stories_by_title = {s.title: s for s in stories_data}
@@ -210,4 +259,5 @@ async def seeded_db(db_session):
         "users": {"admin": admin, "alice": alice, "bob": bob},
         "stories": stories_by_title,
         "public": public,
+        "media": {"constantinople_image": media},
     }

--- a/backend/tests/integration/test_seed_db.py
+++ b/backend/tests/integration/test_seed_db.py
@@ -17,17 +17,23 @@ class TestSeededDatabaseContent:
             assert resp.status_code == 200, f"Login failed for {email}: {resp.json()}"
             assert "access_token" in resp.json()
 
-    async def test_three_public_stories_in_listing(self, client, seeded_db):
+    async def test_five_public_stories_in_listing(self, client, seeded_db):
         resp = await client.get("/stories")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["total"] == 3
+        assert data["total"] == 5
 
     async def test_public_story_titles_in_listing(self, client, seeded_db):
         resp = await client.get("/stories")
         assert resp.status_code == 200
         titles = {s["title"] for s in resp.json()["stories"]}
-        assert titles == {"Fall of Constantinople", "Atatürk's Ankara", "Ancient Ephesus"}
+        assert titles == {
+            "Fall of Constantinople",
+            "Atatürk's Ankara",
+            "Ancient Ephesus",
+            "Battle of Gallipoli",
+            "Admin's Historical Note",
+        }
 
     async def test_draft_story_excluded_from_listing(self, client, seeded_db):
         resp = await client.get("/stories")
@@ -45,8 +51,11 @@ class TestSeededDatabaseContent:
         resp = await client.get("/stories/search?place_name=Ankara")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["total"] == 1
-        assert data["stories"][0]["title"] == "Atatürk's Ankara"
+        # Two seeded stories share place_name "Ankara"
+        assert data["total"] == 2
+        titles = {s["title"] for s in data["stories"]}
+        assert "Atatürk's Ankara" in titles
+        assert "Admin's Historical Note" in titles
 
     async def test_bounds_filter_returns_istanbul_story(self, client, seeded_db):
         # Tight bounding box around Istanbul (41.0082, 28.9784)
@@ -77,3 +86,28 @@ class TestSeededDatabaseContent:
         assert "Atatürk's Ankara" in titles
         assert "Fall of Constantinople" not in titles
         assert "Ancient Ephesus" not in titles
+
+    async def test_story_detail_includes_seeded_media_file(self, client, seeded_db):
+        story_id = seeded_db["stories"]["Fall of Constantinople"].id
+        resp = await client.get(f"/stories/{story_id}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["media_files"]) == 1
+        mf = data["media_files"][0]
+        assert mf["original_filename"] == "constantinople.png"
+        assert mf["media_type"] == "image"
+
+    async def test_date_precision_story_retrievable(self, client, seeded_db):
+        story_id = seeded_db["stories"]["Battle of Gallipoli"].id
+        resp = await client.get(f"/stories/{story_id}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["date_precision"] == "date"
+        assert data["date_start"] == "1915-04-25"
+        assert data["date_end"] == "1915-04-25"
+
+    async def test_admin_story_appears_in_public_listing(self, client, seeded_db):
+        resp = await client.get("/stories")
+        assert resp.status_code == 200
+        titles = [s["title"] for s in resp.json()["stories"]]
+        assert "Admin's Historical Note" in titles


### PR DESCRIPTION
## Description
Extends the `seeded_db` fixture (introduced in #110) to cover three gaps identified in #224:
- No media files were seeded, so story-detail media assertions had nothing to check
- No story used `DATE` precision, leaving the exact-date filter path untested
- `seed_admin` owned no stories, blocking admin moderation test scenarios

Also adds a `TEST_DATABASE_URL` env-var override to `conftest.py` so integration tests can be run inside Docker (where the DB is at `db:5432`, not `localhost:5432`) without modifying the CI setup.

## Related Issue(s)
- Closes #224


## Changes

| File | Change |
|------|--------|
| `backend/tests/conftest.py` | Added `import os`; replaced hardcoded `@db:→@localhost:` logic with `TEST_DATABASE_URL` env-var override; added `else` branch for already-prefixed URLs; added `MediaType` + `make_media_file_entity` imports in `seeded_db`; added "Battle of Gallipoli" (DATE precision), "Admin's Historical Note" (admin-owned), and a `MediaFile` attached to "Fall of Constantinople" |
| `backend/tests/integration/test_seed_db.py` | Updated listing count assertion 3→5 and Ankara search count 1→2; added 3 new tests: `test_story_detail_includes_seeded_media_file`, `test_date_precision_story_retrievable`, `test_admin_story_appears_in_public_listing` |


## Checklist
- [x] All tests passed 
- [x] I have self-reviewed my own code
- [ ] I have requested at least 1 reviewer