### PR TITLE
fix: update date input format in badge and story E2E tests

### DIFF
--- a/frontend/tests/mobile-e2e/specs/tc-badge-1.spec.js
+++ b/frontend/tests/mobile-e2e/specs/tc-badge-1.spec.js
@@ -1,0 +1,205 @@
+// TC_BADGE_1 - First Post Badge Awarded (mobile Appium / WebdriverIO)
+//
+// Black-box test against the Capacitor WebView. Requires a running Appium
+// server, a connected Android device/emulator with the debug APK installed,
+// and the backend reachable at MOBILE_API_BASE_URL.
+//
+// The test is skipped automatically when no WEBVIEW context is available.
+
+const assert = require('node:assert/strict');
+const { switchToFirstWebviewContext } = require('../helpers/context');
+
+const TS = Date.now();
+const USERNAME = `badgeuser${TS}`;
+const EMAIL = `badgeuser${TS}@example.com`;
+const PASSWORD = 'Test@1234';
+const FIRST_STORY_BADGE = /First (Post|Story)/i;
+
+async function getAppOrigin() {
+  const url = await browser.getUrl();
+  return new URL(url).origin;
+}
+
+async function navigateTo(path) {
+  const origin = await getAppOrigin();
+  await browser.url(`${origin}${path}`);
+}
+
+async function registerAndLogin() {
+  await navigateTo('/register.html');
+
+  await (await browser.$('[data-testid="register-username"]')).setValue(USERNAME);
+  await (await browser.$('[data-testid="register-email"]')).setValue(EMAIL);
+  await (await browser.$('[data-testid="register-password"]')).setValue(PASSWORD);
+  await (await browser.$('[data-testid="register-confirm-password"]')).setValue(PASSWORD);
+
+  await browser.execute(() => {
+    const cb = document.querySelector('[data-testid="register-terms"]');
+    if (cb && !cb.checked) cb.click();
+  });
+
+  await (await browser.$('[data-testid="register-submit"]')).click();
+  await browser.waitUntil(
+    async () => (await browser.getUrl()).includes('index.html'),
+    { timeout: 10_000, interval: 500, timeoutMsg: 'Did not redirect to index.html after registration' },
+  );
+
+  await (await browser.$('[data-testid="login-email"]')).setValue(EMAIL);
+  await (await browser.$('[data-testid="login-password"]')).setValue(PASSWORD);
+  await (await browser.$('[data-testid="login-submit"]')).click();
+  await browser.waitUntil(
+    async () => (await browser.getUrl()).includes('map.html'),
+    { timeout: 10_000, interval: 500, timeoutMsg: 'Did not redirect to map.html after login' },
+  );
+}
+
+async function getBadgeSectionText() {
+  return browser.execute(() => {
+    const badges = document.querySelector('#profile-badges');
+    return badges ? badges.textContent : '';
+  });
+}
+
+async function getFirstStoryBadgeCount() {
+  return browser.execute((patternSource) => {
+    const pattern = new RegExp(patternSource, 'i');
+    return Array.from(document.querySelectorAll('#profile-badges span'))
+      .filter((el) => pattern.test(el.textContent || '')).length;
+  }, FIRST_STORY_BADGE.source);
+}
+
+async function expectNoFirstStoryBadgeOnProfile() {
+  await navigateTo('/profile.html');
+  await (await browser.$('#profile-badges')).waitForExist({ timeout: 10_000 });
+
+  await browser.waitUntil(
+    async () => (await getBadgeSectionText()).includes('No badges earned yet'),
+    { timeout: 10_000, interval: 500, timeoutMsg: 'Profile did not show the empty badge state' },
+  );
+
+  const badgeText = await getBadgeSectionText();
+  assert.ok(!FIRST_STORY_BADGE.test(badgeText), `first story badge should not be visible yet: "${badgeText}"`);
+}
+
+async function expectSingleFirstStoryBadgeOnProfile() {
+  await navigateTo('/profile.html');
+  await (await browser.$('#profile-badges')).waitForExist({ timeout: 10_000 });
+
+  await browser.waitUntil(
+    async () => FIRST_STORY_BADGE.test(await getBadgeSectionText()),
+    { timeout: 10_000, interval: 500, timeoutMsg: 'First story badge did not appear on profile' },
+  );
+
+  const badgeCount = await getFirstStoryBadgeCount();
+  assert.strictEqual(badgeCount, 1, `expected exactly one first story badge, got ${badgeCount}`);
+
+  const imageLoaded = await browser.execute((patternSource) => {
+    const pattern = new RegExp(patternSource, 'i');
+    const badgeCard = Array.from(document.querySelectorAll('#profile-badges div'))
+      .find((el) => pattern.test(el.textContent || ''));
+    const image = badgeCard ? badgeCard.querySelector('img') : null;
+    return Boolean(image && image.complete && image.naturalWidth > 0 && image.naturalHeight > 0);
+  }, FIRST_STORY_BADGE.source);
+
+  assert.ok(imageLoaded, 'profile first story badge image should load from bundled assets');
+}
+
+async function fillRequiredStoryFields(storyNumber) {
+  await navigateTo('/story-create.html');
+
+  await (await browser.$('#title')).setValue(`TC_BADGE_1 Story ${storyNumber}`);
+  await (await browser.$('#story')).setValue(
+    `Automated mobile story ${storyNumber} for verifying the first story badge award flow.`,
+  );
+  await (await browser.$('#location')).setValue('Bogazici University, Istanbul');
+  await (await browser.$('#date-single')).setValue('2026-05-12');
+
+  await browser.execute(() => {
+    document.querySelector('#latitude').value = '41.0857';
+    document.querySelector('#longitude').value = '29.0448';
+  });
+}
+
+async function publishStory(storyNumber) {
+  await fillRequiredStoryFields(storyNumber);
+  await (await browser.$('#btn-publish')).click();
+}
+
+async function expectBadgeUnlockModal() {
+  const modal = await browser.$('#badge-unlock-modal');
+  await browser.waitUntil(
+    async () => {
+      const classes = await modal.getAttribute('class');
+      return !classes.includes('hidden');
+    },
+    { timeout: 10_000, interval: 500, timeoutMsg: 'Badge unlock modal did not appear' },
+  );
+
+  const modalText = await modal.getText();
+  assert.ok(FIRST_STORY_BADGE.test(modalText), `badge modal should mention the first story badge: "${modalText}"`);
+
+  const imageLoaded = await browser.execute(() => {
+    const image = document.querySelector('#badge-unlock-image');
+    return Boolean(
+      image
+        && image.getAttribute('src')
+        && image.getAttribute('src').includes('assets/1st story.png')
+        && image.complete
+        && image.naturalWidth > 0
+        && image.naturalHeight > 0,
+    );
+  });
+
+  assert.ok(imageLoaded, 'badge unlock image should load from bundled assets');
+}
+
+async function expectNoBadgeUnlockModalAfterSecondStory() {
+  await browser.waitUntil(
+    async () => {
+      const success = await browser.$('#form-success');
+      return (await success.isExisting()) && (await success.getText()).includes('Story published successfully');
+    },
+    { timeout: 10_000, interval: 500, timeoutMsg: 'Second story success confirmation did not appear' },
+  );
+
+  const modalVisible = await browser.execute(() => {
+    const modal = document.querySelector('#badge-unlock-modal');
+    return Boolean(modal && !modal.classList.contains('hidden'));
+  });
+
+  assert.strictEqual(modalVisible, false, 'second story should not show a duplicate first story badge modal');
+}
+
+describe('TC_BADGE_1 - First post badge awarded', () => {
+  it('awards the first story badge once and displays it on the profile', async function () {
+    const webviewContext = await switchToFirstWebviewContext();
+    if (!webviewContext) {
+      return this.skip();
+    }
+
+    await registerAndLogin();
+
+    await expectNoFirstStoryBadgeOnProfile();
+
+    await publishStory(1);
+    await expectBadgeUnlockModal();
+
+    await (await browser.$('#badge-keep-publishing')).click();
+    await browser.waitUntil(
+      async () => (await browser.getUrl()).includes('story-create.html'),
+      { timeout: 5_000, interval: 500, timeoutMsg: 'Keep publishing did not open story-create.html' },
+    );
+
+    await expectSingleFirstStoryBadgeOnProfile();
+
+    await publishStory(2);
+    await expectNoBadgeUnlockModalAfterSecondStory();
+
+    await browser.waitUntil(
+      async () => (await browser.getUrl()).includes('map.html'),
+      { timeout: 10_000, interval: 500, timeoutMsg: 'Second publish did not redirect to map.html' },
+    );
+
+    await expectSingleFirstStoryBadgeOnProfile();
+  });
+});

