### PR TITLE
feat: ISSUE-376 add serverside filtering on /saerch/nearby

### DIFF
--- a/backend/app/routers/story.py
+++ b/backend/app/routers/story.py
@@ -259,9 +259,10 @@ async def list_nearby_stories(
     lat: float = Query(ge=-90.0, le=90.0),
     lng: float = Query(ge=-180.0, le=180.0),
     radius_km: float = Query(default=10.0, gt=0.0, le=500.0),
+    tags: list[str] | None = Query(default=None),
     db: AsyncSession = Depends(get_db),
 ):
-    return await get_nearby_stories(db, center_lat=lat, center_lng=lng, radius_km=radius_km)
+    return await get_nearby_stories(db, center_lat=lat, center_lng=lng, radius_km=radius_km, tags=tags)
 
 
 @router.get(

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -813,6 +813,7 @@ async def get_nearby_stories(
     center_lat: float,
     center_lng: float,
     radius_km: float = 10.0,
+    tags: list[str] | None = None,
 ) -> StoryListResponse:
     lat1 = func.radians(center_lat)
     lat2 = func.radians(Story.latitude)

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -815,6 +815,7 @@ async def get_nearby_stories(
     radius_km: float = 10.0,
     tags: list[str] | None = None,
 ) -> StoryListResponse:
+    normalized_tags = normalize_tag_list(tags)
     lat1 = func.radians(center_lat)
     lat2 = func.radians(Story.latitude)
     lon1 = func.radians(center_lng)
@@ -838,8 +839,19 @@ async def get_nearby_stories(
             Story.longitude.is_not(None),
             distance_km <= radius_km,
         )
-        .order_by(distance_km)
     )
+
+    if normalized_tags:
+        tag_match_count = func.count(Tag.id)
+        stmt = (
+            stmt.join(story_tags_table, story_tags_table.c.story_id == Story.id)
+            .join(Tag, Tag.id == story_tags_table.c.tag_id)
+            .where(Tag.name.in_(normalized_tags))
+            .group_by(Story.id, User.username)
+            .order_by(tag_match_count.desc(), distance_km)
+        )
+    else:
+        stmt = stmt.order_by(distance_km)
 
     result = await db.execute(stmt)
     rows = result.all()

--- a/backend/tests/api/test_story_api.py
+++ b/backend/tests/api/test_story_api.py
@@ -2116,6 +2116,37 @@ class TestNearbyStoriesAPI:
         data = resp.json()
         assert data["total"] == 0
 
+    async def test_filters_nearby_stories_by_repeated_tags(self, client, db_session):
+        user = self._make_user("nearbytagauthor", "nearbytag@example.com")
+        db_session.add(user)
+        await db_session.flush()
+
+        multi_tag_story = self._make_story(user.id, "Nearby Sport History", lat=41.0082, lng=28.9784)
+        single_tag_story = self._make_story(user.id, "Nearby Sport", lat=41.0090, lng=28.9790)
+        wrong_tag_story = self._make_story(user.id, "Nearby Music", lat=41.0085, lng=28.9788)
+        far_matching_story = self._make_story(
+            user.id,
+            "Far Sport History",
+            lat=39.9334,
+            lng=32.8597,
+            place_name="Ankara",
+        )
+        db_session.add_all([multi_tag_story, single_tag_story, wrong_tag_story, far_matching_story])
+        await db_session.commit()
+
+        await apply_ai_tags_to_story(db_session, multi_tag_story.id, ["spor", "tarih"])
+        await apply_ai_tags_to_story(db_session, single_tag_story.id, ["spor"])
+        await apply_ai_tags_to_story(db_session, wrong_tag_story.id, ["muzik"])
+        await apply_ai_tags_to_story(db_session, far_matching_story.id, ["spor", "tarih"])
+
+        resp = await client.get("/stories/nearby?lat=41.0082&lng=28.9784&radius_km=5&tags=spor&tags=tarih")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        titles = [story["title"] for story in data["stories"]]
+        assert data["total"] == 2
+        assert titles == ["Nearby Sport History", "Nearby Sport"]
+
     async def test_returns_empty_when_no_stories_exist(self, client):
         resp = await client.get("/stories/nearby?lat=41.0082&lng=28.9784")
 

--- a/backend/tests/integration/test_story_tag_flow.py
+++ b/backend/tests/integration/test_story_tag_flow.py
@@ -108,6 +108,40 @@ class TestStoryTagFlow:
         titles = [story["title"] for story in resp.json()["stories"]]
         assert titles == ["Sport History Story", "Sport Story"]
 
