### PR TITLE
mobil fix screen issue

### DIFF
--- a/frontend/map.html
+++ b/frontend/map.html
@@ -456,7 +456,7 @@
     </div>
 
     <!-- Map Container -->
-    <main class="relative w-full pt-[68px] md:h-screen">
+    <main class="relative w-full pt-[60px] md:pt-[68px] md:h-screen">
         <div class="relative h-[58vh] min-h-[360px] md:h-[calc(100vh-68px)]">
             <div id="map" class="absolute inset-0 md:top-0"></div>
 

--- a/frontend/site-header.js
+++ b/frontend/site-header.js
@@ -20,11 +20,11 @@
 
         return (
             '<header class="fixed top-0 left-0 right-0 z-[1100] bg-[#f8f3ea]/95 backdrop-blur-sm border-b border-border/30">' +
-            '<div class="flex justify-between items-center w-full px-6 sm:px-8 py-4 max-w-screen-2xl mx-auto gap-4">' +
-            '<div class="flex items-center gap-8 shrink-0">' +
-            '<a href="map.html" class="text-xl sm:text-2xl font-bold font-headline text-textmain tracking-tight hover:text-tertiary transition-colors">Local History Map</a>' +
+            '<div class="flex justify-between items-center w-full px-4 sm:px-6 md:px-8 py-3 md:py-4 max-w-screen-2xl mx-auto gap-2 md:gap-4">' +
+            '<div class="flex items-center shrink-0">' +
+            '<a href="map.html" class="text-base sm:text-xl md:text-2xl font-bold font-headline text-textmain tracking-tight hover:text-tertiary transition-colors whitespace-nowrap">Local History Map</a>' +
             '</div>' +
-            (extra ? '<div class="hidden md:flex flex-1 items-center justify-center min-w-0">' + extra + '</div>' : '') +
+            (extra ? '<div class="flex flex-1 items-center justify-center min-w-0">' + extra + '</div>' : '') +
             '<div class="flex items-center gap-3 sm:gap-4 shrink-0">' +
             (options && options.extraRight ? options.extraRight : '') +
             '<div class="relative">' +


### PR DESCRIPTION
## Description

   The search bar on the map page was invisible on mobile devices. It was wrapped in a `hidden md:flex` container in
   the shared site header, making it only visible on desktop. This fix makes the search bar visible on all screen
   sizes and adjusts the header layout to accommodate it on small screens.

   The search bar on the map page was invisible on mobile devices. It was wrapped in a `hidden md:flex` container in
   the shared site header, making it only visible on desktop. This fix makes the search bar visible on all screen
   sizes and adjusts the header layout to accommodate it on small screens.

   ## Related Issue(s)
   - Closes #

   ## Changes

   | File | Change |
   |------|--------|
   | `frontend/site-header.js` | Removed `hidden` from `extraCenter` wrapper so it renders on mobile; tightened
   header padding and gap for small screens; made logo font size responsive |
   | `frontend/map.html` | Adjusted top padding to `pt-[60px] md:pt-[68px]` to match the slightly shorter mobile
   header |

   ## Checklist
   - [ ] All tests passed
   - [ ] I have self-reviewed my own code
   - [ ] I have requested at least 1 reviewer