### PR TITLE
feat: ISSUE-382 restrict user

### DIFF
--- a/backend/alembic/versions/20260512_0025_add_user_restriction_flag.py
+++ b/backend/alembic/versions/20260512_0025_add_user_restriction_flag.py
@@ -1,0 +1,28 @@
+"""Add user restriction flag.
+
+Revision ID: 20260512_0025
+Revises: 20260512_0024
+Create Date: 2026-05-12 00:00:00
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "20260512_0025"
+down_revision: Union[str, Sequence[str], None] = "20260512_0024"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("is_restricted", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "is_restricted")

--- a/backend/app/db/user.py
+++ b/backend/app/db/user.py
@@ -45,6 +45,12 @@ class User(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         default=True,
         server_default=text("true"),
     )
+    is_restricted: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=False,
+        server_default=text("false"),
+    )
 
     stories: Mapped[list["Story"]] = relationship(
         back_populates="user",

--- a/backend/app/models/admin.py
+++ b/backend/app/models/admin.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field
 
-from app.db.enums import ReportReason, ReportStatus
+from app.db.enums import ReportReason, ReportStatus, UserRole
 
 
 class AdminReportListItem(BaseModel):
@@ -17,7 +17,10 @@ class AdminReportListItem(BaseModel):
     status: ReportStatus
     created_at: datetime
     story_title: str | None = None
+    story_author_user_id: uuid.UUID | None = None
     story_author_username: str | None = None
+    reported_user_id: uuid.UUID | None = None
+    reported_username: str | None = None
     reporter_username: str | None = None
 
     model_config = {"from_attributes": True}
@@ -34,3 +37,15 @@ class UpdateReportStatusRequest(BaseModel):
     """Request to update report status."""
 
     status: ReportStatus = Field(..., description="New status for the report")
+
+
+class AdminUserRestrictionResponse(BaseModel):
+    """Restricted-state response for admin user moderation actions."""
+
+    id: uuid.UUID
+    username: str
+    email: str
+    role: UserRole
+    is_restricted: bool
+
+    model_config = {"from_attributes": True}

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -7,16 +7,20 @@ from app.core.deps import get_current_user
 from app.db.enums import ReportStatus
 from app.db.session import get_db
 from app.db.user import User
-from app.models.admin import AdminReportsListResponse, UpdateReportStatusRequest
+from app.models.admin import AdminReportsListResponse, AdminUserRestrictionResponse, UpdateReportStatusRequest
 from app.models.story import StoryReportResponse
 from app.services.admin_service import (
     ensure_admin_user,
     list_admin_reports,
     remove_story_as_admin,
+    restrict_user_as_admin,
+    unrestrict_user_as_admin,
     update_report_status_as_admin,
 )
 
-router = APIRouter(prefix="/stories/admin", tags=["admin"])
+router = APIRouter(tags=["admin"])
+story_admin_router = APIRouter(prefix="/stories/admin")
+user_admin_router = APIRouter(prefix="/admin/users")
 
 
 async def get_admin_context(
@@ -27,7 +31,7 @@ async def get_admin_context(
     return current_user, db
 
 
-@router.get(
+@story_admin_router.get(
     "/reports",
     response_model=AdminReportsListResponse,
     summary="Get reported stories (admin only)",
@@ -45,7 +49,7 @@ async def get_admin_reports(
     return await list_admin_reports(db, report_status=report_status)
 
 
-@router.put(
+@story_admin_router.put(
     "/reports/{report_id}",
     response_model=StoryReportResponse,
     summary="Update report status (admin only)",
@@ -67,7 +71,7 @@ async def update_report_status(
     return await update_report_status_as_admin(db, report_id, payload)
 
 
-@router.delete(
+@story_admin_router.delete(
     "/stories/{story_id}",
     status_code=status.HTTP_204_NO_CONTENT,
     summary="Remove story (admin only)",
@@ -84,3 +88,45 @@ async def admin_remove_story(
 ):
     current_user, db = context
     await remove_story_as_admin(db, story_id, current_user)
+
+
+@user_admin_router.patch(
+    "/{user_id}/restrict",
+    response_model=AdminUserRestrictionResponse,
+    summary="Restrict user (admin only)",
+    description="Prevent a user from modifying stories while keeping browse access available.",
+    responses={
+        401: {"description": "Missing or invalid authentication token"},
+        403: {"description": "User is not an admin"},
+        404: {"description": "User not found"},
+    },
+)
+async def restrict_user(
+    user_id: uuid.UUID,
+    context: tuple[User, AsyncSession] = Depends(get_admin_context),
+):
+    _, db = context
+    return await restrict_user_as_admin(db, user_id)
+
+
+@user_admin_router.patch(
+    "/{user_id}/unrestrict",
+    response_model=AdminUserRestrictionResponse,
+    summary="Unrestrict user (admin only)",
+    description="Restore a user's ability to modify stories.",
+    responses={
+        401: {"description": "Missing or invalid authentication token"},
+        403: {"description": "User is not an admin"},
+        404: {"description": "User not found"},
+    },
+)
+async def unrestrict_user(
+    user_id: uuid.UUID,
+    context: tuple[User, AsyncSession] = Depends(get_admin_context),
+):
+    _, db = context
+    return await unrestrict_user_as_admin(db, user_id)
+
+
+router.include_router(story_admin_router)
+router.include_router(user_admin_router)

--- a/backend/app/routers/story.py
+++ b/backend/app/routers/story.py
@@ -61,6 +61,7 @@ router = APIRouter(prefix="/stories", tags=["stories"])
     ),
     responses={
         401: {"description": "Missing or invalid authentication token"},
+        403: {"description": "Restricted users cannot modify stories"},
         422: {"description": "Validation error for story/location input"},
     },
 )
@@ -89,7 +90,7 @@ async def create_story(
     ),
     responses={
         401: {"description": "Missing or invalid authentication token"},
-        403: {"description": "Authenticated user is not the story owner"},
+        403: {"description": "Authenticated user is not the story owner, or is restricted"},
         404: {"description": "Story not found"},
         422: {"description": "Validation error for story/location input"},
     },
@@ -494,6 +495,7 @@ async def unsave_story(
     ),
     responses={
         401: {"description": "Missing or invalid authentication token"},
+        403: {"description": "Restricted users cannot modify stories"},
         404: {"description": "Story not found"},
         413: {"description": "File exceeds the 20 MB size limit"},
         502: {"description": "Object storage backend unavailable"},
@@ -508,7 +510,7 @@ async def upload_story_media(
     caption: str | None = Form(default=None),
     transcript: str | None = Form(default=None),
     sort_order: int = Form(default=0),
-    _current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
     payload = MediaUploadRequest(
@@ -523,6 +525,7 @@ async def upload_story_media(
         story_id,
         file,
         payload,
+        current_user=current_user,
         background_tasks=background_tasks,
     )
 

--- a/backend/app/services/admin_service.py
+++ b/backend/app/services/admin_service.py
@@ -10,7 +10,12 @@ from app.db.enums import ReportStatus, UserRole
 from app.db.story import Story
 from app.db.story_report import StoryReport
 from app.db.user import User
-from app.models.admin import AdminReportListItem, AdminReportsListResponse, UpdateReportStatusRequest
+from app.models.admin import (
+    AdminReportListItem,
+    AdminReportsListResponse,
+    AdminUserRestrictionResponse,
+    UpdateReportStatusRequest,
+)
 from app.models.story import StoryReportResponse
 
 
@@ -79,6 +84,32 @@ async def remove_story_as_admin(
     await db.commit()
 
 
+async def restrict_user_as_admin(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+) -> AdminUserRestrictionResponse:
+    user = await _get_user_or_404(db, user_id)
+    user.is_restricted = True
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+
+    return AdminUserRestrictionResponse.model_validate(user)
+
+
+async def unrestrict_user_as_admin(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+) -> AdminUserRestrictionResponse:
+    user = await _get_user_or_404(db, user_id)
+    user.is_restricted = False
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+
+    return AdminUserRestrictionResponse.model_validate(user)
+
+
 async def _fetch_admin_report_rows(
     db: AsyncSession,
     report_status: ReportStatus | None,
@@ -96,6 +127,7 @@ async def _fetch_admin_report_rows(
             StoryReport.status,
             StoryReport.created_at,
             Story.title.label("story_title"),
+            Story.user_id.label("story_author_user_id"),
             story_author.username.label("story_author_username"),
             reporter.username.label("reporter_username"),
         )
@@ -123,8 +155,11 @@ def _map_admin_report_row(row) -> AdminReportListItem:
         status=row.status,
         created_at=row.created_at,
         story_title=row.story_title,
+        story_author_user_id=row.story_author_user_id,
         reporter_username=row.reporter_username,
         story_author_username=row.story_author_username,
+        reported_user_id=row.story_author_user_id,
+        reported_username=row.story_author_username,
     )
 
 
@@ -151,6 +186,18 @@ async def _get_story_or_404(
         )
 
     return story
+
+
+async def _get_user_or_404(db: AsyncSession, user_id: uuid.UUID) -> User:
+    user_result = await db.execute(select(User).where(User.id == user_id))
+    user = user_result.scalar_one_or_none()
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found",
+        )
+
+    return user
 
 
 async def _list_pending_reports_for_story(

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -216,6 +216,14 @@ def _build_media_storage_key(story_id: uuid.UUID, filename: str) -> str:
     return f"stories/{story_id}/media/{uuid.uuid4()}{ext}"
 
 
+def _ensure_user_can_modify_stories(current_user: User) -> None:
+    if getattr(current_user, "is_restricted", False):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Restricted users cannot modify stories",
+        )
+
+
 async def _get_story_or_404(
     db: AsyncSession,
     story_id: uuid.UUID,
@@ -566,6 +574,8 @@ async def create_story_with_location(
     current_user: User,
     payload: StoryCreateRequest,
 ) -> StoryDetailResponse:
+    _ensure_user_can_modify_stories(current_user)
+
     place_name = payload.place_name.strip() if payload.place_name else None
     if not place_name:
         raise HTTPException(
@@ -625,6 +635,8 @@ async def update_story_with_location_and_dates(
     current_user: User,
     payload: StoryUpdateRequest,
 ) -> StoryDetailResponse:
+    _ensure_user_can_modify_stories(current_user)
+
     story_result = await db.execute(
         select(Story)
         .options(selectinload(Story.locations))
@@ -732,8 +744,12 @@ async def upload_media_for_story(
     story_id: uuid.UUID,
     file: UploadFile,
     payload: MediaUploadRequest,
+    current_user: User | None = None,
     background_tasks: BackgroundTasks | None = None,
 ) -> MediaUploadResponse:
+    if current_user is not None:
+        _ensure_user_can_modify_stories(current_user)
+
     normalized_content_type = validate_media_upload(file, payload.media_type)
 
     story_result = await db.execute(select(Story).where(Story.id == story_id, Story.deleted_at.is_(None)))

--- a/backend/tests/api/test_admin_routing_api.py
+++ b/backend/tests/api/test_admin_routing_api.py
@@ -8,6 +8,8 @@ def _route_by_path(path: str):
 class TestAdminRoutingAPI:
     def test_admin_routes_are_exposed_from_admin_router(self):
         admin_paths = {
+            "/admin/users/{user_id}/restrict",
+            "/admin/users/{user_id}/unrestrict",
             "/stories/admin/reports",
             "/stories/admin/reports/{report_id}",
             "/stories/admin/stories/{story_id}",
@@ -29,6 +31,8 @@ class TestAdminRoutingAPI:
 
     def test_story_router_does_not_own_admin_paths(self):
         admin_routes = [
+            _route_by_path("/admin/users/{user_id}/restrict"),
+            _route_by_path("/admin/users/{user_id}/unrestrict"),
             _route_by_path("/stories/admin/reports"),
             _route_by_path("/stories/admin/reports/{report_id}"),
             _route_by_path("/stories/admin/stories/{story_id}"),

--- a/backend/tests/factories/user_factory.py
+++ b/backend/tests/factories/user_factory.py
@@ -68,6 +68,7 @@ def make_user_entity(
     avatar_bucket_name: str | None = None,
     avatar_storage_key: str | None = None,
     is_active: bool = True,
+    is_restricted: bool = False,
     password_hash: str | None = None,
     suffix: int | str | None = None,
 ) -> User:
@@ -84,4 +85,5 @@ def make_user_entity(
         avatar_storage_key=avatar_storage_key,
         role=role,
         is_active=is_active,
+        is_restricted=is_restricted,
     )

--- a/backend/tests/integration/test_admin_user_restriction_api.py
+++ b/backend/tests/integration/test_admin_user_restriction_api.py
@@ -1,0 +1,74 @@
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from app.db.user import User
+
+
+@pytest.mark.asyncio
+class TestAdminUserRestrictionAPI:
+    async def _register_and_login(self, client, username, email, password):
+        await client.post(
+            "/auth/register",
+            json={"username": username, "email": email, "password": password},
+        )
+        login_resp = await client.post(
+            "/auth/login",
+            json={"email": email, "password": password},
+        )
+        return login_resp.json()["access_token"]
+
+    async def _get_user_by_email(self, db_session, email):
+        result = await db_session.execute(select(User).where(User.email == email))
+        return result.scalar_one()
+
+    async def test_admin_can_restrict_and_unrestrict_user(self, seeded_db, client, db_session):
+        admin_token = await self._register_and_login(client, "seed_admin", "seed_admin@example.com", "ValidPass1!")
+        await self._register_and_login(client, "restrict_target", "restrict-target@example.com", "TargetPass1!")
+        target_user = await self._get_user_by_email(db_session, "restrict-target@example.com")
+
+        restrict_resp = await client.patch(
+            f"/admin/users/{target_user.id}/restrict",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+
+        assert restrict_resp.status_code == 200
+        assert restrict_resp.json()["id"] == str(target_user.id)
+        assert restrict_resp.json()["is_restricted"] is True
+
+        await db_session.refresh(target_user)
+        assert target_user.is_restricted is True
+
+        unrestrict_resp = await client.patch(
+            f"/admin/users/{target_user.id}/unrestrict",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+
+        assert unrestrict_resp.status_code == 200
+        assert unrestrict_resp.json()["is_restricted"] is False
+
+        await db_session.refresh(target_user)
+        assert target_user.is_restricted is False
+
+    async def test_non_admin_cannot_restrict_user(self, client):
+        user_token = await self._register_and_login(client, "regular_mod", "regular-mod@example.com", "RegularPass1!")
+
+        resp = await client.patch(
+            f"/admin/users/{uuid.uuid4()}/restrict",
+            headers={"Authorization": f"Bearer {user_token}"},
+        )
+
+        assert resp.status_code == 403
+        assert "Admin" in resp.json()["detail"]
+
+    async def test_restrict_nonexistent_user_returns_404(self, seeded_db, client):
+        admin_token = await self._register_and_login(client, "seed_admin", "seed_admin@example.com", "ValidPass1!")
+
+        resp = await client.patch(
+            f"/admin/users/{uuid.uuid4()}/restrict",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "User not found"

--- a/backend/tests/unit/test_admin_service.py
+++ b/backend/tests/unit/test_admin_service.py
@@ -12,6 +12,8 @@ from app.services.admin_service import (
     ensure_admin_user,
     list_admin_reports,
     remove_story_as_admin,
+    restrict_user_as_admin,
+    unrestrict_user_as_admin,
     update_report_status_as_admin,
 )
 
@@ -67,6 +69,7 @@ class TestAdminReportsService:
             status=ReportStatus.PENDING,
             created_at=created_at,
             story_title="Reported Story",
+            story_author_user_id=uuid.uuid4(),
             reporter_username="reporter",
             story_author_username="author",
         )
@@ -87,6 +90,8 @@ class TestAdminReportsService:
         assert result.reports[0].story_title == "Reported Story"
         assert result.reports[0].reporter_username == "reporter"
         assert result.reports[0].story_author_username == "author"
+        assert result.reports[0].reported_user_id == row.story_author_user_id
+        assert result.reports[0].reported_username == "author"
         db.execute.assert_awaited_once()
 
     async def test_list_admin_reports_applies_status_filter(self):
@@ -200,4 +205,60 @@ class TestAdminRemoveStoryService:
 
         assert exc_info.value.status_code == 404
         assert exc_info.value.detail == "Story not found"
+        db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+class TestAdminUserRestrictionService:
+    async def test_restrict_user_sets_restricted_flag(self):
+        user = SimpleNamespace(
+            id=uuid.uuid4(),
+            username="target",
+            email="target@example.com",
+            role=UserRole.USER,
+            is_restricted=False,
+        )
+
+        db = AsyncMock()
+        db.add = MagicMock()
+        db.execute.return_value = SimpleNamespace(scalar_one_or_none=lambda: user)
+
+        result = await restrict_user_as_admin(db, user.id)
+
+        assert user.is_restricted is True
+        assert result.is_restricted is True
+        db.add.assert_called_once_with(user)
+        db.commit.assert_awaited_once()
+        db.refresh.assert_awaited_once_with(user)
+
+    async def test_unrestrict_user_clears_restricted_flag(self):
+        user = SimpleNamespace(
+            id=uuid.uuid4(),
+            username="target",
+            email="target@example.com",
+            role=UserRole.USER,
+            is_restricted=True,
+        )
+
+        db = AsyncMock()
+        db.add = MagicMock()
+        db.execute.return_value = SimpleNamespace(scalar_one_or_none=lambda: user)
+
+        result = await unrestrict_user_as_admin(db, user.id)
+
+        assert user.is_restricted is False
+        assert result.is_restricted is False
+        db.add.assert_called_once_with(user)
+        db.commit.assert_awaited_once()
+        db.refresh.assert_awaited_once_with(user)
+
+    async def test_restrict_user_raises_404_when_user_missing(self):
+        db = AsyncMock()
+        db.execute.return_value = SimpleNamespace(scalar_one_or_none=lambda: None)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await restrict_user_as_admin(db, uuid.uuid4())
+
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "User not found"
         db.commit.assert_not_awaited()

--- a/backend/tests/unit/test_story_service.py
+++ b/backend/tests/unit/test_story_service.py
@@ -402,6 +402,22 @@ class TestSearchAvailableStoriesByPlaceService:
 
 @pytest.mark.asyncio
 class TestUploadMediaForStoryService:
+    async def test_restricted_user_cannot_upload_media(self):
+        story_id = uuid.uuid4()
+        payload = MediaUploadRequest(media_type=MediaType.IMAGE)
+        file = _make_upload_file("photo.png", b"fake-image-bytes", "image/png")
+        current_user = _make_user(is_restricted=True)
+        db = AsyncMock()
+
+        with patch("app.services.story_service.upload_bytes") as mock_upload:
+            with pytest.raises(HTTPException) as exc_info:
+                await upload_media_for_story(db, story_id, file, payload, current_user=current_user)
+
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.detail == "Restricted users cannot modify stories"
+        db.execute.assert_not_awaited()
+        mock_upload.assert_not_called()
+
     async def test_upload_successful(self):
         story_id = uuid.uuid4()
         story = _make_story(id=story_id)
@@ -1257,6 +1273,26 @@ class TestStoryLikeService:
 
 @pytest.mark.asyncio
 class TestCreateStoryWithLocationService:
+    async def test_restricted_user_cannot_create_story(self):
+        payload = StoryCreateRequest(
+            title="New Story",
+            content="Story content",
+            summary="Summary",
+            place_name="Istanbul",
+            latitude=41.0082,
+            longitude=28.9784,
+        )
+        current_user = SimpleNamespace(id=uuid.uuid4(), username="authoruser", is_restricted=True)
+        db = AsyncMock()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await create_story_with_location(db, current_user, payload)
+
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.detail == "Restricted users cannot modify stories"
+        db.add.assert_not_called()
+        db.commit.assert_not_awaited()
+
     async def test_create_story_with_valid_location(self):
         payload = StoryCreateRequest(
             title="New Story",
@@ -1389,6 +1425,26 @@ class TestCreateStoryWithLocationService:
 
 @pytest.mark.asyncio
 class TestUpdateStoryWithLocationAndDatesService:
+    async def test_restricted_user_cannot_update_story(self):
+        payload = StoryUpdateRequest(
+            title="Updated Story",
+            content="Updated content",
+            summary="Updated summary",
+            place_name="Ankara",
+            latitude=39.9334,
+            longitude=32.8597,
+        )
+        current_user = SimpleNamespace(id=uuid.uuid4(), username="authoruser", is_restricted=True)
+        db = AsyncMock()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await update_story_with_location_and_dates(db, uuid.uuid4(), current_user, payload)
+
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.detail == "Restricted users cannot modify stories"
+        db.execute.assert_not_awaited()
+        db.commit.assert_not_awaited()
+
     async def test_update_story_success(self):
         story_id = uuid.uuid4()
         story = _make_story(id=story_id, user_id=uuid.uuid4())

--- a/frontend/story-create.html
+++ b/frontend/story-create.html
@@ -164,7 +164,7 @@
           </div>
           <div>
             <label for="date-single" class="mb-2 block text-sm font-semibold text-textmain">Date</label>
-            <input id="date-single" type="date" class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary" />
+            <input id="date-single" type="text" inputmode="numeric" placeholder="mm/dd/yyyy" class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary" />
           </div>
         </div>
 
@@ -177,11 +177,11 @@
           <div id="date-range-fields" class="mt-3 hidden grid gap-4 md:grid-cols-2">
             <div>
               <label for="date-start" class="mb-2 block text-sm font-semibold text-textmain">Start Date</label>
-              <input id="date-start" type="date" class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary" />
+              <input id="date-start" type="text" inputmode="numeric" placeholder="mm/dd/yyyy" class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary" />
             </div>
             <div>
               <label for="date-end" class="mb-2 block text-sm font-semibold text-textmain">End Date</label>
-              <input id="date-end" type="date" class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary" />
+              <input id="date-end" type="text" inputmode="numeric" placeholder="mm/dd/yyyy" class="w-full rounded-xl border-border bg-white px-4 py-3 text-sm focus:border-primary focus:ring-primary" />
             </div>
           </div>
         </div>
@@ -499,11 +499,15 @@
 
   // ─── Date Range Toggle ───
   function isValidDateInput(value) {
-    return /^\d{4}-\d{2}-\d{2}$/.test(value);
+    return /^\d{4}-\d{2}-\d{2}$/.test(value) || /^(0[1-9]|1[0-2])\/(0[1-9]|[12][0-9]|3[01])\/\d{4}$/.test(value);
   }
 
   function getISODateFromDateInput(value) {
-    return value; // native date input already returns yyyy-mm-dd
+    if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+      return value;
+    }
+    var parts = value.split("/");
+    return parts[2] + "-" + parts[0] + "-" + parts[1];
   }
 
   document.getElementById("date-range-toggle").addEventListener("change", function () {
@@ -1137,7 +1141,7 @@
     }
 
     if (!usingDateRange && !isValidDateInput(dateSingle)) {
-      errorEl.textContent = "Date must use mm/dd/yyyy format.";
+      errorEl.textContent = "Date must use mm/dd/yyyy or yyyy-mm-dd format.";
       errorEl.classList.remove("hidden");
       return;
     }
@@ -1149,13 +1153,13 @@
     }
 
     if (usingDateRange && !isValidDateInput(dateStart)) {
-      errorEl.textContent = "Start date must use mm/dd/yyyy format.";
+      errorEl.textContent = "Start date must use mm/dd/yyyy or yyyy-mm-dd format.";
       errorEl.classList.remove("hidden");
       return;
     }
 
     if (usingDateRange && !isValidDateInput(dateEnd)) {
-      errorEl.textContent = "End date must use mm/dd/yyyy format.";
+      errorEl.textContent = "End date must use mm/dd/yyyy or yyyy-mm-dd format.";
       errorEl.classList.remove("hidden");
       return;
     }

--- a/frontend/tests/uat/badge.spec.js
+++ b/frontend/tests/uat/badge.spec.js
@@ -58,7 +58,7 @@ async function fillRequiredStoryFields(page, storyNumber) {
     `Automated acceptance story ${storyNumber} for verifying the first story badge award flow.`
   );
   await page.locator('#location').fill('Bogazici University, Istanbul');
-  await page.locator('#date-single').fill('05/12/2026');
+  await page.locator('#date-single').fill('2026-05-12');
 
   await page.evaluate(() => {
     document.querySelector('#latitude').value = '41.0857';

--- a/frontend/tests/uat/story.spec.js
+++ b/frontend/tests/uat/story.spec.js
@@ -53,7 +53,7 @@ test.describe('TC_STORY_5 — Anonymous Story Sharing', () => {
     await authorPage.fill('#title', 'Old Fountain');
     await authorPage.fill('#story', 'A forgotten fountain in the heart of the old city.');
     await authorPage.fill('#location', 'Istanbul');
-    await authorPage.fill('#date-single', '01/01/2024');
+    await authorPage.fill('#date-single', '2024-01-01');
 
     // Set lat/lng hidden fields directly — the Leaflet map click is not
     // reliable in headless mode and the submit handler requires these values.

--- a/frontend/tests/uat/tag.spec.js
+++ b/frontend/tests/uat/tag.spec.js
@@ -63,7 +63,7 @@ test.describe('TC_TAG_1 - Keyword Tagging on Story Creation', () => {
       await page.goto('/story-create.html');
       await page.fill('#title', title);
       await page.fill('#story', content);
-      await page.fill('#date-single', '01/01/1890');
+      await page.fill('#date-single', '1890-01-01');
 
       // Step 2: Add keyword tags through the tag input UI.
       await addStoryTag(page, 'ottoman');


### PR DESCRIPTION
## Description
Adds backend support for restricting users from story modification actions. Admins can now restrict or unrestrict users from the admin panel, and restricted users are blocked from creating, editing, or uploading media to stories while still being able to browse the platform.

## Related Issue(s)
- Closes #

## Changes

| File | Change |
|------|--------|
| `backend/app/db/user.py` | Added `is_restricted` user flag. |
| `backend/alembic/versions/20260512_0025_add_user_restriction_flag.py` | Added migration for `users.is_restricted`. |
| `backend/app/routers/admin.py` | Added `PATCH /admin/users/{user_id}/restrict` and `/unrestrict` endpoints. |
| `backend/app/services/admin_service.py` | Added admin-only restrict/unrestrict service logic with 404 handling. |
| `backend/app/models/admin.py` | Added admin user restriction response model and report author aliases for admin panel compatibility. |
| `backend/app/services/story_service.py` | Added restricted-user guard for story create, update, and media upload. |
| `backend/app/routers/story.py` | Passed current user into media upload service and documented 403 responses. |
| `backend/tests/unit/test_admin_service.py` | Added unit tests for restrict/unrestrict behavior. |
| `backend/tests/api/test_admin_routing_api.py` | Added route registration coverage for new admin user endpoints. |
| `backend/tests/unit/test_story_service.py` | Added tests ensuring restricted users cannot modify stories. |
| `backend/tests/factories/user_factory.py` | Added `is_restricted` support to user factory. |

## Checklist
- [x] All tests passed 
- [x] I have self-reviewed my own code
- [ ] I have requested at least 1 reviewer