--- a/frontend/tests/mobile-e2e/specs/tc-story-5.spec.js
+++ b/frontend/tests/mobile-e2e/specs/tc-story-5.spec.js
@@ -75,7 +75,7 @@ describe('TC_STORY_5 — Anonymous Story Sharing', () => {
     await (await browser.$('#title')).setValue('Old Fountain');
     await (await browser.$('#story')).setValue('A forgotten fountain in the heart of the old city.');
     await (await browser.$('#location')).setValue('Istanbul');
-    await (await browser.$('#date-single')).setValue('01/01/2024');
+    await (await browser.$('#date-single')).setValue('2024-01-01');
     // Set lat/lng hidden fields directly — the Leaflet map is not interactive
     // in the WebView and the submit handler requires non-empty coordinates.
     await browser.execute(() => {

--- a/frontend/tests/uat/badge.spec.js
+++ b/frontend/tests/uat/badge.spec.js
@@ -1,0 +1,98 @@
+// UAT - Badge award flows
+// Black-box tests against the running full-stack app (docker compose).
+//
+// Prerequisites:
+//   ./localrun.sh   (or docker compose up --build)
+//
+// Run:
+//   UAT_BASE_URL=http://localhost:3000 npx playwright test tests/uat/badge.spec.js  (from frontend/)
+
+const { test, expect } = require('@playwright/test');
+
+const PASSWORD = 'Test@1234';
+const FIRST_STORY_BADGE = /First (Post|Story)/i;
+
+async function registerAndLogin(page) {
+  const ts = Date.now();
+  const username = `badgeuser${ts}`;
+  const email = `badgeuser${ts}@example.com`;
+
+  await page.goto('/register.html');
+  await page.getByTestId('register-username').fill(username);
+  await page.getByTestId('register-email').fill(email);
+  await page.getByTestId('register-password').fill(PASSWORD);
+  await page.getByTestId('register-confirm-password').fill(PASSWORD);
+  await page.getByTestId('register-terms').check();
+  await page.getByTestId('register-submit').click();
+
+  await expect(page.getByTestId('register-success')).toBeVisible();
+  await page.waitForURL('**/index.html', { timeout: 5_000 });
+
+  await page.getByTestId('login-email').fill(email);
+  await page.getByTestId('login-password').fill(PASSWORD);
+  await page.getByTestId('login-submit').click();
+
+  await page.waitForURL('**/map.html', { timeout: 5_000 });
+
+  return { username, email };
+}
+
+async function expectNoFirstStoryBadgeOnProfile(page) {
+  await page.goto('/profile.html');
+  await expect(page.locator('#profile-badges')).toBeVisible();
+  await expect(page.locator('#profile-badges')).toContainText('No badges earned yet');
+  await expect(page.locator('#profile-badges')).not.toContainText(FIRST_STORY_BADGE);
+}
+
+async function expectSingleFirstStoryBadgeOnProfile(page) {
+  await page.goto('/profile.html');
+  await expect(page.locator('#profile-badges')).toContainText(FIRST_STORY_BADGE);
+  await expect(page.locator('#profile-badges span').filter({ hasText: FIRST_STORY_BADGE })).toHaveCount(1);
+}
+
+async function fillRequiredStoryFields(page, storyNumber) {
+  await page.goto('/story-create.html');
+
+  await page.locator('#title').fill(`TC_BADGE_1 Story ${storyNumber}`);
+  await page.locator('#story').fill(
+    `Automated acceptance story ${storyNumber} for verifying the first story badge award flow.`
+  );
+  await page.locator('#location').fill('Bogazici University, Istanbul');
+  await page.locator('#date-single').fill('2026-05-12');
+
+  await page.evaluate(() => {
+    document.querySelector('#latitude').value = '41.0857';
+    document.querySelector('#longitude').value = '29.0448';
+  });
+}
+
+async function publishStory(page, storyNumber) {
+  await fillRequiredStoryFields(page, storyNumber);
+  await page.locator('#btn-publish').click();
+}
+
+test.describe('TC_BADGE_1 - First post badge awarded', () => {
+  test('awards the first story badge once and displays it on the profile', async ({ page }) => {
+    await registerAndLogin(page);
+
+    await expectNoFirstStoryBadgeOnProfile(page);
+
+    await publishStory(page, 1);
+
+    const badgeModal = page.locator('#badge-unlock-modal');
+    await expect(badgeModal).toBeVisible({ timeout: 10_000 });
+    await expect(badgeModal).toContainText(FIRST_STORY_BADGE);
+
+    await page.locator('#badge-keep-publishing').click();
+    await page.waitForURL('**/story-create.html', { timeout: 5_000 });
+
+    await expectSingleFirstStoryBadgeOnProfile(page);
+
+    await publishStory(page, 2);
+
+    await expect(page.locator('#badge-unlock-modal')).toBeHidden({ timeout: 10_000 });
+    await expect(page.locator('#form-success')).toContainText('Story published successfully');
+
+    await expectSingleFirstStoryBadgeOnProfile(page);
+  });
+});

--- a/frontend/tests/uat/story.spec.js
+++ b/frontend/tests/uat/story.spec.js
@@ -53,7 +53,7 @@ test.describe('TC_STORY_5 — Anonymous Story Sharing', () => {
     await authorPage.fill('#title', 'Old Fountain');
     await authorPage.fill('#story', 'A forgotten fountain in the heart of the old city.');
     await authorPage.fill('#location', 'Istanbul');
-    await authorPage.fill('#date-single', '01/01/2024');
+    await authorPage.fill('#date-single', '2024-01-01');
 
     // Set lat/lng hidden fields directly — the Leaflet map click is not
     // reliable in headless mode and the submit handler requires these values.


### PR DESCRIPTION
## Summary
- `#date-single` was changed to `type="date"` (native date picker), which requires `yyyy-mm-dd` format instead of `mm/dd/yyyy`
- Updated all four affected test files in UAT and mobile E2E suites

## Test plan
- [ ] Run `npx playwright test tests/uat/badge.spec.js` — TC_BADGE_1 passes
- [ ] Run `npx playwright test tests/uat/story.spec.js` — TC_STORY_5 passes
- [ ] Run mobile Appium tests for tc-badge-1 and tc-story-5

Closes #383