+    async def test_nearby_filters_by_tags_and_radius_with_or_matching(self, client, db_session):
+        token = await self._register_and_login(client, "tagnearby", "tagnearby@example.com")
+        multi_tag_story_id = await self._create_story(client, token, title="Nearby Sport History Story")
+        single_tag_story_id = await self._create_story(client, token, title="Nearby Sport Story")
+        non_matching_story_id = await self._create_story(client, token, title="Nearby Music Story")
+
+        far_resp = await client.post(
+            "/stories",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "title": "Far Sport History Story",
+                "content": "Story content about sports history in Ankara.",
+                "summary": "Tagged Ankara summary",
+                "place_name": "Ankara",
+                "latitude": 39.9334,
+                "longitude": 32.8597,
+                "date_start": 2024,
+                "date_end": 2024,
+            },
+        )
+        assert far_resp.status_code == 201
+        far_story_id = far_resp.json()["id"]
+
+        await apply_ai_tags_to_story(db_session, uuid.UUID(multi_tag_story_id), ["Spor", "Tarih"])
+        await apply_ai_tags_to_story(db_session, uuid.UUID(single_tag_story_id), ["Spor"])
+        await apply_ai_tags_to_story(db_session, uuid.UUID(non_matching_story_id), ["Muzik"])
+        await apply_ai_tags_to_story(db_session, uuid.UUID(far_story_id), ["Spor", "Tarih"])
+
+        resp = await client.get("/stories/nearby?lat=41.0082&lng=28.9784&radius_km=5&tags=spor&tags=tarih")
+
+        assert resp.status_code == 200
+        titles = [story["title"] for story in resp.json()["stories"]]
+        assert titles == ["Nearby Sport History Story", "Nearby Sport Story"]
+
     async def test_story_search_filters_by_place_and_tags_with_relevance_ranking(self, client, db_session):
         token = await self._register_and_login(client, "tagsearch", "tagsearch@example.com")
         multi_tag_story_id = await self._create_story(client, token, title="Istanbul Sport History Story")

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -1578,6 +1578,42 @@ class TestGetNearbyStoriesService:
         assert "ORDER BY" in sql
         assert "DESC" not in sql
 
+    async def test_query_includes_tag_filter_when_tags_provided(self):
+        db = AsyncMock()
+        db.execute.return_value.all = lambda: []
+
+        await get_nearby_stories(
+            db,
+            center_lat=41.0082,
+            center_lng=28.9784,
+            tags=[" Spor ", "history", "spor"],
+        )
+
+        stmt = db.execute.await_args.args[0]
+        sql = str(stmt)
+
+        assert "JOIN story_tags" in sql
+        assert "JOIN tags" in sql
+        assert "tags.name IN" in sql
+        assert "GROUP BY stories.id, users.username" in sql
+
+    async def test_query_ranks_tag_matches_then_distance_when_tags_provided(self):
+        db = AsyncMock()
+        db.execute.return_value.all = lambda: []
+
+        await get_nearby_stories(
+            db,
+            center_lat=41.0082,
+            center_lng=28.9784,
+            tags=["spor", "tarih"],
+        )
+
+        stmt = db.execute.await_args.args[0]
+        sql = str(stmt)
+
+        assert "ORDER BY count(tags.id) DESC" in sql
+        assert "asin" in sql
+
 
 @pytest.mark.asyncio
 class TestGetTimelineStoriesService:


### PR DESCRIPTION
## Description
Adds server-side tag filtering support for map nearby story queries. This lets `/stories/nearby` combine radius-based filtering with repeated `tags` query params, matching the existing story tag filtering behavior.

## Related Issue(s)
- Closes #

## Changes

| File | Change |
|------|--------|
| `backend/app/routers/story.py` | Added optional `tags` query param to `GET /stories/nearby`. |
| `backend/app/services/story_service.py` | Added tag normalization and server-side tag filtering for nearby stories while preserving distance ordering. |
| `backend/tests/unit/test_story_service.py` | Added unit coverage for nearby tag filtering query behavior. |
| `backend/tests/api/test_story_api.py` | Added API test for repeated tag params on `/stories/nearby`. |
| `backend/tests/integration/test_story_tag_flow.py` | Added integration flow for nearby radius + tag filtering. |

## Checklist
- [x] All tests passed
- [x] I have self-reviewed my own code

