### PR TITLE
multiple-location-story-popup-fix

### DIFF
--- a/frontend/map.html
+++ b/frontend/map.html
@@ -1064,20 +1064,57 @@
                 focusPolyline = null;
             }
 
+            var stopCoverImage = null;
+            function buildStopPopupHtml(loc, idx, coverImage) {
+                var coordsText = loc.latitude.toFixed(4) + ", " + loc.longitude.toFixed(4);
+                var stopStory = Object.assign({}, story, {
+                    latitude: loc.latitude,
+                    longitude: loc.longitude,
+                    place_name: loc.label || coordsText
+                });
+                var stopBadge =
+                    '<div style="padding:8px 16px 0;font-size:11px;font-weight:700;color:#35618f;text-transform:uppercase;letter-spacing:0.06em;">' +
+                    'Stop ' + (idx + 1) + ' / ' + locs.length +
+                    '</div>';
+                return buildPopupHtml(stopStory, coverImage).replace(
+                    '<div style="padding:14px 16px 14px;">',
+                    stopBadge + '<div style="padding:6px 16px 14px;">'
+                );
+            }
+
             locs.forEach(function (loc, idx) {
                 var marker = L.marker([loc.latitude, loc.longitude], {
                     icon: buildNumberedIcon(L, idx, { color: "#35618f", size: 36 })
                 });
                 var coordsText = loc.latitude.toFixed(4) + ", " + loc.longitude.toFixed(4);
                 var stopTitle = (idx + 1) + ". " + (loc.label || coordsText);
-                marker.bindPopup(
-                    '<div style="font-family:Inter,sans-serif;min-width:200px;">' +
-                    '<div style="font-size:11px;font-weight:700;color:#35618f;text-transform:uppercase;letter-spacing:0.06em;margin-bottom:4px;">Stop ' + (idx + 1) + ' / ' + locs.length + '</div>' +
-                    '<div style="font-size:13px;font-weight:700;color:#1d1c16;margin-bottom:6px;">' + (loc.label || coordsText) + '</div>' +
-                    '<a href="story-detail.html?id=' + story.id + '" style="font-size:12px;color:#775a19;font-weight:700;text-decoration:none;">Read full story →</a>' +
-                    '</div>',
-                    { closeButton: true }
-                );
+                marker.bindPopup(buildStopPopupHtml(loc, idx, stopCoverImage), {
+                    maxWidth: 300,
+                    minWidth: 300,
+                    closeButton: true,
+                    autoPan: true
+                });
+                marker.on("popupopen", function () {
+                    if (stopCoverImage) {
+                        marker.setPopupContent(buildStopPopupHtml(loc, idx, stopCoverImage));
+                        return;
+                    }
+                    fetch(API_BASE + "/stories/" + story.id)
+                        .then(function (res) { return res.json(); })
+                        .then(function (detail) {
+                            if (!detail.media_files) return;
+                            for (var i = 0; i < detail.media_files.length; i++) {
+                                if (detail.media_files[i].media_type === "image") {
+                                    stopCoverImage = detail.media_files[i].media_url;
+                                    break;
+                                }
+                            }
+                            if (stopCoverImage) {
+                                marker.setPopupContent(buildStopPopupHtml(loc, idx, stopCoverImage));
+                            }
+                        })
+                        .catch(function () { /* keep placeholder on error */ });
+                });
                 marker.bindTooltip(stopTitle, { direction: "top", offset: [0, -18] });
                 focusLayer.addLayer(marker);
             });

--- a/frontend/tests/mobile-e2e/specs/tc-map-2.spec.js
+++ b/frontend/tests/mobile-e2e/specs/tc-map-2.spec.js
@@ -216,7 +216,7 @@ describe('TC_MAP_2 — Multi-Location Story Display on Map', () => {
       () => (document.querySelector('.leaflet-popup-content') || {}).textContent || '',
     );
     assert.ok(popup1Text.includes('Stop 1'), `First pin popup should contain "Stop 1", got "${popup1Text}"`);
-    assert.ok(popup1Text.includes('Read full story'), `First pin popup should contain story link, got "${popup1Text}"`);
+    assert.ok(popup1Text.includes('Read Story'), `First pin popup should contain story link, got "${popup1Text}"`);
 
     // ── Step 14: Tap second pin and verify the same story link appears ──────
     // Close the current popup first.

--- a/frontend/tests/uat/map.spec.js
+++ b/frontend/tests/uat/map.spec.js
@@ -124,7 +124,7 @@ test.describe('TC_MAP_2 — Multi-Location Story Display on Map', () => {
       const popup = page.locator('.leaflet-popup-content');
       await expect(popup).toBeVisible({ timeout: 5_000 });
       await expect(popup).toContainText('Stop 1');
-      await expect(popup).toContainText('Read full story');
+      await expect(popup).toContainText('Read Story');
 
       // ── Step 9: Click second pin and verify the same story link appears ───
       await page.locator('.leaflet-popup-close-button').click();
@@ -132,7 +132,7 @@ test.describe('TC_MAP_2 — Multi-Location Story Display on Map', () => {
       await expect(popup).toBeVisible({ timeout: 5_000 });
       await expect(popup).toContainText('Stop 2');
       // Both pins link to the same story detail page.
-      await expect(popup.locator('a')).toHaveAttribute('href', `story-detail.html?id=${storyId}`);
+      await expect(popup.locator('a[href*="story-detail.html"]')).toHaveAttribute('href', `story-detail.html?id=${storyId}`);
     },
   );
 });


### PR DESCRIPTION
## Description
  Make the per-stop popup in multi-location focus mode match the rich preview card used by single-location stories. Clicking a numbered stop pin now opens the same card
  (cover image, date badge, author, italic preview, tags, place name, Report + Timeline + Read Story buttons) with a small "Stop N / M" indicator prepended above the title.
   The focus-mode entry behavior itself (numbered pins + dashed polyline + banner) is unchanged.



  ## Changes

  | File | Change |
  |------|--------|
  | `frontend/map.html` | Replaced the bare-bones popup bound inside `enterFocusMode` with `buildStopPopupHtml`, which shallow-copies the story (overriding
  `latitude`/`longitude`/`place_name` per stop), calls the existing `buildPopupHtml`, and prepends a "Stop N / M" badge. Cover image is lazy-loaded once on first popup open
   and reused across stops. |
  | `frontend/tests/uat/map.spec.js` | Updated assertion `'Read full story'` → `'Read Story'` to match the new popup's button label. Scoped `popup.locator('a')` to
  `popup.locator('a[href*="story-detail.html"]')` so the existing href check doesn't collide with the new "View Timeline" link. |
  | `frontend/tests/mobile-e2e/specs/tc-map-2.spec.js` | Updated assertion `'Read full story'` → `'Read Story'` to match the new popup's button label. |

  ## Checklist
  - [ ] All tests passed
  - [x ] I have self-reviewed my own code
  - [x ] I have requested at least 1 reviewer